### PR TITLE
VPS deployment kit: release-based deploy script, systemd unit, OLS proxy config, SEO-file serving fix

### DIFF
--- a/deploy/vps/README.md
+++ b/deploy/vps/README.md
@@ -1,0 +1,118 @@
+# VPS deployment — Digerati Experts public website
+
+Migration of digeratiexperts.com from Replit Autoscale to the
+CyberPanel/OpenLiteSpeed VPS (192.227.158.46), staging first.
+
+**Ownership split**
+
+- **CyberPanel** owns the domain: website entry, OLS virtual host, SSL,
+  domain logs, backups, file ownership, redirects/proxy. The site must appear
+  normally under CyberPanel → Websites → List Websites.
+- **This kit** (run by Cursor or an admin) owns the app: clone, `npm ci`,
+  build, systemd service, deploys, health checks, rollback.
+
+**Do not** copy files manually into `public_html`, and do not install
+Coolify/Dokploy/Docker panels. Everything runs inside the existing
+CyberPanel installation.
+
+## Directory layout (per site)
+
+```
+/home/staging.digeratiexperts.com/     (production: /home/digeratiexperts.com/)
+├── public_html/          # CyberPanel-managed; placeholder only (app is proxied)
+├── app/                  # bare git mirror of digeratiexperts/Replit-Site
+├── releases/<timestamp>/ # built releases (last 3 kept)
+├── current -> releases/<timestamp>    # active release (atomic symlink)
+├── shared/
+│   └── .env              # production secrets — never in git or public_html
+└── logs/                 # app.log / app-error.log
+```
+
+## Ports
+
+| Service | Port |
+|---|---|
+| Intelligence Hub (techsales) | 3100 — already in use, do not touch |
+| Website staging | 127.0.0.1:3200 |
+| Website production | 127.0.0.1:3300 |
+
+## One-time setup (staging)
+
+```bash
+# 0. Prerequisites (as root, once per server):
+#    - Node.js 20 LTS installed system-wide (node --version)
+#    - CyberPanel website created: staging.digeratiexperts.com + SSL issued
+#    - Cloudflare: staging A record -> 192.227.158.46 (proxied)
+
+SITE=/home/staging.digeratiexperts.com
+SITE_USER=<cyberpanel-site-user>       # see CyberPanel or: ls -ld $SITE
+
+# 1. Directory skeleton + env
+mkdir -p $SITE/{app,releases,shared,logs}
+cp deploy/vps/env.production.example $SITE/shared/.env
+vi $SITE/shared/.env                   # fill real values; PORT=3200
+chown -R $SITE_USER:$SITE_USER $SITE/{app,releases,shared,logs}
+chmod 600 $SITE/shared/.env
+
+# 2. systemd service
+cp deploy/vps/digeratiexperts-site.service /etc/systemd/system/digeratiexperts-staging.service
+#    edit: User/Group=$SITE_USER, WorkingDirectory=$SITE/current,
+#          EnvironmentFile=$SITE/shared/.env, PORT=3200
+systemctl daemon-reload
+systemctl enable digeratiexperts-staging
+
+# 3. First deploy (as the site user)
+sudo -u $SITE_USER bash deploy/vps/deploy.sh staging
+
+# 4. OLS proxy — see deploy/vps/openlitespeed-proxy.md
+```
+
+## Deploying updates
+
+```bash
+sudo -u <site-user> bash deploy/vps/deploy.sh staging      # or: production
+```
+
+The script fetches the deploy branch (default `main`, override with
+`DEPLOY_BRANCH=`), builds a fresh release, validates the build, **scans the
+bundle for internal content and credential patterns**, flips the `current`
+symlink, restarts the systemd service, health-checks `/healthz` and `/`,
+and **rolls back to the previous release automatically** if the health
+check fails.
+
+Automatic deploys: either a cron entry polling `main`, or CyberPanel's Git
+Manager webhook calling the script. Choose ONE mechanism — if this script
+becomes the deployer, disable any competing timer/webhook so there are
+never two systems deploying the same site.
+
+## Verification checklist (staging, before DNS cutover)
+
+- [ ] `curl -I https://staging.digeratiexperts.com/` → 200, valid SSL
+- [ ] All sitemap routes return 200 (`deploy/vps/verify.sh staging.digeratiexperts.com`)
+- [ ] `/internal` and `/internal/pricing-tiers` → 301 to `/`
+- [ ] Built JS contains no internal page content or credentials
+      (deploy script enforces this at build time)
+- [ ] `http://` redirects to `https://`
+- [ ] Lead forms, Turnstile, analytics fire correctly
+- [ ] `systemctl kill --signal=SIGKILL digeratiexperts-staging` → app
+      auto-restarts (Restart=always) and site recovers
+- [ ] `reboot` → service comes back automatically
+
+## Production cutover (after staging verified)
+
+1. Create/finalize the `digeratiexperts.com` website entry in CyberPanel
+   (it may already exist), issue SSL.
+2. Repeat setup with `deploy.sh production` (port 3300,
+   `digeratiexperts-site.service`).
+3. Cloudflare: point apex + `www` A records at 192.227.158.46 (proxied),
+   confirm SSL mode Full, then purge the zone cache.
+4. Re-run the verification checklist against https://digeratiexperts.com.
+5. Watch logs (`journalctl -u digeratiexperts-site -f`) through the first
+   hours; retire the Replit deployment only after verification.
+
+## Database note
+
+The app requires `DATABASE_URL` (Postgres/Drizzle). For the initial
+migration keep pointing at the existing production database used by the
+Replit deployment, so cutover involves no data migration. Moving Postgres
+onto the VPS is a separate decision — do not bundle it into this cutover.

