### PR TITLE
Align managed Store with canonical four-tier pricing catalog

### DIFF
--- a/client/src/data/storeCatalog.test.ts
+++ b/client/src/data/storeCatalog.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { pricingTiers } from "./pricing";
+import {
+  getContractOnlyStoreProducts,
+  getStoreProductBySku,
+  storeCatalogProducts,
+} from "./storeCatalog";
+
+describe("public Store catalog", () => {
+  it("publishes all four ProActive tiers from canonical pricing", () => {
+    const proactive = getContractOnlyStoreProducts().filter((product) =>
+      product.name.startsWith("ProActive Ecosystem"),
+    );
+
+    expect(proactive.map((product) => product.sku)).toEqual([
+      "DE-SVC-MGD-IT-MO",
+      "DE-SVC-MGD-OFFICE-MO",
+      "DE-SVC-MGD-BUSINESS-MO",
+      "DE-SVC-MGD-ENTERPRISE-MO",
+    ]);
+    expect(proactive.map((product) => product.basePrice)).toEqual(
+      pricingTiers.map((tier) => tier.user),
+    );
+  });
+
+  it("keeps managed tiers contract-only and non-checkout", () => {
+    const proactive = storeCatalogProducts.filter((product) =>
+      product.name.startsWith("ProActive Ecosystem"),
+    );
+
+    expect(proactive).toHaveLength(4);
+    for (const product of proactive) {
+      expect(product.isContractOnly).toBe(true);
+      expect(product.isCheckoutEnabled).toBe(false);
+    }
+  });
+
+  it("uses defensible recovery-objective language for public BCDR", () => {
+    const bcdr = getStoreProductBySku("DE-SVC-MGD-BCDR-MO");
+    expect(bcdr).toBeDefined();
+    expect(bcdr?.features).toContain("Contract-Defined RTO/RPO Objectives");
+    expect(bcdr?.features.join(" ")).not.toMatch(/RTO\/RPO Guarantees/i);
+    expect(bcdr?.description).not.toMatch(/ensuring your business can recover from any disruption/i);
+  });
+});

--- a/client/src/data/storeCatalog.ts
+++ b/client/src/data/storeCatalog.ts
@@ -2,6 +2,7 @@ import {
   categoryLabels,
   formatPrice,
   storeProducts as rawStoreProducts,
+  type ProductCategory,
   type StoreProduct,
 } from "./storeProducts";
 import { pricingTiers, type ProActiveTierKey } from "./pricing";
