### PR TITLE
Design system: Phase 1 audit + canonical Digerati design system + reference intake

### DIFF
--- a/design-references/README.md
+++ b/design-references/README.md
@@ -1,0 +1,69 @@
+# Design references (GetDesign + Relume)
+
+This folder holds **external** design-system references used to inform — never clone — the
+Digerati Experts design language. It is the intake area for the GetDesign `DESIGN.md`
+exports (Rambox, Evervault, supporting systems) and for Relume structural references.
+
+> Principle over imitation. We extract hierarchy, spacing, restraint, surface logic,
+> and interaction patterns from these systems and translate them into Digerati's own
+> brand language. We do **not** copy their layouts, headlines, colors, or components.
+> The canonical Digerati spec is [`docs/DIGERATI-DESIGN-SYSTEM.md`](../docs/DIGERATI-DESIGN-SYSTEM.md).
+
+## Relationship to the existing `design/` folder
+
+The repository already has a mature internal design system under [`design/`](../design/):
+
+- `design/BRAND.md`, `design/DESIGN_SYSTEM.md`, `design/IMAGERY.md`, `design/UX_PRINCIPLES.md`
+- `design/approved/` — shipped, DE-approved quality bar (screenshots + rationale)
+- `design/rejected/` — anti-patterns
+- `design/references/` — internal *principle notes* + inspiration screenshots (e.g. `clarity-bar-rambox-monday-2026-08.md`)
+
+`design-references/` (this folder) is **only** for the raw, externally-sourced reference
+material (GetDesign `DESIGN.md` files and Relume component references). Keep the two
+separate: `design/` is Digerati's own system; `design-references/` is the source material
+we learn from. Do not duplicate content between them — cross-link instead.
+
+## Structure
+
+```
+design-references/
+  getdesign/
+    rambox/        # Rambox DESIGN.md (primary visual sophistication reference)
+    evervault/     # Evervault DESIGN.md (cybersecurity / trust reference)
+    supporting/    # Vercel / HashiCorp / Stripe DESIGN.md (only where appropriate)
+  relume/          # Relume section/component structural references
+  README.md
+```
+
+## Reference priority (when references disagree)
+
+1. Existing Digerati business requirements and functionality
+2. Existing Digerati brand identity (`design/BRAND.md`, `.cursor/rules/brand.mdc`)
+3. **Rambox** `DESIGN.md` — overall visual sophistication and presentation
+4. **Evervault** `DESIGN.md` — cybersecurity and trust-oriented patterns
+5. **Relume** — UX architecture and section/component structure
+6. Supporting systems (Vercel, HashiCorp, Stripe) — targeted patterns only
+
+Do not blend five visual languages arbitrarily. There is exactly one Digerati system.
+
+## How to add the reference files (action for DE)
+
+The Rambox and Evervault `DESIGN.md` exports are **not yet in the repository**. When you
+have them, place them here (filenames are suggestions — keep the `DESIGN.md` name where
+possible so tooling can find them):
+
+| Reference | Put the file at | Status |
+|-----------|-----------------|--------|
+| Rambox (primary) | `design-references/getdesign/rambox/DESIGN.md` | ⛔ not provided yet |
+| Evervault (secondary) | `design-references/getdesign/evervault/DESIGN.md` | ⛔ not provided yet |
+| Vercel (optional) | `design-references/getdesign/supporting/vercel-DESIGN.md` | optional |
+| HashiCorp (optional) | `design-references/getdesign/supporting/hashicorp-DESIGN.md` | optional |
+| Stripe (optional) | `design-references/getdesign/supporting/stripe-DESIGN.md` | optional |
+| Relume references | `design-references/relume/<pattern-name>.md` or screenshots | as gathered |
+
+If a `DESIGN.md` already exists elsewhere in the repo, reuse it in place rather than
+duplicating; note its location in the relevant leaf `README.md`.
+
+After the files are added, the canonical spec (`docs/DIGERATI-DESIGN-SYSTEM.md`) should be
+revisited so that any concrete Rambox/Evervault principles are folded into the Digerati
+tokens and component rules.

--- a/design-references/getdesign/evervault/README.md
+++ b/design-references/getdesign/evervault/README.md
@@ -1,0 +1,24 @@
+# Evervault — GetDesign DESIGN.md (SECONDARY cybersecurity/enterprise reference)
+
+**Status: not yet provided.** Do not invent Evervault's contents.
+
+Place the Evervault GetDesign export here as `DESIGN.md` when available:
+
+```
+design-references/getdesign/evervault/DESIGN.md
+```
+
+## Role in the Digerati system
+
+Evervault is the **secondary reference for cybersecurity- and trust-oriented patterns** —
+how a security company signals technical credibility and trust without resorting to
+cliché (glowing shields, padlocks, hacker hoodies, matrix rain). Reference priority #4.
+
+Extract *principles*, not pixels:
+
+- credibility through precision, restraint, and technical clarity
+- dark, controlled surfaces; light used deliberately
+- trust signals (compliance, proof, transparency) presented calmly, not loudly
+
+Translate into Digerati's brand. Do **not** clone Evervault's palette, marks, or layouts.
+Digerati remains graphite + restrained violet + brand magenta `#D3126A`.

--- a/design-references/getdesign/rambox/README.md
+++ b/design-references/getdesign/rambox/README.md
@@ -1,0 +1,27 @@
+# Rambox — GetDesign DESIGN.md (PRIMARY visual reference)
+
+**Status: not yet provided.** Do not invent Rambox's contents.
+
+Place the Rambox GetDesign export here as `DESIGN.md` when available:
+
+```
+design-references/getdesign/rambox/DESIGN.md
+```
+
+## Role in the Digerati system
+
+Rambox is the **primary reference for overall visual sophistication and presentation** —
+editorial polish, typographic hierarchy, spacing rhythm, surface/elevation logic, and
+restraint. It is reference priority #3 (after Digerati business requirements and brand).
+
+Extract *principles*, not pixels:
+
+- one idea per band; type hierarchy over volume; whitespace as structure
+- imagery is the product/system, not decoration
+- one primary action per view
+
+Translate these into Digerati's dark graphite + violet-as-light + magenta-CTA language.
+Do **not** copy Rambox's colors, headlines, layouts, or "book a demo" patterns.
+
+Existing internal principle note (already in repo, keep in sync):
+[`design/references/clarity-bar-rambox-monday-2026-08.md`](../../../design/references/clarity-bar-rambox-monday-2026-08.md)

