### PR TITLE
Prevent silent production drift with exact release verification

### DIFF
--- a/deploy/vps/deploy.sh
+++ b/deploy/vps/deploy.sh
@@ -7,11 +7,11 @@
 #   GitHub <branch>
 #        ↓  git fetch (bare mirror in $SITE_HOME/app)
 #   releases/<timestamp>/   (checkout + npm ci + npm run build)
-#        ↓  build validation
+#        ↓  build validation + release.txt commit marker
 #   current -> releases/<timestamp>   (atomic symlink flip)
 #        ↓  sudo -n /usr/bin/systemctl restart $SERVICE_NAME
 #        ↓  sudo -n /usr/bin/systemctl is-active $SERVICE_NAME
-#   health check (127.0.0.1 /healthz + /; production also public /healthz)
+#   health check (127.0.0.1 + public HTTPS) AND exact deployed commit verification
 #        ↓  on failure: flip symlink back, restart, exit 1
 #
 # Production (authoritative):
@@ -130,6 +130,10 @@ npm run build
 JS_COUNT="$(find dist/public/assets -name '*.js' | wc -l)"
 [ "$JS_COUNT" -gt 0 ] || fail "build validation failed: no JS assets emitted"
 
+# Publish an immutable-by-content release identity into the built site. Health checks
+# request it with a cache-busting query string and compare it to the exact Git commit.
+printf '%s\n' "$COMMIT" > "$NEW_RELEASE/dist/public/release.txt"
+
 log "Scanning built bundle for internal content and secret patterns"
 if grep -rqE 'internal/(pricing-tiers|sales-process|security-stack|usp-worksheet)' dist/public/assets/; then
   fail "bundle contains internal page routes — refusing to deploy"
@@ -143,8 +147,12 @@ ln -sfn "$SHARED_ENV" "$NEW_RELEASE/.env"
 
 # ---------------------------------------------------------------- switch
 PREVIOUS_RELEASE=""
+PREVIOUS_COMMIT=""
 if [ -L "$CURRENT_LINK" ]; then
   PREVIOUS_RELEASE="$(readlink -f "$CURRENT_LINK")"
+  if [ -f "$PREVIOUS_RELEASE/dist/public/release.txt" ]; then
+    PREVIOUS_COMMIT="$(tr -d '\r\n' < "$PREVIOUS_RELEASE/dist/public/release.txt")"
+  fi
 fi
 
 log "Activating release $TS"
@@ -179,11 +187,26 @@ restart_app() {
   return 0
 }
 