--- a/deploy/vps/deploy.sh
+++ b/deploy/vps/deploy.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+#
+# Digerati Experts public website — VPS deployment script.
+#
+# Release-based deploy with health check and automatic rollback:
+#
+#   GitHub <branch>
+#        ↓  git fetch (bare mirror in $SITE_HOME/app)
+#   releases/<timestamp>/   (checkout + npm ci + npm run build)
+#        ↓  build validation
+#   current -> releases/<timestamp>   (atomic symlink flip)
+#        ↓  systemctl restart $SERVICE_NAME
+#   health check (/healthz + /)
+#        ↓  on failure: flip symlink back, restart, exit 1
+#
+# Usage:
+#   deploy.sh staging          # deploys to /home/staging.digeratiexperts.com
+#   deploy.sh production       # deploys to /home/digeratiexperts.com
+#
+# Overridable environment variables (defaults set per target below):
+#   DEPLOY_BRANCH   git branch to deploy            (default: main)
+#   SITE_HOME       website home directory
+#   APP_PORT        private 127.0.0.1 port the app listens on
+#   SERVICE_NAME    systemd service to restart
+#   REPO_URL        git remote
+#   KEEP_RELEASES   how many old releases to keep   (default: 3)
+#   NO_SYSTEMD=1    test mode: start node directly instead of systemd
+#                   (used for local/CI validation only)
+#
+set -euo pipefail
+
+TARGET="${1:-}"
+case "$TARGET" in
+  staging)
+    SITE_HOME="${SITE_HOME:-/home/staging.digeratiexperts.com}"
+    APP_PORT="${APP_PORT:-3200}"
+    SERVICE_NAME="${SERVICE_NAME:-digeratiexperts-staging}"
+    ;;
+  production)
+    SITE_HOME="${SITE_HOME:-/home/digeratiexperts.com}"
+    APP_PORT="${APP_PORT:-3300}"
+    SERVICE_NAME="${SERVICE_NAME:-digeratiexperts-site}"
+    ;;
+  *)
+    echo "Usage: $0 staging|production" >&2
+    exit 64
+    ;;
+esac
+
+REPO_URL="${REPO_URL:-https://github.com/digeratiexperts/Replit-Site.git}"
+DEPLOY_BRANCH="${DEPLOY_BRANCH:-main}"
+KEEP_RELEASES="${KEEP_RELEASES:-3}"
+NO_SYSTEMD="${NO_SYSTEMD:-0}"
+
+MIRROR_DIR="$SITE_HOME/app"
+RELEASES_DIR="$SITE_HOME/releases"
+SHARED_ENV="$SITE_HOME/shared/.env"
+CURRENT_LINK="$SITE_HOME/current"
+LOG_DIR="$SITE_HOME/logs"
+TS="$(date +%Y%m%d%H%M%S)"
+NEW_RELEASE="$RELEASES_DIR/$TS"
+
+log() { printf '[deploy %s] %s\n' "$(date +%H:%M:%S)" "$*"; }
+fail() { log "ERROR: $*"; exit 1; }
+
+# ---------------------------------------------------------------- preflight
+command -v node >/dev/null || fail "node not found on PATH"
+command -v npm  >/dev/null || fail "npm not found on PATH"
+NODE_MAJOR="$(node -p 'process.versions.node.split(".")[0]')"
+[ "$NODE_MAJOR" -ge 20 ] || fail "Node 20+ required, found $(node --version)"
+
+[ -f "$SHARED_ENV" ] || fail "$SHARED_ENV missing — create it before deploying (see deploy/vps/env.production.example)"
+mkdir -p "$RELEASES_DIR" "$LOG_DIR"
+
+# ---------------------------------------------------------------- fetch
+if [ ! -d "$MIRROR_DIR" ]; then
+  log "Cloning $REPO_URL (bare mirror) into $MIRROR_DIR"
+  git clone --mirror "$REPO_URL" "$MIRROR_DIR"
+else
+  log "Fetching latest $DEPLOY_BRANCH"
+  git --git-dir="$MIRROR_DIR" fetch --prune origin
+fi
+COMMIT="$(git --git-dir="$MIRROR_DIR" rev-parse "$DEPLOY_BRANCH")"
+log "Deploying $DEPLOY_BRANCH @ $COMMIT"
+
+# ---------------------------------------------------------------- build
+log "Checking out release into $NEW_RELEASE"
+mkdir -p "$NEW_RELEASE"
+git --git-dir="$MIRROR_DIR" --work-tree="$NEW_RELEASE" checkout -f "$DEPLOY_BRANCH" -- .
+
+cd "$NEW_RELEASE"
+log "Installing dependencies (npm ci)"
+npm ci --no-audit --no-fund
+
+log "Building production bundle"
+npm run build
+
+# ---------------------------------------------------------------- validate
+[ -f dist/index.js ] || fail "build validation failed: dist/index.js missing"
+[ -f dist/public/index.html ] || fail "build validation failed: dist/public/index.html missing"
+JS_COUNT="$(find dist/public/assets -name '*.js' | wc -l)"
+[ "$JS_COUNT" -gt 0 ] || fail "build validation failed: no JS assets emitted"
+
+log "Scanning built bundle for internal content and secret patterns"
+if grep -rqE 'internal/(pricing-tiers|sales-process|security-stack|usp-worksheet)' dist/public/assets/; then
+  fail "bundle contains internal page routes — refusing to deploy"
+fi
+if grep -rqE 'sk_live_[A-Za-z0-9]|whsec_[A-Za-z0-9]|jca_[A-Za-z0-9]{20}|client_secret["'"'"']?\s*[:=]\s*["'"'"'][a-f0-9]{30}' dist/public/assets/; then
+  fail "bundle appears to contain credentials — refusing to deploy"
+fi
+
+# link the shared env into the release for tooling that expects a local .env
+ln -sfn "$SHARED_ENV" "$NEW_RELEASE/.env"
+
+# ---------------------------------------------------------------- switch
+PREVIOUS_RELEASE=""
+if [ -L "$CURRENT_LINK" ]; then
+  PREVIOUS_RELEASE="$(readlink -f "$CURRENT_LINK")"
+fi
+
+log "Activating release $TS"
+ln -sfn "$NEW_RELEASE" "$CURRENT_LINK"
+
+restart_app() {
+  if [ "$NO_SYSTEMD" = "1" ]; then
+    # Test mode only: run the server directly, fully detached (setsid) so the
+    # deploy script never blocks waiting on it.
+    pkill -f "node $CURRENT_LINK/dist/index.js" 2>/dev/null || true
+    sleep 1
+    (cd "$CURRENT_LINK" && set -a && . "$SHARED_ENV" && set +a \
+      && NODE_ENV=production PORT="$APP_PORT" setsid nohup node "$CURRENT_LINK/dist/index.js" \
+         >> "$LOG_DIR/app.log" 2>&1 < /dev/null &) &
+    wait $! 2>/dev/null || true
+  else
+    sudo systemctl restart "$SERVICE_NAME"
+  fi
+}
+
+health_check() {
+  local tries=15
+  for i in $(seq 1 "$tries"); do
+    if curl -sf -o /dev/null -m 5 "http://127.0.0.1:$APP_PORT/healthz" \
+       && [ "$(curl -s -o /dev/null -m 5 -w '%{http_code}' "http://127.0.0.1:$APP_PORT/")" = "200" ]; then
+      return 0
+    fi
+    sleep 2
+  done
+  return 1
+}
+
+restart_app
+log "Waiting for health check on 127.0.0.1:$APP_PORT"
+if health_check; then
+  log "Health check passed"
+else
+  log "Health check FAILED — rolling back"
+  if [ -n "$PREVIOUS_RELEASE" ] && [ -d "$PREVIOUS_RELEASE" ]; then
+    ln -sfn "$PREVIOUS_RELEASE" "$CURRENT_LINK"
+    restart_app
+    if health_check; then
+      log "Rollback to $(basename "$PREVIOUS_RELEASE") succeeded"
+    else
+      log "Rollback restart ALSO failing — manual intervention required"
+    fi
+  else
+    log "No previous release available to roll back to"
+  fi
+  exit 1
+fi
+
+# ---------------------------------------------------------------- cleanup
+log "Pruning old releases (keeping $KEEP_RELEASES + current)"
+ls -1dt "$RELEASES_DIR"/*/ 2>/dev/null | tail -n "+$((KEEP_RELEASES + 1))" | while read -r old; do
+  [ "$(readlink -f "$old")" = "$(readlink -f "$CURRENT_LINK")" ] && continue
+  log "Removing old release $old"
+  rm -rf "$old"
+done
+
+log "Deploy complete: $DEPLOY_BRANCH @ $COMMIT is live on 127.0.0.1:$APP_PORT"

--- a/deploy/vps/digeratiexperts-site.service
+++ b/deploy/vps/digeratiexperts-site.service
@@ -1,0 +1,45 @@
+# systemd unit for the Digerati Experts public website (production).
+#
+# Install:
+#   sudo cp deploy/vps/digeratiexperts-site.service /etc/systemd/system/digeratiexperts-site.service
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now digeratiexperts-site
+#
+# For STAGING, copy this file to digeratiexperts-staging.service and change:
+#   User/Group        -> the staging.digeratiexperts.com CyberPanel site user
+#   WorkingDirectory  -> /home/staging.digeratiexperts.com/current
+#   EnvironmentFile   -> /home/staging.digeratiexperts.com/shared/.env
+#   PORT              -> 3200
+#
+# NOTE: replace CYBERPANEL_SITE_USER with the actual website user CyberPanel
+# created for the domain (visible in CyberPanel -> Websites -> List Websites,
+# or `ls -l /home/digeratiexperts.com`). Port 3100 is NOT available on this
+# VPS — it is used by the Intelligence Hub (techsales).
+
+[Unit]
+Description=Digerati Experts public website (Node/Express)
+After=network.target
+
+[Service]
+Type=simple
+User=CYBERPANEL_SITE_USER
+Group=CYBERPANEL_SITE_USER
+WorkingDirectory=/home/digeratiexperts.com/current
+EnvironmentFile=/home/digeratiexperts.com/shared/.env
+Environment=NODE_ENV=production
+Environment=PORT=3300
+ExecStart=/usr/bin/node /home/digeratiexperts.com/current/dist/index.js
+Restart=always
+RestartSec=3
+StandardOutput=append:/home/digeratiexperts.com/logs/app.log
+StandardError=append:/home/digeratiexperts.com/logs/app-error.log
+
+# Hardening
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+ProtectHome=read-only
+ReadWritePaths=/home/digeratiexperts.com/logs
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/vps/env.production.example
+++ b/deploy/vps/env.production.example
@@ -1,0 +1,41 @@
+# Production environment for the Digerati Experts public website.
+#
+# Copy to /home/<site>/shared/.env on the VPS and fill in real values there.
+# NEVER commit real values to this repository. Set restrictive permissions:
+#   chown <site-user>:<site-user> /home/<site>/shared/.env
+#   chmod 600 /home/<site>/shared/.env
+
+NODE_ENV=production
+# staging: 3200 · production: 3300 (3100 is taken by the Intelligence Hub)
+PORT=3300
+
+# --- Database -------------------------------------------------------------
+# Initial migration: keep pointing at the existing production Postgres used
+# by the Replit deployment (Neon/Replit DB) so no data migration is needed
+# on cutover. Moving the DB onto the VPS is a separate, later decision.
+DATABASE_URL=
+
+# --- Security (generate fresh values, 32+ chars) ---------------------------
+JWT_SECRET=
+SESSION_SECRET=
+
+# --- Domain ----------------------------------------------------------------
+MAIN_DOMAIN=digeratiexperts.com
+PORTAL_DOMAIN=portal.digeratiexperts.com
+ALLOWED_ORIGINS=https://digeratiexperts.com,https://portal.digeratiexperts.com
+
+# --- Integrations (use the ROTATED credentials, not the leaked ones) -------
+ZOHO_CLIENT_ID=
+ZOHO_CLIENT_SECRET=
+ZOHO_REFRESH_TOKEN=
+JUMPCLOUD_API_KEY=
+CORO_CLIENT_ID=
+CORO_CLIENT_SECRET=
+STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=
+OPENAI_API_KEY=
+ADMIN_EMAIL=info@digeratiexperts.com
+
+# --- Public-by-design client values (baked into the frontend at BUILD time)
+VITE_TURNSTILE_SITE_KEY=0x4AAAAAACVFaZbvIxse5DMd
+VITE_CLARITY_ID=fwts8lj42i

--- a/deploy/vps/openlitespeed-proxy.md
+++ b/deploy/vps/openlitespeed-proxy.md
@@ -1,0 +1,66 @@
+# OpenLiteSpeed proxy configuration (CyberPanel)
+
+Public HTTPS traffic terminates at OpenLiteSpeed (managed by CyberPanel);
+OLS proxies to the private Node app on `127.0.0.1:<port>`.
+
+Ports on this VPS:
+
+| App | Port |
+|---|---|
+| Intelligence Hub (techsales) | 3100 — **do not reuse** |
+| digeratiexperts.com staging | 3200 |
+| digeratiexperts.com production | 3300 |
+
+This is the same pattern already used for `techsales.digerati-experts.com`
+(OLS → 127.0.0.1:3100), so the vhost for that site can be used as a working
+reference.
+
+## Steps (staging shown; production is identical with port 3300)
+
+1. In CyberPanel create the website `staging.digeratiexperts.com`
+   (Websites → Create Website), then issue SSL (SSL → Manage SSL).
+
+2. OpenLiteSpeed WebAdmin (https://SERVER_IP:7080) →
+   Virtual Hosts → `staging.digeratiexperts.com`:
+
+   **a. External App** (Tab: External App → Add → Web Server):
+
+   ```
+   Name:             nodeapp-staging
+   Address:          127.0.0.1:3200
+   Max Connections:  100
+   Initial Request Timeout (secs): 60
+   Retry Timeout (secs):           0
+   Response Buffering:             No   (the app streams; keep off)
+   ```
+
+   **b. Rewrite** (Tab: Rewrite → Rewrite Rules), enable rewriting and set:
+
+   ```
+   RewriteEngine On
+   REWRITERULE ^(.*)$ http://nodeapp-staging/$1 [P,E=Proxy-Host:staging.digeratiexperts.com]
+   ```
+
+   Everything is proxied — the Node server serves both the SPA and `/api/*`,
+   and performs the `/internal/*` 301 itself. Do NOT add a docroot static
+   context in front, or stale files in public_html could shadow the app.
+
+3. Graceful restart OLS (Actions → Graceful Restart, or
+   `systemctl restart lsws`).
+
+4. Verify from the VPS:
+
+   ```bash
+   curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:3200/healthz   # 200
+   curl -s -o /dev/null -w '%{http_code}\n' -H 'Host: staging.digeratiexperts.com' https://127.0.0.1/ -k  # 200
+   ```
+
+## Cloudflare notes
+
+- Staging: add `staging` A record → 192.227.158.46 (proxied) in the
+  digeratiexperts.com zone, and extend the origin SSL rule if one is host-scoped.
+- Production cutover: change the `digeratiexperts.com` apex (and `www`)
+  records from the Replit deployment to 192.227.158.46, keep proxied,
+  confirm SSL mode Full, then purge the zone cache.
+- Do not touch the existing `portal`/`techsales` records in the
+  digerati-experts.com zone.

--- a/deploy/vps/verify.sh
+++ b/deploy/vps/verify.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# Post-deploy verification for the Digerati Experts public website.
+#
+# Usage:
+#   verify.sh staging.digeratiexperts.com
+#   verify.sh digeratiexperts.com
+#   verify.sh 127.0.0.1:3200 --insecure-http    # direct app check on the VPS
+#
+set -uo pipefail
+
+HOST="${1:-}"
+[ -n "$HOST" ] || { echo "Usage: $0 <hostname>[:port] [--insecure-http]" >&2; exit 64; }
+SCHEME="https"
+[ "${2:-}" = "--insecure-http" ] && SCHEME="http"
+BASE="$SCHEME://$HOST"
+
+PASS=0; FAIL=0
+ok()   { PASS=$((PASS+1)); printf 'PASS  %s\n' "$1"; }
+bad()  { FAIL=$((FAIL+1)); printf 'FAIL  %s\n' "$1"; }
+
+code() { curl -s -o /dev/null -m 20 -w '%{http_code}' "$1"; }
+redirect_target() { curl -s -o /dev/null -m 20 -w '%{redirect_url}' "$1"; }
+
+echo "== Verifying $BASE =="
+
+# Homepage
+[ "$(code "$BASE/")" = "200" ] && ok "homepage 200" || bad "homepage not 200"
+
+# Health endpoints
+[ "$(code "$BASE/healthz")" = "200" ] && ok "/healthz 200" || bad "/healthz not 200"
+
+# All sitemap routes
+SITEMAP="$(curl -s -m 20 "$BASE/sitemap.xml")"
+if [ -z "$SITEMAP" ]; then
+  bad "sitemap.xml empty"
+else
+  echo "$SITEMAP" | grep -oE '<loc>[^<]*</loc>' | sed 's/<[^>]*>//g' | while read -r url; do
+    path="${url#https://digeratiexperts.com}"
+    c="$(code "$BASE$path")"
+    [ "$c" = "200" ] && printf 'PASS  sitemap %s\n' "$path" || printf 'FAIL  sitemap %s -> %s\n' "$path" "$c"
+  done
+fi
+
+# /internal redirects
+for p in /internal /internal/pricing-tiers /internal/sales-process; do
+  c="$(code "$BASE$p")"
+  t="$(redirect_target "$BASE$p")"
+  if [ "$c" = "301" ] || { [ "$c" = "200" ] && [ -n "$t" ]; }; then
+    ok "$p redirects (HTTP $c -> ${t:-followed})"
+  else
+    bad "$p returned $c (expected 301 to /)"
+  fi
+done
+
+# Bundle content scan (no internal data / credentials in shipped JS)
+TMP="$(mktemp -d)"
+MAIN_JS="$(curl -s -m 20 "$BASE/" | grep -oE '/assets/index-[A-Za-z0-9_-]+\.js' | head -1)"
+if [ -n "$MAIN_JS" ]; then
+  curl -s -m 30 "$BASE$MAIN_JS" -o "$TMP/bundle.js"
+  if grep -qE 'internal/pricing-tiers|internal/usp-worksheet|Guided Sales Pitch' "$TMP/bundle.js"; then
+    bad "main bundle contains internal content"
+  else
+    ok "main bundle free of internal routes/tools"
+  fi
+  if grep -qE 'sk_live_|whsec_|jca_[A-Za-z0-9]{20}' "$TMP/bundle.js"; then
+    bad "main bundle contains credential patterns"
+  else
+    ok "main bundle free of credential patterns"
+  fi
+else
+  bad "could not locate main JS bundle"
+fi
+rm -rf "$TMP"
+
+# HTTP -> HTTPS (only meaningful through the proxy, skip for direct app checks)
+if [ "$SCHEME" = "https" ]; then
+  c="$(curl -s -o /dev/null -m 20 -w '%{http_code}' "http://$HOST/")"
+  case "$c" in
+    301|302|308) ok "http -> https redirect ($c)" ;;
+    *) bad "http://$HOST/ returned $c (expected redirect)" ;;
+  esac
+fi
+
+echo "== $PASS passed, $FAIL failed =="
+[ "$FAIL" -eq 0 ]

--- a/server/index.ts
+++ b/server/index.ts
@@ -195,6 +195,17 @@ app.use((req, res, next) => {
   next();
 });
 
+// SEO files (sitemap.xml, robots.txt) live in the repo-root public/ folder,
+// which is outside Vite's publicDir (client/public) and therefore not copied
+// into dist/public by the build. Serve it directly so /sitemap.xml and
+// /robots.txt work in every deployment.
+app.use(
+  express.static(path.resolve(process.cwd(), "public"), {
+    index: false,
+    maxAge: "1h",
+  }),
+);
+
 /** Utility to list routes for debugging */
 function listEndpoints(): Array<{ method: string; path: string }> {
   const routes: Array<{ method: string; path: string }> = [];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Turnkey kit for migrating digeratiexperts.com from Replit Autoscale to the CyberPanel/OpenLiteSpeed VPS, per the agreed split: **CyberPanel owns the domain** (website entry, vhost, SSL, logs, backups), **this kit owns the app** (clone, build, systemd service, deploys, health checks, rollback). No manual `public_html` copies, no Coolify/Dokploy/Docker panels.

## Files added

| File | Purpose |
|---|---|
| `deploy/vps/README.md` | Full runbook: directory layout, one-time staging setup, cutover order, verification checklist, database note |
| `deploy/vps/deploy.sh` | Release-based deployer: bare git mirror → `releases/<ts>` checkout → `npm ci` → build → **build validation + bundle scan for internal content/credentials** → atomic `current` symlink flip → `systemctl restart` → health check (`/healthz` + `/`) → **automatic rollback to the previous release on failure** → prune (keep 3) |
| `deploy/vps/digeratiexperts-site.service` | systemd unit (Restart=always, boot-start, EnvironmentFile from `shared/.env`, hardening, journald+file logs). Staging variant documented in-file |
| `deploy/vps/verify.sh` | Post-deploy checks: homepage, `/healthz`, every sitemap route, `/internal/*` 301s, bundle content/credential scan, HTTP→HTTPS |
| `deploy/vps/openlitespeed-proxy.md` | OLS External App + rewrite-proxy config per vhost, mirroring the existing techsales pattern; Cloudflare DNS/cutover notes |
| `deploy/vps/env.production.example` | `.env` template for `/home/<site>/shared/.env` (0600, never committed) |

## One code change

`server/index.ts`: serve the repo-root `public/` folder via Express. **Bug found during testing** — `sitemap.xml` and `robots.txt` live in root `public/`, which is outside Vite's `publicDir` (`client/public`), so they were never copied into `dist/public`; on a VPS deploy they would have returned the SPA shell instead of XML. Now served explicitly in all environments.

## Key decisions / corrections

- **Port 3100 is not available** on this VPS (Intelligence Hub/techsales). Kit uses **3200 staging / 3300 production**, bound to 127.0.0.1 only.
- systemd (not PM2), per requirements.
- Database: initial cutover keeps `DATABASE_URL` pointed at the existing production Postgres used by Replit — no data migration bundled into the traffic cutover.
- Single deployer rule: if this script becomes the deploy mechanism (cron or CyberPanel Git Manager webhook), any competing timer/webhook must be disabled.

## Test results (all run in this environment, `NO_SYSTEMD=1` test mode)

- **Happy path**: fresh clone → build → scan → activate → health check → prune, exit 0, app healthy on 127.0.0.1:3456
- **Rollback**: forced health-check failure → script exits 1 and `current` symlink verifiably restored to the previous release
- **verify.sh**: 38/38 PASS against the deployed instance — homepage, `/healthz`, all sitemap routes (confirming the SEO-file fix), `/internal`, `/internal/pricing-tiers`, `/internal/sales-process` all 301 → `/`, bundle free of internal content and credential patterns
- `bash -n` syntax checks pass; production build passes

## What still requires action before running on the VPS

1. **`VPS_SSH_PRIVATE_KEY` secret** — not present in this agent VM; after repairing the stored value (raw multiline key, no gutter characters), a new agent run will have SSH access to execute the runbook.
2. **Merge [PR #3](https://github.com/digeratiexperts/Replit-Site/pull/3) before deploying staging from `main`** — main currently still contains the old `/pricing` page with internal unit-cost/margin data; the deploy script's bundle scan checks internal *routes* and credentials but PR #3 is what actually removes that page content.
3. CyberPanel: create `staging.digeratiexperts.com` website + SSL; Cloudflare: `staging` A record → 192.227.158.46 (proxied).
4. Rotate Zoho/JumpCloud/Coro credentials and put replacements only in `/home/<site>/shared/.env`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f942c2d0-acab-4d93-92eb-e385eff30956?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f942c2d0-acab-4d93-92eb-e385eff30956&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

