### PR TITLE
Redact leaked vendor credentials from VENDOR_SETUP_STATUS.md

### DIFF
--- a/VENDOR_SETUP_STATUS.md
+++ b/VENDOR_SETUP_STATUS.md
@@ -72,11 +72,12 @@
 
 ## 📝 Environment Variables Set
 ```
-ZOHO_CLIENT_ID=1000.YSAZC0WPSR6912VXW4MJFTG76LTD0S
-ZOHO_CLIENT_SECRET=fd8352031f30b49d178332398166041d9b5c35f0fe
-JUMPCLOUD_API_KEY=jca_3zmVKcVUkdfVjUBqcWCVX7gz6AJC3DkbB4hL
-CORO_CLIENT_ID=d95432aaf81c4e1cb9639670515cf5d3
-CORO_CLIENT_SECRET=960352eb679447428403284ac1bedd47
+ZOHO_CLIENT_ID=<set in environment — do not commit>
+ZOHO_CLIENT_SECRET=<set in environment — do not commit>
+JUMPCLOUD_API_KEY=<set in environment — do not commit>
+CORO_CLIENT_ID=<set in environment — do not commit>
+CORO_CLIENT_SECRET=<set in environment — do not commit>
 ```
 
-All set and secure! 🔐
+> ⚠️ Real values were previously committed to this public repo and remain in git
+> history. Those Zoho, JumpCloud, and Coro credentials must be rotated.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`VENDOR_SETUP_STATUS.md` contained **live credentials committed to this public repository**:

- Zoho client ID + client secret
- JumpCloud API key
- Coro client ID + client secret

This PR replaces the real values with placeholders and adds a warning note.

## Important — rotation still required

Removing the values from the current file does **not** remove them from git history, and this repo is public. The following credentials must be rotated at their respective providers:

1. **Zoho** — regenerate the client secret for client ID `1000.YSAZ…` in the Zoho API console
2. **JumpCloud** — revoke and reissue the API key (`jca_…`)
3. **Coro** — regenerate the client ID/secret pair in the Coro console

After rotation, update the values only in server environment variables (VPS `.env` / PM2 ecosystem / Replit secrets), never in committed files.

## Context

Found during a health/consistency audit of digerati-experts.com, digeratiexperts.com, and techsales.digerati-experts.com.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f942c2d0-acab-4d93-92eb-e385eff30956?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f942c2d0-acab-4d93-92eb-e385eff30956&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

