### PR TITLE
Turn CI green again and stop dropping the advisor test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,5 +42,10 @@ jobs:
       - name: Unit tests
         run: npm test
 
+      # msp-advisor uses the node:test runner, so it is excluded from Vitest
+      # collection and needs its own step to stay covered.
+      - name: MSP advisor tests
+        run: npm run test:advisor
+
       - name: Production build
         run: npm run build

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:watch": "vitest",
     "smoke:public": "node scripts/public-route-smoke.mjs",
     "db:push": "drizzle-kit push",
-    "test:advisor": "tsx --test server/services/msp-advisor/**/*.test.ts",
+    "test:advisor": "tsx --test server/services/msp-advisor/*.test.ts",
     "eval:advisor": "tsx server/services/msp-advisor/eval/score.ts"
   },
   "dependencies": {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,10 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["client/src/**/*.test.ts", "server/**/*.test.ts", "shared/**/*.test.ts", "scripts/**/*.test.ts"],
+    // msp-advisor is written against the node:test runner and is executed by
+    // `npm run test:advisor`. Collecting it here makes Vitest fail the suite
+    // with "No test suite found".
+    exclude: ["**/node_modules/**", "**/dist/**", "server/services/msp-advisor/**"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

`main` CI has failed on every push since **Aug 11**. The cause is a single collection error:

```
FAIL  server/services/msp-advisor/msp-advisor.test.ts
Error: No test suite found in file .../msp-advisor.test.ts
```

`server/services/msp-advisor/msp-advisor.test.ts` is written against the **`node:test`** runner, but Vitest's `include` glob `server/**/*.test.ts` collects it anyway, so `npm test` exits 1 with 53 tests passing and one suite failing to collect.

Because `npm test` is a hard gate, the **Production build step has not executed in CI since Aug 11** — roughly 50 commits of homepage work merged without the build gate ever running. (The build does pass; this is a gate-coverage gap, not a broken build.)

## What changed

- `vitest.config.ts` — add an `exclude` for `server/services/msp-advisor/**` (plus the standard `node_modules` / `dist` entries that adding `exclude` otherwise overrides).
- `.github/workflows/ci.yml` — add an **MSP advisor tests** step running `npm run test:advisor` (`tsx --test`).
- `package.json` — change that script's glob from `msp-advisor/**/*.test.ts` to `msp-advisor/*.test.ts`.

The second bullet matters: excluding the directory alone would silently drop 33 passing tests. This keeps them covered under the runner they were written for.

The third bullet was caught by CI on this very PR. No POSIX shell expands `**`, so the literal pattern reaches the runner — Node 22 globs it itself (which is why it passed locally) but CI pins **Node 20**, which does not, and the new step died with `Could not find '.../**/*.test.ts'`. A single-star glob is resolved by the shell in both environments.

## Validation

CI on this branch: **pass**.

| Gate | Before | After |
|---|---|---|
| `npm test` (Vitest) | 13 passed / **1 failed to collect** | **13 files, 53 tests passed** |
| `npm run test:advisor` (node:test) | not run in CI | **33 tests passed**, now a CI step |
| `npm run build` | never reached in CI | PASS |
| `npm run check` | 78 errors (17 client) | unchanged — pre-existing, `continue-on-error`, tracked by #12 |

No application or UI code is touched.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55eac13a-e87f-4a00-9c34-f63bb77c3080&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

