### PR TITLE
Recover paid orders safely after fulfillment crashes

### DIFF
--- a/server/secureStoreCheckout.ts
+++ b/server/secureStoreCheckout.ts
@@ -40,7 +40,6 @@ function isPurchasableForRole(product: StoreProduct, role: StoreRole): boolean {
   if (!product.isCheckoutEnabled || product.isContractOnly) return false;
   if (role === "admin") return true;
   if (role !== "comanaged") return false;
-
   return product.requiredClientType === "public" || product.requiredClientType === "comanaged";
 }
 
@@ -227,7 +226,7 @@ export function registerSecureZohoStoreCheckout(
         } catch (error) {
           await db
             .update(storeOrders)
-            .set({ status: "payment_failed", updatedAt: new Date() })
+            .set({ status: "pending", updatedAt: new Date() })
             .where(eq(storeOrders.id, order.id))
             .catch(() => undefined);
           throw error;

--- a/server/services/orderFulfillment.test.ts
+++ b/server/services/orderFulfillment.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  isFulfillmentActiveStatus,
+  isFulfillmentTerminalStatus,
+  isStaleProvisioning,
+} from "./orderFulfillment";
+
+describe("paid-order fulfillment recovery helpers", () => {
+  it("treats active claims separately from terminal fulfillment states", () => {
+    expect(isFulfillmentActiveStatus("provisioning")).toBe(true);
+    expect(isFulfillmentActiveStatus("processing")).toBe(true);
+    expect(isFulfillmentActiveStatus("paid")).toBe(false);
+    expect(isFulfillmentActiveStatus("completed")).toBe(false);
+
+    expect(isFulfillmentTerminalStatus("completed")).toBe(true);
+    expect(isFulfillmentTerminalStatus("cancelled")).toBe(true);
+    expect(isFulfillmentTerminalStatus("refunded")).toBe(true);
+    expect(isFulfillmentTerminalStatus("provisioning")).toBe(false);
+    expect(isFulfillmentTerminalStatus("paid")).toBe(false);
+  });
+
+  it("only considers provisioning claims stale after the recovery timeout", () => {
+    const now = new Date("2026-08-10T18:00:00-07:00").getTime();
+
+    expect(
+      isStaleProvisioning(
+        "provisioning",
+        new Date(now - 31 * 60 * 1000),
+        now,
+      ),
+    ).toBe(true);
+
+    expect(
+      isStaleProvisioning(
+        "provisioning",
+        new Date(now - 29 * 60 * 1000),
+        now,
+      ),
+    ).toBe(false);
+
+    expect(
+      isStaleProvisioning(
+        "paid",
+        new Date(now - 60 * 60 * 1000),
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it("does not classify missing or malformed timestamps as stale", () => {
+    expect(isStaleProvisioning("provisioning", null)).toBe(false);
+    expect(isStaleProvisioning("provisioning", "not-a-date")).toBe(false);
+  });
+});

--- a/server/services/orderFulfillment.ts
+++ b/server/services/orderFulfillment.ts
@@ -1,10 +1,15 @@
 /**
  * Post-payment order fulfillment orchestrator.
- * Called after store_orders is marked paid (Zoho Payments webhook).
- * Fail-soft: never throws to the caller; webhook must still return 200.
+ *
+ * Reliability model:
+ * - the payment webhook durably marks an order `paid`
+ * - exactly one worker atomically claims `paid -> provisioning`
+ * - completed/cancelled/refunded orders are terminal
+ * - a fatal exception returns our still-owned `provisioning` claim to `paid`
+ * - a bounded reconciler recovers paid orders and stale provisioning claims
  */
 
-import { eq } from "drizzle-orm";
+import { and, eq, lt } from "drizzle-orm";
 import { db } from "../db";
 import { storeOrders, type StoreOrder } from "@shared/schema";
 import { notificationService } from "./notificationService";
@@ -12,9 +17,15 @@ import { zohoClient } from "../zoho/zohoClient";
 import { zohoDeskService } from "../zoho/zohoDesk";
 import { eventBus, EventTypes } from "../eventBus";
 
-const FULFILLED_STATUSES = new Set(["provisioning", "processing", "completed"]);
-const SKIP_STATUSES = new Set(["cancelled", "refunded"]);
+const ACTIVE_FULFILLMENT_STATUSES = new Set(["provisioning", "processing"]);
+const TERMINAL_FULFILLMENT_STATUSES = new Set(["completed", "cancelled", "refunded"]);
 const FULFILLED_NOTE_MARKER = "[FULFILLED]";
+const STALE_PROVISIONING_MS = 30 * 60 * 1000;
+const RECONCILE_INTERVAL_MS = 5 * 60 * 1000;
+const RECONCILE_BATCH_SIZE = 25;
+
+let reconciliationRunning = false;
+let reconciliationTimer: NodeJS.Timeout | null = null;
 
 type LineItem = {
   name?: string;
@@ -28,10 +39,27 @@ function logSecurity(event: string, data: Record<string, unknown>) {
   console.log(`[SECURITY] ${event}`, data);
 }
 
-function alreadyFulfilled(order: StoreOrder): boolean {
-  if (FULFILLED_STATUSES.has(order.status || "")) return true;
-  if ((order.notes || "").includes(FULFILLED_NOTE_MARKER)) return true;
-  return false;
+export function isFulfillmentTerminalStatus(status: string | null | undefined): boolean {
+  return TERMINAL_FULFILLMENT_STATUSES.has(status || "");
+}
+
+export function isFulfillmentActiveStatus(status: string | null | undefined): boolean {
+  return ACTIVE_FULFILLMENT_STATUSES.has(status || "");
+}
+
+export function isStaleProvisioning(
+  status: string | null | undefined,
+  updatedAt: Date | string | null | undefined,
+  nowMs = Date.now(),
+): boolean {
+  if (status !== "provisioning" || !updatedAt) return false;
+  const updatedMs = new Date(updatedAt).getTime();
+  return Number.isFinite(updatedMs) && nowMs - updatedMs >= STALE_PROVISIONING_MS;
+}
+
+function alreadyCompleted(order: StoreOrder): boolean {
+  if (order.status === "completed") return true;
+  return (order.notes || "").includes(FULFILLED_NOTE_MARKER);
 }
 
 function parseLineItems(raw: unknown): LineItem[] {
@@ -111,7 +139,7 @@ async function createFulfillmentDeskTicket(order: StoreOrder, items: LineItem[])
   } catch (err: any) {
     console.warn(
       "[ORDER FULFILLMENT] Zoho Desk ticket failed:",
-      err?.response?.data || err?.message || err
+      err?.response?.data || err?.message || err,
     );
     return null;
   }
@@ -146,68 +174,85 @@ async function sendConfirmation(order: StoreOrder, items: LineItem[]): Promise<v
   }
 }
 
+async function loadOrder(id: string): Promise<StoreOrder | null> {
+  const [order] = await db.select().from(storeOrders).where(eq(storeOrders.id, id)).limit(1);
+  return order || null;
+}
+
 /**
- * Fulfill a paid store order: confirm email + Zoho Desk ticket + status progression.
- * Idempotent via status (provisioning/processing/completed) or notes marker.
+ * Atomically claim a paid order. Returning null means another worker owns it,
+ * it is already complete/terminal, or it is not yet eligible for fulfillment.
  */
-export async function fulfillPaidOrder(orderId: string | number): Promise<void> {
+async function claimPaidOrder(id: string): Promise<StoreOrder | null> {
+  const [claimed] = await db
+    .update(storeOrders)
+    .set({ status: "provisioning", updatedAt: new Date() })
+    .where(and(eq(storeOrders.id, id), eq(storeOrders.status, "paid")))
+    .returning();
+  return claimed || null;
+}
+
+async function releaseFailedClaim(id: string): Promise<void> {
+  const [released] = await db
+    .update(storeOrders)
+    .set({ status: "paid", updatedAt: new Date() })
+    .where(and(eq(storeOrders.id, id), eq(storeOrders.status, "provisioning")))
+    .returning({ id: storeOrders.id, orderNumber: storeOrders.orderNumber });
+
+  if (released) {
+    logSecurity("ORDER_FULFILLMENT_CLAIM_RELEASED", {
+      orderId: released.id,
+      orderNumber: released.orderNumber,
+      reason: "fatal_error",
+      newStatus: "paid",
+    });
+  }
+}
+
+/**
+ * Fulfill one durably paid order.
+ *
+ * The atomic `paid -> provisioning` update is the concurrency lock. Orders in
+ * `awaiting_payment` are never eligible; provider confirmation must first mark
+ * them paid. A fatal exception releases our claim back to paid for reconciliation.
+ */
+export async function fulfillPaidOrder(orderId: string | number): Promise<boolean> {
   const id = String(orderId);
+  let claimed = false;
 
   try {
-    const [order] = await db.select().from(storeOrders).where(eq(storeOrders.id, id)).limit(1);
-
+    const order = await claimPaidOrder(id);
     if (!order) {
-      console.error("[ORDER FULFILLMENT] Order not found", { orderId: id });
-      logSecurity("ORDER_FULFILLMENT_SKIPPED", { orderId: id, reason: "not_found" });
-      return;
-    }
+      const latest = await loadOrder(id);
+      if (!latest) {
+        logSecurity("ORDER_FULFILLMENT_SKIPPED", { orderId: id, reason: "not_found" });
+        return false;
+      }
 
-    if (SKIP_STATUSES.has(order.status || "")) {
+      const reason = alreadyCompleted(latest)
+        ? "already_completed"
+        : isFulfillmentTerminalStatus(latest.status)
+          ? "terminal_status"
+          : isFulfillmentActiveStatus(latest.status)
+            ? "already_claimed"
+            : "not_paid";
+
       logSecurity("ORDER_FULFILLMENT_SKIPPED", {
-        orderId: order.id,
-        orderNumber: order.orderNumber,
-        reason: "terminal_status",
-        status: order.status,
+        orderId: latest.id,
+        orderNumber: latest.orderNumber,
+        reason,
+        status: latest.status,
       });
-      return;
+      return false;
     }
 
-    if (alreadyFulfilled(order)) {
-      logSecurity("ORDER_FULFILLMENT_SKIPPED", {
-        orderId: order.id,
-        orderNumber: order.orderNumber,
-        reason: "already_fulfilled",
-        status: order.status,
-      });
-      return;
-    }
-
-    // Allow paid (and awaiting_payment in case webhook race left status briefly stale)
-    if (order.status !== "paid" && order.status !== "awaiting_payment") {
-      logSecurity("ORDER_FULFILLMENT_SKIPPED", {
-        orderId: order.id,
-        orderNumber: order.orderNumber,
-        reason: "unexpected_status",
-        status: order.status,
-      });
-      return;
-    }
-
-    const oldStatus = order.status;
+    claimed = true;
     const items = parseLineItems(order.lineItems);
-
-    await db
-      .update(storeOrders)
-      .set({
-        status: "provisioning",
-        updatedAt: new Date(),
-      })
-      .where(eq(storeOrders.id, order.id));
 
     logSecurity("ORDER_STATUS_CHANGED", {
       orderId: order.id,
       orderNumber: order.orderNumber,
-      oldStatus,
+      oldStatus: "paid",
       newStatus: "provisioning",
       triggeredBy: "order_fulfillment",
     });
@@ -215,7 +260,6 @@ export async function fulfillPaidOrder(orderId: string | number): Promise<void> 
     await sendConfirmation(order, items);
     const deskTicketId = await createFulfillmentDeskTicket(order, items);
 
-    // Push paid purchase into TechSales (same website-lead webhook path as marketing leads)
     try {
       await eventBus.emit(EventTypes.LEAD_CREATED, {
         id: String(order.id),
@@ -229,7 +273,7 @@ export async function fulfillPaidOrder(orderId: string | number): Promise<void> 
     } catch (syncErr: any) {
       console.warn(
         "[ORDER FULFILLMENT] TechSales purchase sync emit failed:",
-        syncErr?.message || syncErr
+        syncErr?.message || syncErr,
       );
     }
 
@@ -240,15 +284,21 @@ export async function fulfillPaidOrder(orderId: string | number): Promise<void> 
       deskTicketId ? `deskTicket:${deskTicketId}` : "deskTicket:skipped",
     ].filter(Boolean);
 
-    await db
+    const [completed] = await db
       .update(storeOrders)
       .set({
         status: "completed",
         notes: noteParts.join(" | "),
         updatedAt: new Date(),
       })
-      .where(eq(storeOrders.id, order.id));
+      .where(and(eq(storeOrders.id, order.id), eq(storeOrders.status, "provisioning")))
+      .returning({ id: storeOrders.id });
 
+    if (!completed) {
+      throw new Error("Fulfillment claim was lost before completion");
+    }
+
+    claimed = false;
     logSecurity("ORDER_STATUS_CHANGED", {
       orderId: order.id,
       orderNumber: order.orderNumber,
@@ -264,6 +314,7 @@ export async function fulfillPaidOrder(orderId: string | number): Promise<void> 
       deskTicketId,
       total: order.total,
     });
+    return true;
   } catch (error: any) {
     console.error("[ORDER FULFILLMENT ERROR]", {
       orderId: id,
@@ -273,5 +324,89 @@ export async function fulfillPaidOrder(orderId: string | number): Promise<void> 
       orderId: id,
       error: error?.message || String(error),
     });
+
+    if (claimed) {
+      try {
+        await releaseFailedClaim(id);
+      } catch (releaseError: any) {
+        console.error("[ORDER FULFILLMENT CLAIM RELEASE ERROR]", {
+          orderId: id,
+          message: releaseError?.message || String(releaseError),
+        });
+      }
+    }
+    return false;
   }
+}
+
+/**
+ * Recover work after restarts/crashes and pick up paid orders whose webhook-side
+ * asynchronous fulfillment did not run. The overlap guard prevents one process
+ * from stacking reconciliation passes; atomic claims protect across processes.
+ */
+export async function reconcilePaidOrders(): Promise<{ recovered: number; attempted: number; fulfilled: number }> {
+  if (reconciliationRunning) {
+    return { recovered: 0, attempted: 0, fulfilled: 0 };
+  }
+
+  reconciliationRunning = true;
+  try {
+    const now = new Date();
+    const staleCutoff = new Date(now.getTime() - STALE_PROVISIONING_MS);
+
+    const recoveredRows = await db
+      .update(storeOrders)
+      .set({ status: "paid", updatedAt: now })
+      .where(and(eq(storeOrders.status, "provisioning"), lt(storeOrders.updatedAt, staleCutoff)))
+      .returning({ id: storeOrders.id, orderNumber: storeOrders.orderNumber });
+
+    for (const recovered of recoveredRows) {
+      logSecurity("ORDER_FULFILLMENT_STALE_CLAIM_RECOVERED", {
+        orderId: recovered.id,
+        orderNumber: recovered.orderNumber,
+        newStatus: "paid",
+      });
+    }
+
+    const pending = await db
+      .select({ id: storeOrders.id })
+      .from(storeOrders)
+      .where(eq(storeOrders.status, "paid"))
+      .limit(RECONCILE_BATCH_SIZE);
+
+    let fulfilled = 0;
+    for (const order of pending) {
+      if (await fulfillPaidOrder(order.id)) fulfilled += 1;
+    }
+
+    if (recoveredRows.length > 0 || pending.length > 0) {
+      logSecurity("ORDER_FULFILLMENT_RECONCILED", {
+        recovered: recoveredRows.length,
+        attempted: pending.length,
+        fulfilled,
+      });
+    }
+
+    return {
+      recovered: recoveredRows.length,
+      attempted: pending.length,
+      fulfilled,
+    };
+  } catch (error: any) {
+    console.error("[ORDER FULFILLMENT RECONCILIATION ERROR]", error?.message || error);
+    return { recovered: 0, attempted: 0, fulfilled: 0 };
+  } finally {
+    reconciliationRunning = false;
+  }
+}
+
+/** Start production recovery once after boot, then every five minutes. */
+export function startOrderFulfillmentReconciliation(): void {
+  if (process.env.NODE_ENV !== "production" || reconciliationTimer) return;
+
+  void reconcilePaidOrders();
+  reconciliationTimer = setInterval(() => {
+    void reconcilePaidOrders();
+  }, RECONCILE_INTERVAL_MS);
+  reconciliationTimer.unref?.();
 }


### PR DESCRIPTION
Addresses #15 and fixes an additional payment-status bug found during the recovery audit.

## Reliability fixes
- fulfillment now starts only from durably `paid` orders; `awaiting_payment` is never fulfillable
- `paid -> provisioning` is an atomic conditional claim, preventing concurrent workers from both owning the same order
- fatal fulfillment errors conditionally release the still-owned `provisioning` claim back to `paid`
- stale `provisioning` claims older than 30 minutes are recovered to `paid`
- a bounded reconciler processes up to 25 paid orders per pass
- reconciliation has an in-process overlap guard; cross-process safety remains enforced by the atomic database claim
- production startup immediately runs reconciliation, then repeats every five minutes
- scheduler startup is attached to the existing one-time secure-checkout registration rather than adding another server bootstrap path

## Additional bug fixed
The secure checkout failure path wrote `payment_failed`, but `store_order_status` has no `payment_failed` enum member. A Zoho session-creation failure could therefore cause a second database failure.

The failure path now returns the local order to valid `pending` so it is clearly non-payable and can be retried with a new checkout attempt.

## Existing fail-soft behavior preserved
Confirmation email, Zoho Desk ticket creation, and TechSales event emission remain fail-soft. The order reaches `completed` after the fulfillment orchestration finishes; fatal orchestration/database exceptions release the claim for retry.

## Tests
Adds focused tests for:
- active vs terminal fulfillment states
- stale provisioning timeout behavior
- malformed/missing timestamps

## Acceptance / deployment rule
This PR should merge only if the hard unit-test and production-build gates pass. The repository-wide TypeScript baseline remains informational under #12.

Even after merge, Zoho Payments should not be considered production-live until real Payments credentials/webhook configuration are installed and a controlled paid-order + webhook + fulfillment test is completed.