--- a/design-references/getdesign/supporting/README.md
+++ b/design-references/getdesign/supporting/README.md
@@ -1,0 +1,22 @@
+# Supporting references (Vercel / HashiCorp / Stripe) — OPTIONAL
+
+**Status: not yet provided.** Use only where a specific, targeted pattern helps.
+
+Place optional supporting exports here, e.g.:
+
+```
+design-references/getdesign/supporting/vercel-DESIGN.md
+design-references/getdesign/supporting/hashicorp-DESIGN.md
+design-references/getdesign/supporting/stripe-DESIGN.md
+```
+
+## Role in the Digerati system
+
+Reference priority #6 (lowest). Use for narrowly-scoped patterns only:
+
+- **Vercel** — restrained dark developer-marketing surfaces, code/diagram presentation.
+- **HashiCorp** — dense technical product/architecture explanation, documentation IA.
+- **Stripe** — pricing/comparison clarity, form and checkout ergonomics, gradient discipline.
+
+Never let a supporting system set the overall look. They contribute individual solutions,
+not a visual language. The Digerati system in `docs/DIGERATI-DESIGN-SYSTEM.md` is canonical.

--- a/design-references/relume/README.md
+++ b/design-references/relume/README.md
@@ -1,0 +1,40 @@
+# Relume — structural / UX architecture references
+
+Relume is a **structural and component reference**: page architecture, section
+composition, UX patterns, responsive layouts, and React component references. It is
+reference priority #5 and it is **not** permission to replace the existing website.
+
+## How to use Relume here
+
+Drop Relume references as markdown notes and/or screenshots, named by the pattern they
+inform, e.g.:
+
+```
+design-references/relume/hero-split-with-assessment.md
+design-references/relume/feature-grid-3col.md
+design-references/relume/pricing-tiers-comparison.md
+design-references/relume/faq-accordion.md
+```
+
+Each note should capture the *structure and UX rationale* (layout, hierarchy, responsive
+behavior, states), not the raw copy or imagery.
+
+## Rules when importing/recreating a Relume component
+
+- Adapt it to this codebase (Vite + React + TS + Tailwind + shadcn/ui + wouter).
+- Reuse existing primitives (`components/ui/*`, `components/visual/IconWell`, etc.).
+- Remove unnecessary dependencies; do not add new libraries for effects.
+- Replace placeholder copy with existing Digerati content (do not invent facts).
+- Replace placeholder imagery with Digerati assets (`client/src/lib/visualAssets.ts`).
+- Use Digerati design tokens (`--de-*`, `de-*` Tailwind colors) — no one-off hexes.
+- Preserve SEO semantics (`useSEO`, `JsonLd`) and accessibility.
+- Preserve responsive behavior (verify 390 / 768 / 1440 minimum).
+
+Treat Relume as a high-quality reference implementation. **Never paste Relume code
+verbatim into production.**
+
+## Where Relume patterns will materially help (from the audit)
+
+See `docs/DESIGN-SYSTEM-AUDIT.md` → "Where Relume patterns would materially improve UX"
+for the prioritized list (hero, service presentation, feature grids, pricing/comparison,
+FAQ, CTA, contact/booking, resources).