+release_matches() {
+  local url="$1"
+  local expected_sha="$2"
+  local seen_sha
+
+  # An empty expected SHA is allowed only for rollback to a release created before
+  # commit markers existed. New deployments always pass COMMIT and are strict.
+  [ -z "$expected_sha" ] && return 0
+
+  seen_sha="$(curl -fsS -m 5 "${url}?sha=${expected_sha}&ts=${TS}" 2>/dev/null | tr -d '\r\n' || true)"
+  [ "$seen_sha" = "$expected_sha" ]
+}
+
 local_health_check() {
+  local expected_sha="${1:-}"
   local tries=15
   for i in $(seq 1 "$tries"); do
     if curl -sf -o /dev/null -m 5 "http://127.0.0.1:$APP_PORT/healthz" \
-       && [ "$(curl -s -o /dev/null -m 5 -w '%{http_code}' "http://127.0.0.1:$APP_PORT/")" = "200" ]; then
+       && [ "$(curl -s -o /dev/null -m 5 -w '%{http_code}' "http://127.0.0.1:$APP_PORT/")" = "200" ] \
+       && release_matches "http://127.0.0.1:$APP_PORT/release.txt" "$expected_sha"; then
       return 0
     fi
     sleep 2
@@ -192,12 +215,16 @@ local_health_check() {
 }
 
 public_health_check() {
+  local expected_sha="${1:-}"
   # Skip when NO_SYSTEMD or PUBLIC_HEALTH_URL explicitly emptied.
   [ "$NO_SYSTEMD" = "1" ] && return 0
   [ -z "${PUBLIC_HEALTH_URL:-}" ] && return 0
+
+  local public_base="${PUBLIC_HEALTH_URL%/healthz}"
   local tries=10
   for i in $(seq 1 "$tries"); do
-    if curl -fsS -m 10 "$PUBLIC_HEALTH_URL" >/dev/null; then
+    if curl -fsS -m 10 "${PUBLIC_HEALTH_URL}?sha=${expected_sha}&ts=${TS}" >/dev/null \
+       && release_matches "${public_base}/release.txt" "$expected_sha"; then
       return 0
     fi
     sleep 2
@@ -206,21 +233,29 @@ public_health_check() {
 }
 
 health_check() {
-  local_health_check || return 1
-  public_health_check || return 1
+  local expected_sha="${1:-}"
+  local_health_check "$expected_sha" || return 1
+  public_health_check "$expected_sha" || return 1
   return 0
 }
 
 restart_app || fail "service restart failed — deployment aborted (no silent continue)"
-log "Waiting for health check on 127.0.0.1:$APP_PORT (and public healthz if configured)"
-if health_check; then
-  log "Health check passed"
+log "Waiting for health check and exact release verification on 127.0.0.1:$APP_PORT (and public HTTPS if configured)"
+if health_check "$COMMIT"; then
+  log "Health check passed; verified live release SHA $COMMIT"
 else
-  log "Health check FAILED — rolling back"
+  log "Health/release verification FAILED — rolling back"
   if [ -n "$PREVIOUS_RELEASE" ] && [ -d "$PREVIOUS_RELEASE" ]; then
     ln -sfn "$PREVIOUS_RELEASE" "$CURRENT_LINK"
-    if restart_app && health_check; then
-      log "Rollback to $(basename "$PREVIOUS_RELEASE") succeeded"
+    if [ -z "$PREVIOUS_COMMIT" ]; then
+      log "WARN: previous release predates release markers; rollback will verify service health but cannot verify its commit SHA"
+    fi
+    if restart_app && health_check "$PREVIOUS_COMMIT"; then
+      if [ -n "$PREVIOUS_COMMIT" ]; then
+        log "Rollback to $(basename "$PREVIOUS_RELEASE") @ $PREVIOUS_COMMIT succeeded"
+      else
+        log "Rollback to $(basename "$PREVIOUS_RELEASE") succeeded"
+      fi
     else
       log "Rollback restart/health ALSO failing — manual intervention required"
     fi
@@ -238,4 +273,4 @@ ls -1dt "$RELEASES_DIR"/*/ 2>/dev/null | tail -n "+$((KEEP_RELEASES + 1))" | whi
   rm -rf "$old"
 done
 
-log "Deploy complete: $DEPLOY_BRANCH @ $COMMIT is live on 127.0.0.1:$APP_PORT"
+log "Deploy complete: $DEPLOY_BRANCH @ $COMMIT is verified live on 127.0.0.1:$APP_PORT and public HTTPS"


### PR DESCRIPTION
## Why
Recent work has repeatedly reached a state where GitHub is fixed but production may still be serving an older release. A simple 200 `/healthz` cannot prove the intended commit is actually live.

## What changed
- writes the deployed Git SHA to `dist/public/release.txt` during every release build
- verifies `/healthz`, `/`, and `release.txt` locally after restart
- verifies public HTTPS health plus the same exact release SHA before declaring success
- cache-busts release checks so Cloudflare cannot satisfy the check with an old marker
- preserves automatic rollback and verifies the previous commit when its release marker is available
- allows health-only rollback for the one-time transition from older releases that predate release markers

## Outcome
A deploy can no longer report success merely because *some* app is answering on port 3300. The public site must prove it is serving the exact Git commit the deploy script selected.

## Validation
Review `deploy/vps/deploy.sh`; production execution should use the existing release-based deployment path. The first successful deployment of this change will create the release marker used by future strict rollback verification.