@@ -82,4 +83,4 @@ export const getRelatedStoreProducts = (
     .slice(0, limit);
 
 export { categoryLabels, formatPrice };
-export type { StoreProduct };
+export type { ProductCategory, StoreProduct };

--- a/client/src/data/storeCatalog.ts
+++ b/client/src/data/storeCatalog.ts
@@ -1,0 +1,85 @@
+import {
+  categoryLabels,
+  formatPrice,
+  storeProducts as rawStoreProducts,
+  type StoreProduct,
+} from "./storeProducts";
+import { pricingTiers, type ProActiveTierKey } from "./pricing";
+
+const PROACTIVE_SKUS: Record<ProActiveTierKey, { id: string; sku: string }> = {
+  it: { id: "prod-000", sku: "DE-SVC-MGD-IT-MO" },
+  office: { id: "prod-001", sku: "DE-SVC-MGD-OFFICE-MO" },
+  business: { id: "prod-002", sku: "DE-SVC-MGD-BUSINESS-MO" },
+  enterprise: { id: "prod-003", sku: "DE-SVC-MGD-ENTERPRISE-MO" },
+};
+
+const proactiveProducts: StoreProduct[] = pricingTiers.map((tier, index) => ({
+  id: PROACTIVE_SKUS[tier.id].id,
+  sku: PROACTIVE_SKUS[tier.id].sku,
+  name: `ProActive Ecosystem - ${tier.name}`,
+  shortDescription: tier.idealBuyer,
+  description: tier.note,
+  category: "contract_services",
+  pricingType: "per_user",
+  basePrice: tier.user,
+  pricingUnit: "user",
+  isContractOnly: true,
+  isCheckoutEnabled: false,
+  isClientOnly: false,
+  requiredClientType: "public",
+  minimumQuantity: 1,
+  features: [...tier.inclusions],
+  sortOrder: index,
+}));
+
+function sanitizePublicPromises(product: StoreProduct): StoreProduct {
+  if (product.sku !== "DE-SVC-MGD-BCDR-MO") return product;
+
+  return {
+    ...product,
+    description:
+      "Managed business continuity and disaster recovery services designed to improve recovery readiness and reduce disruption risk.",
+    features: product.features.map((feature) =>
+      feature === "RTO/RPO Guarantees" ? "Contract-Defined RTO/RPO Objectives" : feature,
+    ),
+  };
+}
+
+const nonProactiveProducts = rawStoreProducts
+  .filter((product) => !product.name.startsWith("ProActive Ecosystem"))
+  .map(sanitizePublicPromises);
+
+/**
+ * Public Store catalog view.
+ *
+ * ProActive managed tiers are derived from the canonical pricing module rather
+ * than duplicated Store numbers. Other products retain their existing Store
+ * definitions, with public-facing promise language normalized here.
+ */
+export const storeCatalogProducts: StoreProduct[] = [
+  ...proactiveProducts,
+  ...nonProactiveProducts,
+].sort((a, b) => a.sortOrder - b.sortOrder);
+
+export const getStoreProductBySku = (sku: string | undefined): StoreProduct | undefined =>
+  storeCatalogProducts.find((product) => product.sku === sku);
+
+export const getContractOnlyStoreProducts = (): StoreProduct[] =>
+  storeCatalogProducts.filter((product) => product.isContractOnly);
+
+export const getRelatedStoreProducts = (
+  product: StoreProduct,
+  includeClientOnly: boolean,
+  limit = 4,
+): StoreProduct[] =>
+  storeCatalogProducts
+    .filter(
+      (candidate) =>
+        candidate.category === product.category &&
+        candidate.id !== product.id &&
+        (includeClientOnly || !candidate.isClientOnly),
+    )
+    .slice(0, limit);
+
+export { categoryLabels, formatPrice };
+export type { StoreProduct };

--- a/client/src/pages/store/ManagedStore.tsx
+++ b/client/src/pages/store/ManagedStore.tsx
@@ -3,19 +3,18 @@ import { MegaMenu } from "@/components/MegaMenu";
 import { DigeratiEnhancedFooterSection } from "../sections/DigeratiEnhancedFooterSection";
 import { Button } from "@/components/ui/button";
 import { Link } from "wouter";
-import { 
-  ArrowRight, Shield, Building, Calendar, CheckCircle, Phone, 
+import {
+  ArrowRight, Shield, Building, Calendar, CheckCircle, Phone,
   Star, Clock, Award, Lock
 } from "lucide-react";
 import { useSEO } from "@/hooks/useSEO";
-import { 
-  getContractOnlyProducts,
+import {
+  getContractOnlyStoreProducts,
   categoryLabels,
-  formatPrice,
   type StoreProduct
-} from "@/data/storeProducts";
+} from "@/data/storeCatalog";
 import { CartButton } from "@/components/store/CartButton";
-import { pricing, getPricingFooterText } from "@/data/pricing";
+import { getPricingFooterText } from "@/data/pricing";
 
 const ManagedStore = () => {
   const prefersReducedMotion = useReducedMotion();
@@ -26,13 +25,13 @@ const ManagedStore = () => {
     canonical: '/store/managed',
   });
 
-  const contractOnlyProducts = getContractOnlyProducts();
+  const contractOnlyProducts = getContractOnlyStoreProducts();
 
-  const proactiveEcosystemProducts = contractOnlyProducts.filter(p => 
+  const proactiveEcosystemProducts = contractOnlyProducts.filter(p =>
     p.name.includes("ProActive Ecosystem")
   );
-  
-  const otherManagedProducts = contractOnlyProducts.filter(p => 
+
+  const otherManagedProducts = contractOnlyProducts.filter(p =>
     !p.name.includes("ProActive Ecosystem")
   );
 
@@ -51,8 +50,8 @@ const ManagedStore = () => {
       <motion.div
         variants={itemVariants}
         className={`relative rounded-2xl p-6 border transition-all duration-300 hover:-translate-y-1 cursor-pointer ${
-          featured 
-            ? 'bg-violet-500/10 border-violet-500/40 shadow-[0_0_40px_rgba(139,92,246,0.2)]' 
+          featured
+            ? 'bg-violet-500/10 border-violet-500/40 shadow-[0_0_40px_rgba(139,92,246,0.2)]'
             : 'bg-white/[0.03] border-white/10 hover:border-violet-500/30'
         }`}
         data-testid={`product-${product.id}`}
@@ -63,7 +62,7 @@ const ManagedStore = () => {
           Most Popular
         </div>
       )}
-      
+
       <div className="mb-4">
         <span className="text-xs text-white/40 uppercase tracking-wider">{categoryLabels[product.category]}</span>
         <h3 className="text-xl font-bold text-white mt-1">{product.name}</h3>
@@ -93,10 +92,10 @@ const ManagedStore = () => {
         ))}
       </ul>
 
-      <Button 
+      <Button
         className={`w-full ${
-          featured 
-            ? 'bg-violet-600 hover:bg-violet-500 text-white' 
+          featured
+            ? 'bg-violet-600 hover:bg-violet-500 text-white'
             : 'bg-white/10 hover:bg-white/20 text-white border border-white/20'
         }`}
         onClick={(e) => {
@@ -116,10 +115,10 @@ const ManagedStore = () => {
   return (
     <div className="min-h-screen bg-[#0a0a0a]">
       <MegaMenu />
-      
+
       <main className="pt-28 pb-20">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          
+
           {/* Breadcrumb with Cart Button */}
           <div className="mb-8 flex items-center justify-between">
             <div className="flex items-center gap-2 text-sm text-white/50">
@@ -131,7 +130,7 @@ const ManagedStore = () => {
           </div>
 
           {/* Hero Section */}
-          <motion.div 
+          <motion.div
             className="text-center mb-16"
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
@@ -148,13 +147,13 @@ const ManagedStore = () => {
               </span>
             </h1>
             <p className="text-xl text-white/70 max-w-3xl mx-auto leading-relaxed">
-              Complete managed IT packages designed for businesses that want predictable costs and comprehensive support. 
+              Complete managed IT packages designed for businesses that want predictable costs and comprehensive support.
               Everything you need in one subscription—no surprise bills, no nickel-and-diming.
             </p>
           </motion.div>
 
           {/* Contract Notice */}
-          <motion.div 
+          <motion.div
             className="mb-12 p-4 rounded-xl bg-violet-500/10 border border-violet-500/20 flex items-start gap-4"
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
@@ -164,14 +163,14 @@ const ManagedStore = () => {
             <div>
               <h3 className="text-white font-semibold mb-1">Contract-Based Services</h3>
               <p className="text-white/60 text-sm">
-                These managed IT packages require a consultation and service agreement. 
+                These managed IT packages require a consultation and service agreement.
                 Schedule a call to discuss your needs and receive a customized quote tailored to your organization.
               </p>
             </div>
           </motion.div>
 
           {/* ProActive Ecosystem Plans */}
-          <motion.section 
+          <motion.section
             className="mb-20"
             variants={containerVariants}
             initial="hidden"
@@ -182,17 +181,17 @@ const ManagedStore = () => {
               <h2 className="text-2xl md:text-3xl font-bold text-white mb-3">ProActive Ecosystem Plans</h2>
               <p className="text-white/60">All-inclusive managed IT packages. Choose the tier that fits your security and compliance needs.</p>
             </div>
-            
-            <div className="grid md:grid-cols-3 gap-6">
-              {proactiveEcosystemProducts.map((product, idx) => (
-                <ProductCard 
-                  key={product.id} 
-                  product={product} 
-                  featured={idx === 1} 
+
+            <div className="grid md:grid-cols-2 xl:grid-cols-4 gap-6">
+              {proactiveEcosystemProducts.map((product) => (
+                <ProductCard
+                  key={product.id}
+                  product={product}
+                  featured={product.sku === "DE-SVC-MGD-OFFICE-MO"}
                 />
               ))}
             </div>
-            
+
             <p className="text-center text-white/40 text-sm mt-6">
               {getPricingFooterText()}. Final pricing tailored to your users, sites, and compliance needs.
             </p>
@@ -200,7 +199,7 @@ const ManagedStore = () => {
 
           {/* Other Managed Services */}
           {otherManagedProducts.length > 0 && (
-            <motion.section 
+            <motion.section
               className="mb-20"
               variants={containerVariants}
               initial="hidden"
@@ -211,7 +210,7 @@ const ManagedStore = () => {
                 <h2 className="text-2xl md:text-3xl font-bold text-white mb-3">Additional Managed Services</h2>
                 <p className="text-white/60">Specialized managed services for specific needs.</p>
               </div>
-              
+
               <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
                 {otherManagedProducts.map((product) => (
                   <ProductCard key={product.id} product={product} />
@@ -221,7 +220,7 @@ const ManagedStore = () => {
           )}
 
           {/* Why Choose Managed */}
-          <motion.section 
+          <motion.section
             className="mb-20 rounded-2xl p-8 bg-gradient-to-br from-violet-900/20 to-purple-900/20 border border-violet-500/20"
             initial={{ opacity: 0, y: 30 }}
             whileInView={{ opacity: 1, y: 0 }}
@@ -231,7 +230,7 @@ const ManagedStore = () => {
             <div className="text-center mb-10">
               <h2 className="text-2xl md:text-3xl font-bold text-white mb-3">Why Choose Managed IT?</h2>
             </div>
-            
+
             <div className="grid md:grid-cols-4 gap-6">
               {[
                 { icon: Clock, value: "Assessment-led", label: "Engagement", description: "Prioritize before you buy" },
@@ -252,7 +251,7 @@ const ManagedStore = () => {
           </motion.section>
 
           {/* Final CTA */}
-          <motion.section 
+          <motion.section
             className="text-center"
             initial={{ opacity: 0, y: 30 }}
             whileInView={{ opacity: 1, y: 0 }}
@@ -263,12 +262,12 @@ const ManagedStore = () => {
               Ready to Get Started?
             </h2>
             <p className="text-white/60 mb-8 max-w-xl mx-auto">
-              Schedule a free 15-minute call to discuss your needs. We'll help you choose the right plan 
+              Schedule a free 15-minute call to discuss your needs. We'll help you choose the right plan
               and provide a customized quote for your organization.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <a href="/book">
-                <Button 
+                <Button
                   size="lg"
                   className="h-14 px-8 text-lg font-semibold bg-violet-600 hover:bg-violet-500 text-white shadow-lg shadow-violet-500/25"
                   data-testid="button-final-cta"
@@ -278,7 +277,7 @@ const ManagedStore = () => {
                 </Button>
               </a>
               <a href="tel:325-480-9870">
-                <Button 
+                <Button
                   size="lg"
                   className="h-14 px-8 text-lg font-semibold bg-transparent border-2 border-white/30 text-white hover:bg-white/10"
                   data-testid="button-call-us"
@@ -288,11 +287,11 @@ const ManagedStore = () => {
                 </Button>
               </a>
             </div>
-            
+
             <div className="mt-8">
               <Link href="/store/co-managed">
-                <Button 
-                  variant="link" 
+                <Button
+                  variant="link"
                   className="text-violet-400 hover:text-violet-300"
                   data-testid="button-browse-comanaged"
                 >

--- a/client/src/pages/store/ProductDetail.tsx
+++ b/client/src/pages/store/ProductDetail.tsx
@@ -9,12 +9,12 @@ import { ProductJsonLd, BreadcrumbJsonLd } from "@/components/JsonLd";
 import { useCart } from "@/contexts/CartContext";
 import { useToast } from "@/hooks/use-toast";
 import {
-  storeProducts,
+  getRelatedStoreProducts,
+  getStoreProductBySku,
   categoryLabels,
   formatPrice,
-  type StoreProduct,
   type ProductCategory,
-} from "@/data/storeProducts";
+} from "@/data/storeCatalog";
 import {
   ArrowRight,
   ArrowLeft,
@@ -76,17 +76,11 @@ const ProductDetail = () => {
     }
   }, [clientPricing, setClientPricing]);
 
-  const product = useMemo(() => {
-    return storeProducts.find((p) => p.sku === sku);
-  }, [sku]);
+  const product = useMemo(() => getStoreProductBySku(sku), [sku]);
 
   const relatedProducts = useMemo(() => {
     if (!product) return [];
-    let related = storeProducts.filter((p) => p.category === product.category && p.id !== product.id);
-    if (!isLoggedIn) {
-      related = related.filter((p) => !p.isClientOnly);
-    }
-    return related.slice(0, 4);
+    return getRelatedStoreProducts(product, isLoggedIn);
   }, [product, isLoggedIn]);
 
   useSEO({
@@ -123,10 +117,9 @@ const ProductDetail = () => {
     setQuantity((prev) => Math.max(minQty, prev + delta));
   };
 
-  const productPricing = product ? getProductPrice(product.id, product.basePrice) : { price: 0, hasDiscount: false, discountPercent: 0 };
+  const productPricing = getProductPrice(product.id, product.basePrice);
 
   const handleAddToCart = () => {
-    if (!product) return;
     addToCart(product, quantity, productPricing.price);
     toast({
       title: "Added to Cart",
@@ -152,7 +145,7 @@ const ProductDetail = () => {
         { name: "Home", url: "/" },
         { name: "Store", url: "/store" },
         { name: storeLabel, url: storeLink },
-        { name: product.name, url: `/store/product/${product.id}` }
+        { name: product.name, url: `/store/product/${product.sku}` }
       ]} />
       <MegaMenu />
 
@@ -185,7 +178,7 @@ const ProductDetail = () => {
                 </Button>
               </div>
             ) : (
-              <Button 
+              <Button
                 variant="outline"
                 size="sm"
                 onClick={loginRedirect}
@@ -278,7 +271,7 @@ const ProductDetail = () => {
                     )}
                     {!isLoggedIn && (
                       <div className="mt-2">
-                        <Button 
+                        <Button
                           variant="link"
                           size="sm"
                           onClick={loginRedirect}


### PR DESCRIPTION
Addresses #8 without changing checkout or canonical pricing.

## What changes
- builds the public ProActive managed Store catalog from the canonical `client/src/data/pricing.ts` tiers instead of consuming duplicated managed-tier values from the legacy Store array
- adds the missing **ProActive IT** Store SKU: `DE-SVC-MGD-IT-MO`
- preserves Office / Business / Enterprise managed SKUs and their contract-only behavior
- presents IT → Office → Business → Enterprise in a responsive 4-tier grid, with Office still highlighted as the recommended plan
- routes Product Detail and related managed products through the same canonical Store catalog adapter
- replaces unconditional `RTO/RPO Guarantees` public BCDR copy with `Contract-Defined RTO/RPO Objectives` and removes the absolute recovery claim from the description
- fixes Product Detail breadcrumb JSON-LD to use the SKU route rather than the internal product ID

## Pricing source of truth
No canonical prices are changed. Public managed Store presentation now derives rates from `client/src/data/pricing.ts`:
- IT $125/user/mo, $1,600 monthly minimum
- Office $165/user/mo, $2,400 monthly minimum
- Business $245/user/mo, $5,400 monthly minimum
- Enterprise $345/user/mo, $9,000 monthly minimum

## Tests
Adds `client/src/data/storeCatalog.test.ts` to assert:
- all four managed SKUs exist in order
- rates equal canonical pricing tiers
- all managed tiers remain contract-only / non-checkout
- public BCDR copy no longer contains the guarantee language

## Remaining #8 cleanup
The legacy `client/src/data/storeProducts.ts` array still contains the old three hard-coded ProActive records even though the managed listing/product-detail surfaces no longer consume those records. Keep #8 open until those dead duplicate definitions are removed safely and any remaining Store consumers are confirmed to use the canonical adapter.

## Scope
This PR changes Store presentation/catalog normalization only. It does not change the paid checkout path or Zoho Payments PR #9.