--- a/docs/DESIGN-SYSTEM-AUDIT.md
+++ b/docs/DESIGN-SYSTEM-AUDIT.md
@@ -1,0 +1,294 @@
+# Design System Audit — Digerati Experts
+
+> Phase 1 deliverable. Read-only audit of the existing production site before any broad
+> visual change. Companion to [`docs/DIGERATI-DESIGN-SYSTEM.md`](./DIGERATI-DESIGN-SYSTEM.md)
+> (canonical spec) and the existing internal system under [`design/`](../design).
+> Authoritative policy: root `.cursorrules`. Nothing here authorizes deleting content.
+
+**Audit date:** 2026-08 · **Branch:** `cursor/design-system-audit-a75a`
+**Method:** static inspection of `client/`, `server/`, `design/`, `tailwind.config.ts`,
+`client/src/index.css`; rendered inspection of `/`, `/proactive-ecosystem-pricing`,
+`/portal/login` via the local dev server.
+
+---
+
+## 1. What currently exists
+
+### 1.1 Framework & application architecture
+- **Client:** Vite + React 18 + TypeScript SPA. Routing via **wouter** (`client/src/App.tsx`).
+- **Server:** Express (`server/index.ts`) serving the built SPA and the API; Vite
+  middleware in dev. Drizzle ORM (Postgres) with a graceful **in-memory fallback** when
+  `DATABASE_URL` is unset.
+- **Styling:** Tailwind CSS 3 + **shadcn/ui** (new-york style, `components.json`), CVA for
+  variants, `tailwind-merge`/`clsx` via `lib/utils.ts`.
+- **Data/state:** `@tanstack/react-query`, React Context for cart/booking, `zustand` present.
+- **Animation:** `framer-motion` (~77 files) + CSS keyframes in `index.css` + `tailwindcss-animate`.
+- **Icons:** `lucide-react` (~203 files, dominant); `react-icons` in a single legacy file.
+- **SEO:** `react-helmet-async` + `hooks/useSEO.ts` (title/meta/canonical/robots) +
+  `components/JsonLd.tsx` (Organization, WebSite, FAQ, Article, Product, Service, Breadcrumb).
+
+### 1.2 Routing
+- One `<Switch>`/`<Route>` tree in `App.tsx`. Homepage (`/` → `pages/DigeratiHomepage.tsx`)
+  is eagerly imported; ~120+ other pages are `React.lazy` + `<Suspense>`.
+- Dynamic route families from `pages/routes/servicePages.tsx` → `GenericServicePage`
+  (services, industries, resources, support).
+- Redirects encode canonical paths (e.g. `/login` → `/portal/login`, `/contact` → `/#contact`).
+- **No shared marketing layout wrapper** — each page composes `MegaMenu` + footer itself
+  (or via `PageTemplate` / homepage `FullPageScrollProvider`). Only `MarketingChrome`
+  (the DE Desk widget), cart drawer, booking modal, sticky CTA, exit-intent, and cookie
+  banner are truly global (from `App.tsx`).
+
+### 1.3 Styling system & design tokens (three coexisting layers)
+1. **Canonical DE tokens** — `--de-*` in `client/src/index.css` (`:root`) mapped to Tailwind
+   `colors.de.*` in `tailwind.config.ts`. The intended brand system: graphite ladder
+   (`--de-bg #050312` → `--de-surface #0a0a0a` → `--de-raised #151217`), hairlines, paper
+   chapters (`--de-paper #f7f5f2`), brand magenta `--de-magenta #D3126A`, violet
+   `--de-violet #5B45E0`, plus chapter utility classes (`.de-dark-well`, `.de-paper-chapter`,
+   `.de-brand-energy-band`, chapter fades/seams). Documented in `design/DESIGN_SYSTEM.md`.
+2. **shadcn HSL tokens** — `--background`/`--foreground`/`--primary`/… with a `.dark` block
+   and `darkMode: ["class"]`. Default is a **light** theme; `.dark` is **never applied to
+   `<html>`**, so portal `dark:` utilities largely don't activate.
+3. **Legacy `lib/designSystem.ts`** — an off-brand token object (purple→blue gradients,
+   cyan accents, `bg-white`, gray text, glassmorphism, glow shadows). **Zero imports** —
+   dead code that contradicts the brand.
+
+Adoption is uneven: the `de-*` chapter system is used mainly on the homepage and a few
+shells (~21 files), while glassmorphism / purple→blue / cyan / hard-coded hexes remain the
+dominant styling path across inner pages, store, legal, trust, and portal (~100+ files).
+
+### 1.4 Typography
+- Space Grotesk (headings), Inter (body), Oxanium/JetBrains Mono (stats) — set in
+  `index.css` `@layer base` and `tailwind.config.ts` (`font-heading`/`font-sans`/`font-mono`).
+- Root font-size **14px** (15px ≥1920px, 16px ≥2560px). Heading tracking `-0.015em`…`-0.03em`,
+  line-height `1.15`; body line-height `1.6` (prose `1.75`).
+- **Weakness:** section H2s frequently jump to `text-5xl`/`text-6xl` with `text-2xl` body,
+  flattening hierarchy (documented in `design/references/clarity-bar-rambox-monday-2026-08.md`).
+
+### 1.5 Global CSS (`client/src/index.css`, ~1,270 lines)
+- Brand tokens + chapter utilities (good, canonical).
+- Accessibility: `:focus-visible` ring, `.skip-link`, `prefers-reduced-motion`,
+  `prefers-contrast`, `forced-colors`, autofill styling.
+- **Bloat/■off-brand:** large blocks of decorative utilities — `.glass`/`.glass-dark`,
+  `pulse-glow`, `text-gradient-animate`, `animate-float`, `hover-glow`, scroll-progress,
+  ripple, marquee, wave separators, per-city palettes — several of which contradict the
+  brand's "restraint / no excessive glow / no glassmorphism everywhere" rules.
+- **Duplicate declarations:** `html { scroll-behavior }`, `:focus-visible`, and
+  `prefers-reduced-motion` are defined more than once; `@tailwind` directives appear twice.
+
+### 1.6 Tailwind configuration (`tailwind.config.ts`)
+- Extends fonts, `colors.de.*`, radius tokens, radial gradient, accordion animation.
+- Container centered, padding `1rem`, `2xl` max `1680px`.
+- Plugins: `tailwindcss-animate`, `@tailwindcss/typography`. `darkMode: ["class"]`.
+- **Gap:** spacing scale, section-spacing scale, elevation/shadow scale, and motion-duration
+  tokens are **not** codified in config — they live as ad-hoc utility strings per component.
+
+### 1.7 Reusable UI primitives
+- **shadcn/ui** (`components/ui/*`, ~49 files): button, card, badge, accordion, dialog,
+  drawer, sheet, tabs, table, form, input, textarea, select, checkbox, radio-group, switch,
+  slider, calendar, carousel, command, popover, dropdown-menu, navigation-menu, sidebar,
+  toast/toaster, tooltip, skeleton, progress, breadcrumb, pagination, alert, alert-dialog,
+  avatar, chart, plus bespoke `enhanced-input`, `premium-slider`.
+- **Bespoke marketing primitives:** `Button` (shadcn, with `brand` gradient variant),
+  `visual/IconWell` (canonical icon container), `StatCallout`/`StatBanner`, `PremiumCTASection`,
+  `PageTemplate`, `RevealOnScroll`, `SectionPatterns` (pattern overlays, dividers, glow orbs),
+  `ServiceMatrix`/`ServiceCapabilityMatrix`, `EcosystemProgression`, `TierDetailTemplate`,
+  `JsonLd`, booking components. Centralized copy in `lib/ctaCopy.ts`; pricing data in
+  `data/pricing.ts`.
+
+### 1.8 Page layouts & responsive behavior
+- Homepage uses `FullPageScrollProvider` with proximity scroll-snap (desktop only; disabled
+  ≤1023px and under reduced-motion). Inner pages use `PageTemplate` or bespoke composition.
+- Container/padding are consistent via Tailwind container + `de-nav-clear`.
+- Responsive is generally present (Tailwind breakpoints), but several bands are "shrunk
+  desktop" (e.g. N×2 card grids collapsing) rather than recomposed for mobile.
+
+### 1.9 Animations
+- `framer-motion` for reveals/hover/scroll; `RevealOnScroll`; CSS keyframes (marquee, waves,
+  glow, shimmer). Reduced-motion is respected in most motion components and globally.
+- **Weakness:** decorative motion (floating orbs, glow pulses, gradient text) appears in
+  places that the brand says to avoid.
+
+### 1.10 Icons
+- One family for chrome/interface: **lucide-react** (correct per `IMAGERY.md`).
+- Marketing cards should use Lucide inside `IconWell` (muted violet well). Legacy `react-icons`
+  usage is a single file (`ThankYouSuccess.tsx`) — consolidate to Lucide.
+
+### 1.11 Images & 3D assets
+- Locked art-direction system: dark technical sculpture (graphite/smoked-glass/violet-as-light).
+  Registry: `client/src/lib/visualAssets.ts`; engage-path stills in
+  `client/public/images/visual-system/engage-paths/`. Quality bar in `design/approved/`.
+- Rules already documented in `design/IMAGERY.md` (concept-not-noun; sculptures only on
+  engage-path cards; no laptop/robot/lock stills on marketing cards).
+- **Weakness:** legacy Meshy stills and decorative graphics (`components/graphics/*`) exist
+  and must not leak onto marketing cards.
+
+### 1.12 Dark/light theme support
+- **No runtime theme toggle** (no `next-themes`). Marketing is effectively hard-dark via the
+  `de-*` chapter system; light "paper" chapters are explicit sections, not a global theme.
+- The shadcn `.dark` block is inert (never toggled). Portal uses a fixed dark navy shell with
+  `dark:` utilities that mostly don't fire — a latent inconsistency.
+
+### 1.13 Accessibility implementation
+- Present: skip link, visible `:focus-visible` rings (magenta), semantic headings in base CSS,
+  reduced-motion, high-contrast/forced-colors handling, `AccessibleAnnouncer`, `VisuallyHidden`,
+  touch-target guidance (~44px). Radix primitives bring keyboard/ARIA for menus/dialogs.
+- **Watch items:** contrast of muted-on-dark text (`white/45`), gradient-text legibility,
+  and ensuring restyled cards keep focus states and touch targets.
+
+### 1.14 Store architecture (integration-sensitive)
+- Pages: `store/{StoreLanding, ManagedStore, CoManagedStore, ProductDetail, Checkout,
+  OrderConfirmation, QuoteRequest, QuoteConfirmation}`. Components in `components/store/*`
+  (cart, product cards, toolbar, bundles, rails, compare, configure drawer, guided wizard).
+- Data: `data/storeProducts.ts` (primary catalog), `data/storeCatalog.ts` (public view),
+  `data/storeMerchandising.ts`, `data/pricing.ts` (canonical tier pricing).
+- State: `contexts/CartContext.tsx` (localStorage `digerati-store-cart`); `hooks/useStoreAuth.ts`
+  (shares `portalToken`; `canPurchase` = comanaged/admin).
+- Zoho checkout touchpoints: `POST /api/store/checkout/zoho`, quote requests, order fetch.
+
+### 1.15 Portal architecture (integration-sensitive)
+- `PortalLayout` (sidebar + top bar, fixed dark navy) wraps ~40 authenticated pages; auth
+  pages (login/signup/forgot/reset) are standalone cards. RBAC via `lib/portalRoles.ts`.
+- Client session is imperative (localStorage `portalToken`/`portalUser` + httpOnly cookie),
+  through `lib/portalApi.ts`; 401 → `redirectToPortalLogin()`.
+- Canonical login **`/portal/login`** (in-app path) and absolute `PORTAL_LOGIN`
+  (`lib/portalUrls.ts`) for cross-host links — **never `//login`**.
+
+### 1.16 API/integration-sensitive components
+- Forms (RHF+zod mostly): contact, assessment/lead, lead-quote wizard, newsletter, store
+  checkout/quote, public ticket, portal login/signup/forgot/create-ticket/order-form/surveys.
+- Widgets/flows: `TurnstileWidget` (captcha), `ZohoASAPWidget` (DE Desk chat + ticket +
+  resources; `de-open-msp-advisor` event), `ZohoBookingWidget`/`BookingModal`, MSP advisor
+  (`/api/public/advisor/chat`), analytics (`lib/analytics.ts`, consent-gated),
+  `CookieConsentBanner`, `ExitIntentPopup`, `StickyCTABar`.
+
+---
+
+## 2. What should remain (preserve — do not delete)
+
+Per `.cursorrules` §2/§16/§17 and the user's preservation rule, **keep all of the following**;
+restyle in place, never remove without DE approval:
+
+- All routes and pages (marketing, solutions, services, industries, resources, about, support,
+  legal, trust, locations, pricing tools, store, portal).
+- All homepage sections and their content/CTAs/stats (relocate, don't delete, if simplifying).
+- Store catalog, cart, checkout, quote, and order flows + their data files and Zoho touchpoints.
+- Portal auth/session, RBAC, layout nav, MFA, impersonation, contracts/signature, chat.
+- All forms and their POST payload field names; Turnstile wiring; analytics + consent gates.
+- SEO: `useSEO` calls, `JsonLd` mounts, portal `noIndex`, `index.html` static schema.
+- Canonical portal routing rules (`/portal/login`, absolute `PORTAL_LOGIN`).
+- The existing `design/` system (BRAND/DESIGN_SYSTEM/IMAGERY/UX_PRINCIPLES, approved/rejected).
+- The canonical `--de-*` token system, brand fonts, magenta/violet palette, imagery registry.
+
+---
+
+## 3. Duplicated / inconsistent UI patterns
+
+| Pattern | Duplicates found | Recommendation |
+|--------|------------------|----------------|
+| **Design tokens** | `--de-*` (canonical) vs shadcn `.dark` (inert) vs `lib/designSystem.ts` (dead, off-brand) | Make `--de-*` canonical; retire `lib/designSystem.ts`; decide portal theme strategy (see §6 doc). |
+| **Hero** | `ModernHeroSection` (live) + `DigeratiHeroSection` (orphan) + `HeroSection` (Figma) + `hero.tsx` (dead) | Keep live; quarantine/remove dead after confirming no imports. |
+| **Footer** | `DigeratiEnhancedFooterSection` (live) + `DigeratiFooterSection` + `FooterSection` + `Footer.tsx` | Standardize on the enhanced footer. |
+| **CTA surfaces** | `DigeratiCTASection`, `PremiumCTASection`, `CallToActionSection`, `LeadCaptureBand`, `StickyCTABar`, `ExitIntentPopup` | Consolidate into one `CTA` primitive + variants; keep distinct behaviors. |
+| **Service cards** | `DigeratiServicesSection`, `ServicesSection`, inline cards in `GenericServicePage` | One `ServiceCard` primitive. |
+| **Pricing** | `DigeratiPricingSection`, `PricingSection`, `PricingToolsSection`, `EcosystemProgression`, `ProActiveEcosystemPricing` | One `PricingCard` + `ComparisonTable`, all fed by `data/pricing.ts`. |
+| **Stats** | `DigeratiStatsSection` inline cards vs `StatCallout`/`StatBanner` | One `Stat` primitive; prefer a number strip over four cards. |
+| **Testimonials** | `DigeratiTestimonialsSection` (live, API-aware) vs `TestimonialsSection` (legacy) | Keep live; retire legacy. |
+| **Nav** | `MegaMenu` (live) vs `NavigationSection`/`navbar.tsx` (dead) | Keep MegaMenu. |
+| **Accordion** | shadcn `ui/accordion` vs custom motion accordion in FAQ | Standardize on shadcn accordion styled to brand. |
+| **Section shell** | Repeated `max-w-7xl mx-auto px-4` + chapter classes, no `Section`/`Container` component | Introduce `Section` + `Container` primitives. |
+| **Icons** | lucide-react (dominant) + react-icons (1 file) | Consolidate to lucide. |
+| **Section backgrounds** | `SectionPatterns` defaults use off-brand hexes (`#0a0118`, `#F7FAFC`) + glow orbs | Re-point to `--de-*`; drop decorative orbs. |
+
+Dead/legacy (no imports found): `Homepage.tsx` + the Figma section stack, `hero.tsx`,
+`navbar.tsx`, `Footer.tsx`, `lib/designSystem.ts`, `DigeratiHeroSection.tsx`,
+`DigeratiFooterSection.tsx`. `AnnouncementBanner.tsx` exists but is unwired. **Do not delete
+in the audit phase** — flag, confirm zero references, then remove in a dedicated cleanup PR.
+
+---
+
+## 4. Visual weaknesses (grounded in rendered inspection + code)
+
+1. **"Template, not composition."** Several bands are repeated card grids (4 stat cards → 6
+   tackle cards → 6 capability cards). One idea per band with varied composition is missing.
+2. **Flat type hierarchy.** Oversized H2 + oversized body means nothing reads as quiet;
+   the primary message doesn't dominate.
+3. **Decoration competing with content.** Glow orbs, radial blobs, glassmorphism, gradient-text,
+   and floating animations dilute the premium/restrained brand and add JS/paint cost.
+4. **Token drift.** Off-brand purple→blue/cyan gradients and hard-coded hexes on inner/store/
+   legal pages break cohesion with the homepage's graphite+magenta chapter system.
+5. **Inconsistent surfaces & elevation.** Cards vary in radius, border, padding, and background
+   (some `bg-white/5 backdrop-blur`, some `de-raised`), so the interface doesn't feel unified.
+6. **Mobile is often shrunk, not recomposed** for several grids and comparison tables.
+7. **CTA sprawl.** Multiple CTA components with differing treatments weaken the single
+   canonical action ("Get My Cyber Risk Assessment").
+8. **Portal theme ambiguity.** `dark:` utilities that never activate = latent visual bugs.
+
+---
+
+## 5. Components that should become shared primitives
+
+Real, repeated usage justifies these (build in Phase 3, adapt existing where possible):
+
+- `Section` (chapter/background/spacing variants over `--de-*`) and `Container` (widths).
+- `Button` — already canonical (`components/ui/button.tsx`); migrate inline gradient buttons to it.
+- `Badge`, `Card`, `FeatureCard`, `ServiceCard`, `IconWell` (exists — standardize usage).
+- `Stat` (+ number strip), `Testimonial`, `LogoCloud`/trust rail.
+- `CTA` (one component, behavior variants), `PricingCard`, `ComparisonTable`.
+- `Accordion` (brandized shadcn), `Modal` (shadcn dialog wrapper), form-control set (shadcn).
+- `Navigation`/`Footer` — already single live implementations; keep and tokenize.
+
+Avoid over-abstraction: only extract where two or more real call sites exist.
+
+---
+
+## 6. Where Relume patterns would materially improve UX
+
+Use Relume as a **structural** reference (not a paste source) for:
+
+1. **Hero** — claim + one product/system visual + one primary CTA; recomposed mobile column.
+2. **Service presentation** — differentiated bands (engage paths) instead of uniform card grids.
+3. **Feature grids** — 3-up feature blocks with real hierarchy and iconography.
+4. **Pricing & comparison** — tier cards + a scannable comparison table (mobile-friendly).
+5. **FAQ** — accordion IA and question grouping.
+6. **CTA / contact / booking** — single-action conversion bands and booking flow layout.
+7. **Resources / case studies / testimonials** — editorial list/detail patterns.
+
+See `design-references/relume/README.md` for import rules.
+
+## 7. Where GetDesign DESIGN.md principles should improve presentation
+
+(Rambox/Evervault `DESIGN.md` files are **not yet in the repo** — see `design-references/`.)
+
+- **Rambox (primary):** editorial spacing rhythm, type hierarchy over volume, surface/elevation
+  discipline, "imagery is the system," one primary action — apply to hero, services, pricing.
+- **Evervault (secondary):** calm, credible cybersecurity/trust presentation without cliché —
+  apply to trust/proof, assessment, compliance, and industry pages.
+- **Supporting (optional):** Stripe for pricing/comparison + form ergonomics; Vercel for
+  restrained dark surfaces + diagram/code presentation; HashiCorp for dense technical IA.
+
+Fold concrete principles into `docs/DIGERATI-DESIGN-SYSTEM.md` once the files are provided.
+
+---
+
+## 8. Do-not-touch / high-risk list for any visual refactor
+
+Restyle is fine **only if** DOM hooks, payloads, and flows are preserved:
+
+- Portal auth/session (`portalApi.ts`, login/MFA/Zoho SSO), `PORTAL_LOGIN`, `/portal/login`.
+- Store cart/checkout (`CartContext` localStorage schema, `ShoppingCart`, `Checkout`, Zoho URLs),
+  `useStoreAuth` role gating.
+- `TurnstileWidget` (keep `data-testid` + callbacks), all form field names/payloads.
+- `ZohoASAPWidget` (DE Desk) chat/ticket + `de-open-msp-advisor`; `ZohoBookingWidget` embed.
+- Analytics + consent (`analytics.ts`, `CookieConsentBanner`), SEO (`useSEO`, `JsonLd`, noindex).
+
+---
+
+## 9. Recommended phase sequencing (no destructive work)
+
+- **Phase 2 (next):** finalize `docs/DIGERATI-DESIGN-SYSTEM.md` tokens + component contracts;
+  codify spacing/elevation/motion tokens in `tailwind.config.ts` / CSS variables.
+- **Phase 3:** build/normalize shared primitives (`Section`, `Container`, `Card`, `ServiceCard`,
+  `Stat`, `CTA`, `PricingCard`, `ComparisonTable`) on `--de-*`; migrate call sites incrementally.
+- **Phase 4:** redesign the homepage hero + the next 2–3 sections as the proving ground.
+- **Phase 5:** visual + technical review (lint/types/tests/build + 390/768/1440 + console).
+- **Phase 6:** progressive rollout across remaining public pages; dead-code cleanup PR.

--- a/docs/DIGERATI-DESIGN-SYSTEM.md
+++ b/docs/DIGERATI-DESIGN-SYSTEM.md
@@ -1,0 +1,286 @@
+# Digerati Experts — Canonical Design System
+
+> **This is the canonical UI design specification for the project.** It supersedes
+> `client/src/lib/designSystem.ts` (legacy, off-brand, to be retired) and consolidates the
+> existing internal system in [`design/`](../design) with the audit in
+> [`docs/DESIGN-SYSTEM-AUDIT.md`](./DESIGN-SYSTEM-AUDIT.md).
+>
+> Source of truth for **tokens**: `client/src/index.css` (`--de-*`) + `tailwind.config.ts`
+> (`colors.de.*`). Do **not** invent new brand colors — reuse the tokens below.
+> Authoritative policy: root `.cursorrules`. Brand rule: `.cursor/rules/brand.mdc`.
+
+**Status:** Phase 2 specification. Token *values* below marked ✅ already exist in code;
+those marked 🆕 are proposed additions to codify in Phase 3 (no visual change until then).
+
+---
+
+## 1. Brand character
+
+Digerati Experts is a **premium, cybersecurity-first managed IT** company for Arizona SMBs
+and their executives. The design language must feel:
+
+- premium · cybersecurity-first · modern · technically sophisticated
+- trustworthy · enterprise-capable · yet approachable for SMB decision-makers
+- **distinctly different from generic MSP and generic SaaS websites**
+
+**Avoid** (per `.cursorrules`, `design/BRAND.md`, `.cursor/rules/brand.mdc`):
+generic blue cybersecurity gradients everywhere · glowing shields · random laptops · robot
+imagery · visual clutter · dashboard styling on marketing pages · excessive glassmorphism ·
+huge empty hero sections · generic AI-generated SaaS appearance · rainbow gradients · neon glow.
+
+**Design principles (ranked):** restraint over decoration · hierarchy over density ·
+consistency over novelty · purpose over ornament · real composition over generic AI imagery.
+
+---
+
+## 2. Reference hierarchy (when references disagree)
+
+1. Existing Digerati **business requirements & functionality**
+2. Existing Digerati **brand identity** (`design/BRAND.md`)
+3. **Rambox** `DESIGN.md` — overall visual sophistication & presentation
+4. **Evervault** `DESIGN.md` — cybersecurity & trust patterns
+5. **Relume** — UX architecture & section/component structure
+6. **Supporting** (Vercel / HashiCorp / Stripe) — targeted patterns only
+
+Intake location for external references: [`design-references/`](../design-references). The
+Rambox/Evervault `DESIGN.md` files are **not yet provided**; do not invent their contents.
+Produce **one** coherent Digerati system — never a blend of five visual languages.
+
+---
+
+## 3. Design tokens
+
+CSS-variable-first. Prefer tokens over one-off values. All ✅ values are the live `--de-*`
+definitions in `client/src/index.css`; 🆕 values are proposed for Phase 3.
+
+### 3.1 Color — surfaces (dark ladder + paper)
+| Token | Value | Use |
+|-------|-------|-----|
+| `--de-bg` ✅ | `#050312` | Deepest well: hero, credibility, proof-after-magenta, founder, closing CTA/contact/footer |
+| `--de-surface` ✅ | `#0a0a0a` | Marketing field for a dark chapter |
+| `--de-raised` ✅ | `#151217` | Cards / lifted panels within a dark chapter |
+| `--de-hairline` ✅ | `rgba(255,255,255,0.10)` | 1px borders, same-chapter seams |
+| `--de-paper` ✅ | `#f7f5f2` | The one light-chapter recipe (protect, trust, FAQ/newsletter) |
+| `--de-paper-raised` ✅ | `#ffffff` | Cards on paper |
+| `--de-paper-hairline` ✅ | `rgba(26,18,16,0.10)` | Borders on paper |
+
+Chapters must **juxtapose** well ↔ surface ↔ paper ↔ magenta. Never flatten the page to one
+`#0a0a0a` slab. Do not introduce competing grays (`#0f0f0f`, `#0f0f1a`, `#141418`, cool `#F7FAFC`).
+
+### 3.2 Color — text
+| Token | Value | Use |
+|-------|-------|-----|
+| `--de-fg` ✅ | `#ffffff` | Primary text on dark |
+| `--de-muted` ✅ | `rgba(255,255,255,0.85)` | Secondary text on dark |
+| `--de-muted-soft` ✅ | `rgba(255,255,255,0.72)` | Tertiary/supporting text on dark |
+| (paper) 🆕 `--de-ink` | `#111827` | Primary text on paper |
+| (paper) 🆕 `--de-ink-muted` | `#374151` | Secondary text on paper |
+
+Use `white/65` / `white/45` sparingly for the quietest tier only; verify contrast (WCAG 2.2 AA).
+
+### 3.3 Color — accent / brand
+| Token | Value | Use |
+|-------|-------|-----|
+| `--de-magenta` ✅ | `#D3126A` | **Primary brand & CTA**; brand mark, active underline, user bubbles |
+| `--de-violet` ✅ | `#5B45E0` | Accent & illumination (violet as **light, not paint**) |
+| (accent) ✅ | `#7c3aed` / `#8B5CF6` / `#A78BFA` | Deep→lavender violet for gradients/glow frames |
+| `--de-brand-energy` ✅ | violet→magenta→coral gradient | The single loud statement band only |
+
+Purple is illumination/accent, not large fills. Exactly one loud band per page (the magenta
+how-it-works/statement band). No rainbow gradients.
+
+### 3.4 Color — semantic states 🆕 (proposed; restrained, AA-checked)
+State colors are intentionally quiet and only appear on functional UI (forms, portal, alerts),
+never as marketing decoration. Reuse the existing shadcn `--destructive` where a mapping exists.
+| Token | Value (proposed) | Use |
+|-------|------------------|-----|
+| `--de-success` | `#10b981` | Success/validation confirms |
+| `--de-warning` | `#f59e0b` | Non-blocking warnings |
+| `--de-danger` | `#ef4444` | Errors / destructive (align with shadcn `--destructive`) |
+| `--de-info` | `#5B45E0` | Informational (reuse brand violet) |
+
+### 3.5 Color — focus
+| Token | Value | Use |
+|-------|-------|-----|
+| focus ring ✅ | `2px solid #ec4899`, offset `2px` | All `:focus-visible` (already global in `index.css`) |
+
+### 3.6 Spacing scale 🆕 (codify existing rhythm as tokens)
+Base unit 4px. Codify the ad-hoc utility strings into a scale:
+`0, 1(4), 2(8), 3(12), 4(16), 6(24), 8(32), 10(40), 12(48), 16(64), 20(80), 24(96)`.
+Tailwind's default scale already matches; standardize component usage rather than inventing new steps.
+
+### 3.7 Section spacing 🆕
+| Token | Value | Use |
+|-------|-------|-----|
+| `--de-section-y` | `clamp(2.5rem, 4vw, 4rem)` | Standard marketing section vertical padding |
+| `--de-section-y-lg` | `clamp(4rem, 6vw, 6rem)` | Hero / major chapter breaks |
+Current live pattern `py-10 md:py-14 lg:py-16` maps to `--de-section-y`; keep consistent.
+
+### 3.8 Radius scale
+| Token | Value | Use |
+|-------|-------|-----|
+| `--radius` ✅ | `0.5rem` | shadcn base (`rounded-lg`/`md`/`sm` derive from it) |
+| card 🆕 `--de-radius-card` | `1rem` (`rounded-2xl`) | Marketing cards |
+| panel 🆕 `--de-radius-panel` | `1.5rem` (`rounded-3xl`) | Large panels |
+Do **not** invent one-off radii (13px/17px/etc.).
+
+### 3.9 Container widths
+| Token | Value | Use |
+|-------|-------|-----|
+| container ✅ | centered, padding `1rem`, `2xl` max `1680px` | Global (Tailwind container) |
+| content 🆕 `--de-content-max` | `1280px` | Standard marketing content width |
+| prose 🆕 `--de-prose-max` | `72ch` | Long-form reading measure |
+
+### 3.10 Typography scale
+- **Families ✅:** headings `Space Grotesk`; body `Inter`; stats/numbers `Oxanium`/`JetBrains Mono`.
+- **Root ✅:** `14px` (→ `15px` ≥1920px, `16px` ≥2560px).
+- **Headings ✅:** weight 600–700, tracking `-0.015em`…`-0.03em`, line-height `1.15–1.25`.
+- **Body ✅:** weight 400, line-height `1.6` (prose `1.75`).
+- **Scale 🆕 (fluid, one dominant heading per section):**
+  | Role | Size |
+  |------|------|
+  | Display (hero H1) | `clamp(2.25rem, 4.5vw, 3.75rem)` |
+  | H2 (section) | `clamp(1.75rem, 3vw, 2.5rem)` |
+  | H3 | `clamp(1.25rem, 2vw, 1.75rem)` |
+  | Body-lg | `1.125rem` |
+  | Body | `1rem` |
+  | Small/caption | `0.875rem` / `0.75rem` (uppercase tracking for eyebrows) |
+  Fix the current flat-hierarchy weakness: do not push section H2 to `text-5xl/6xl` with `text-2xl` body.
+
+### 3.11 Line heights
+Headings `1.15–1.25` · body `1.6` · prose `1.75` · UI/controls `1.35` (nav labels already `1.35`).
+
+### 3.12 Elevation / shadows 🆕
+Replace scattered glow shadows with a restrained, brand-consistent set:
+| Token | Value | Use |
+|-------|-------|-----|
+| `--de-shadow-sm` | `0 1px 2px rgba(0,0,0,.4)` | Subtle lift on dark |
+| `--de-shadow-md` | `0 8px 24px rgba(0,0,0,.35)` | Cards on dark |
+| `--de-shadow-paper` | `0 10px 28px rgba(26,18,16,.07)` | Cards on paper (matches `.de-paper-lift`) |
+| `--de-shadow-cta` | magenta-tinted, low-spread | Primary CTA only |
+Avoid neon glow shadows (`0 0 40px violet`) as ambient decoration.
+
+### 3.13 Transitions & motion
+- **Durations 🆕:** `--de-dur-fast 150ms`, `--de-dur 200ms`, `--de-dur-slow 300ms`.
+- **Easing:** `ease-out` for enter, `cubic-bezier(0.22,1,0.36,1)` for lifts (already used).
+- **Buttons ✅:** `transition-all 200ms ease-out`, `active:scale-[0.98]`, hover `-translate-y-0.5`.
+- **Rules:** motion communicates state/hierarchy/continuity/feedback — never decoration.
+  Respect `prefers-reduced-motion` (already global). Remove ambient floating/glow/gradient-text
+  animations from marketing per brand rules.
+
+---
+
+## 4. Component architecture
+
+Establish shared primitives **only where reuse is real** (≥2 call sites). Adapt existing
+components before creating new ones. Never create `Button2`/`CardV2`/`ImprovedHero`.
+
+| Primitive | Status / source | Action |
+|-----------|-----------------|--------|
+| `Button` | ✅ `components/ui/button.tsx` (has `brand` variant) | Canonical; migrate inline gradient buttons to it |
+| `Badge` | ✅ `components/ui/badge.tsx` | Brandize; reuse |
+| `Card` | ✅ `components/ui/card.tsx` | Add tokenized dark/paper variants; replace glass cards |
+| `Section` | 🆕 | New: chapter (well/surface/paper/magenta) + spacing variants over `--de-*` |
+| `Container` | 🆕 | New: content/prose width wrapper |
+| `FeatureCard` / `ServiceCard` | partial (`DigeratiServicesSection`, inline) | Extract one primitive |
+| `IconWell` | ✅ `components/visual/IconWell.tsx` | Standardize as the marketing icon container |
+| `Stat` | partial (`StatCallout`/inline) | One primitive; prefer number strip |
+| `Testimonial` | section-only | Extract card; keep API-aware section |
+| `LogoCloud` / trust rail | inline | Extract |
+| `CTA` | many (`DigeratiCTASection`,`PremiumCTASection`,…) | One primitive + behavior variants |
+| `PricingCard` | inline (data in `data/pricing.ts`) | Extract; single source of pricing |
+| `ComparisonTable` | `ServiceMatrix`/`ServiceCapabilityMatrix` | Generalize; mobile-friendly |
+| `Accordion` | ✅ shadcn + custom FAQ | Standardize on shadcn, brandized |
+| `Modal` | ✅ shadcn dialog | Wrap; reuse |
+| `Navigation` / `Footer` | ✅ `MegaMenu` / `DigeratiEnhancedFooterSection` | Keep single live impls; tokenize |
+| Form controls | ✅ shadcn `form/input/...` | Reuse; keep RHF+zod pattern |
+
+Retire (after confirming zero imports, in a dedicated cleanup PR — **not** during audit):
+`lib/designSystem.ts`, dead `Homepage.tsx` + Figma sections, `hero.tsx`, `navbar.tsx`,
+`Footer.tsx`, orphan hero/footer variants.
+
+---
+
+## 5. Marketing site vs application UI
+
+Maintain a deliberate distinction — do **not** turn the public website into a SaaS dashboard.
+
+| | Public marketing site | Portal / application UI |
+|--|-----------------------|--------------------------|
+| Feel | editorial, polished, spacious, trustworthy, conversion-focused | denser, application-oriented, efficient |
+| References | Rambox / Evervault principles | product-app conventions; shadcn density |
+| Surfaces | `--de-*` chapter ladder (well/surface/paper/magenta) | fixed dark app shell (`PortalLayout`) |
+| Motion | restrained, purposeful | minimal, functional |
+| Density | generous whitespace, one idea per band | tables, forms, multi-step flows OK |
+
+Portal theme note: resolve the inert shadcn `.dark` ambiguity in Phase 3 (either apply `.dark`
+to the portal shell or replace non-firing `dark:` utilities with explicit tokens) — behavior-safe.
+
+---
+
+## 6. Imagery & visual assets
+
+Follow `design/IMAGERY.md` (canonical). Summary:
+
+- **Locked system:** dark technical sculpture — graphite / gunmetal / smoked glass / violet-as-light,
+  controlled studio lighting, generous negative space. Registry: `client/src/lib/visualAssets.ts`.
+- **Concept, not noun:** represent the idea (central core + nodes; interlocking systems; scanned
+  lattice) — never shields, padlocks, laptops, robots, hoodies, server racks, binary, cyberpunk.
+- **Placement:** sculptures on engage-path cards (and at most one editorial stage per section);
+  small marketing cards use **Lucide in `IconWell`**; portal/mega-menu chrome stays Lucide.
+- **Icons:** one family for marketing (Lucide via `IconWell`) + chrome (Lucide). Consolidate the
+  single `react-icons` usage to Lucide.
+- **Consistency:** keep camera, lighting, materials, palette, density, scale constant across images.
+
+---
+
+## 7. Homepage objective
+
+The homepage must communicate, with **each section having a defined conversion/communication
+purpose** (no sections added merely to lengthen the page):
+
+1. Who Digerati serves 2. What Digerati does 3. Why Digerati is different 4. Cybersecurity
+credibility 5. Business outcomes 6. Proof/trust 7. Core service paths 8. Assessment/advisory
+capability 9. Pricing/buying-path clarity 10. Strong next action.
+
+The current live composition (`pages/DigeratiHomepage.tsx`) already covers these; Phase 4 will
+**recompose** the hero + following sections (one idea per band, stronger hierarchy, restrained
+decoration) — relocating rather than deleting any content per the preservation rule.
+
+**Canonical CTAs:** Primary "Get My Cyber Risk Assessment" · Secondary "See Plans & Pricing" ·
+Utility "Client Support". Avoid vague "Learn More"/"Get Started".
+
+---
+
+## 8. Relume usage (structure, not paste)
+
+Use Relume to identify better structures for hero, service presentation, feature grids,
+industry pages, trust sections, testimonials, case studies, pricing, comparison, FAQ, CTA,
+contact/booking, and resources. When recreating a Relume component: adapt to this stack, reuse
+primitives, strip extra deps, swap in Digerati copy/imagery/tokens, preserve SEO + a11y +
+responsive behavior. Never paste verbatim. Rules: `design-references/relume/README.md`.
+
+---
+
+## 9. Responsiveness & accessibility (non-negotiable)
+
+- Verify every redesigned component at **390 / 768 / 1440** minimum (plus large desktop).
+  Recompose for mobile (stack/reorder/simplify) — never merely shrink desktop grids.
+- Maintain/improve: semantic HTML, heading hierarchy, keyboard nav, visible focus (magenta
+  ring), contrast (WCAG 2.2 AA), form labels, ARIA where appropriate, reduced-motion, ~44px
+  touch targets. Never sacrifice accessibility for polish.
+
+## 10. Performance
+
+Prefer CSS + existing utilities + optimized SVG + WebP/AVIF + lazy loading + responsive images.
+Do not add dependencies for visual effects. Avoid unnecessary client-side JS and ambient
+animation. Protect Core Web Vitals (LCP < 2.5s, CLS < 0.1, INP < 200ms where achievable).
+
+---
+
+## 11. Definition of done (per section)
+
+A section is done only when: implementation works · build/types/tests pass · console clean ·
+390/768/1440 verified · a11y preserved · no existing content/functionality lost · no fabricated
+facts · brand tokens used (no off-brand hexes) · it reads as a composition, not a template ·
+it would pass an experienced UI/UX designer's review.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the professional UI/UX design workflow **non-destructively**. This is the Phase 1
(audit) + Phase 2 (canonical system spec) + reference-intake scaffold. **No application code
or visual changes** — documentation and folder scaffolding only. Nothing was deleted.

## What's included

- **`docs/DESIGN-SYSTEM-AUDIT.md`** — full read-only audit: framework/architecture, routing,
  styling system, the **three coexisting token layers** (`--de-*` canonical vs inert shadcn
  `.dark` vs dead off-brand `lib/designSystem.ts`), typography, global CSS bloat/dupes,
  Tailwind config gaps, primitives inventory, portal + store + integration-sensitive UI,
  duplicated/inconsistent patterns, visual weaknesses (grounded in rendered inspection),
  primitives to extract, where Relume/GetDesign principles apply, and a **high-risk
  do-not-touch list** (auth, cart/checkout, Zoho widgets, Turnstile, analytics/consent, SEO).
- **`docs/DIGERATI-DESIGN-SYSTEM.md`** — canonical spec grounded in the live `--de-*` tokens
  (does not invent brand colors); codifies the missing spacing / section-spacing / elevation /
  motion-duration / semantic-state scales as clearly-marked proposals; component architecture,
  marketing-vs-application distinction, imagery rules, homepage objective, reference hierarchy.
- **`design-references/`** — intake scaffold: `getdesign/{rambox,evervault,supporting}` +
  `relume/` + README. The Rambox/Evervault `DESIGN.md` files are **not yet provided**, so their
  contents were **not invented**; each folder documents exactly where DE should drop the files
  and how they map into the reference priority. Cross-links (not duplicates) the existing
  internal `design/` system.

## Deliberately preserved

All routes, pages, homepage sections, store/cart/checkout + Zoho flows, portal auth/RBAC/MFA,
forms + payloads, Turnstile, analytics + consent, SEO (`useSEO`/`JsonLd`/noindex), canonical
`/portal/login` routing, the existing `design/` system, and the `--de-*` token system.

## Verification

- Production build passes (`npm run build`, exit 0) — docs-only change, no regression.
- Rendered inspection of `/`, `/proactive-ecosystem-pricing`, `/portal/login` (desktop + mobile);
  no console errors. Evidence confirms the audit's "repeated card-grid bands" weakness.

## Not in this PR (by design — awaiting review before visual changes)

Phase 3 (build/normalize shared primitives on `--de-*`), Phase 4 (recompose homepage hero +
following sections), Phase 5–6 (review + progressive rollout), and dead-code cleanup. Per the
task's instruction to audit before changing anything.

## Next 5 highest-impact UI/UX improvements

1. Retire `lib/designSystem.ts` and migrate off-brand purple→blue/cyan/glass usages to `--de-*`.
2. Add `Section` + `Container` primitives and a tokenized `Card` (dark/paper) to kill surface drift.
3. Fix type hierarchy (one dominant heading/section) and replace 4-stat-card band with a number strip.
4. Consolidate CTA components into one `CTA` primitive around the canonical assessment action.
5. Recompose the homepage hero + next 2–3 bands ("one idea per band") as the Phase 4 proving ground.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e89b7a80-aa85-4287-a8df-353a5769a75a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e89b7a80-aa85-4287-a8df-353a5769a75a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

