### PR TITLE
Finish the accent-pop sweep across public pages, and bring text to WCAG AA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,5 +42,10 @@ jobs:
       - name: Unit tests
         run: npm test
 
+      # msp-advisor uses the node:test runner, so it is excluded from Vitest
+      # collection and needs its own step to stay covered.
+      - name: MSP advisor tests
+        run: npm run test:advisor
+
       - name: Production build
         run: npm run build

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -870,11 +870,30 @@ function SpaPageViews() {
   return null;
 }
 
+/*
+ * Page families keep one hue of their own. It only ever colours topical
+ * signals — eyebrows, glyphs, chips, inline links — while the field, type,
+ * spacing and primary CTA stay identical sitewide. Anything unlisted inherits
+ * the brand magenta default.
+ */
+const ACCENT_BY_PREFIX: ReadonlyArray<readonly [string, string]> = [
+  ["/store", "electric"],
+  ["/support", "cyan"],
+  ["/resources", "amber"],
+  ["/case-studies", "amber"],
+];
+
+function accentFor(location: string): string | undefined {
+  const match = ACCENT_BY_PREFIX.find(([prefix]) => location.startsWith(prefix));
+  return match?.[1];
+}
+
 function AppContent() {
   useGlobalShortcuts();
   const [location] = useLocation();
   const isPortal = location.startsWith("/portal");
   const isHome = location === "/";
+  const accent = isPortal ? undefined : accentFor(location);
 
   useEffect(() => {
     document.documentElement.classList.toggle("de-marketing-canvas", !isPortal);
@@ -888,7 +907,11 @@ function AppContent() {
       </a>
       <ScrollProgress />
       <SpaPageViews />
-      <div id="main-content" className={isPortal ? undefined : "de-site-canvas"}>
+      <div
+        id="main-content"
+        data-accent={accent}
+        className={isPortal ? undefined : "de-site-canvas"}
+      >
         <Router />
       </div>
       <MarketingChrome />

--- a/client/src/components/BlogAudioPlayer.tsx
+++ b/client/src/components/BlogAudioPlayer.tsx
@@ -391,7 +391,7 @@ export function BlogAudioPlayer({
       className="flex items-center gap-3 rounded-full border border-white/10 bg-white/[0.03] px-4 py-2 backdrop-blur-sm"
       data-testid="blog-audio-player"
     >
-      <Volume2 className="h-4 w-4 text-violet-300" />
+      <Volume2 className="h-4 w-4 text-de-accent-ink" />
       <span
         className="text-xs text-white/60 hidden sm:inline"
         title={
@@ -405,7 +405,7 @@ export function BlogAudioPlayer({
 
       <Button
         size="sm"
-        className="h-7 w-7 rounded-full bg-violet-600 hover:bg-violet-500 p-0 disabled:opacity-50"
+        className="h-7 w-7 rounded-full bg-de-accent hover:bg-de-accent p-0 disabled:opacity-50"
         onClick={togglePlay}
         disabled={loading}
         data-testid="button-audio-play"
@@ -434,11 +434,11 @@ export function BlogAudioPlayer({
       <div className="hidden sm:flex items-center gap-1.5">
         <div className="h-1 w-20 rounded-full bg-white/10 overflow-hidden">
           <div
-            className="h-full bg-violet-400 rounded-full transition-all duration-300"
+            className="h-full bg-de-accent rounded-full transition-all duration-300"
             style={{ width: `${progress}%` }}
           />
         </div>
-        <span className="text-[10px] text-white/40 tabular-nums w-8 text-right">
+        <span className="text-[10px] text-white/55 tabular-nums w-8 text-right">
           {progress}%
         </span>
       </div>

--- a/client/src/components/EcosystemProgression.tsx
+++ b/client/src/components/EcosystemProgression.tsx
@@ -36,7 +36,7 @@ export function EcosystemProgression({ compact = false, detailed = false }: Ecos
           : "rounded-2xl border border-[var(--de-hairline)] bg-[var(--de-surface)] p-6 md:p-8 lg:p-10"
       }
     >
-      <p className="text-base font-semibold uppercase tracking-[0.2em] text-[#D3126A]">
+      <p className="text-base font-semibold uppercase tracking-[0.2em] text-de-magenta-ink">
         ProActive Ecosystem
       </p>
       <h2 className="mt-2 font-heading text-2xl font-semibold tracking-[-0.03em] text-white md:text-3xl lg:text-4xl">
@@ -79,7 +79,7 @@ export function EcosystemProgression({ compact = false, detailed = false }: Ecos
               </ul>
             )}
             <Link href={tier.learnMoreUrl}>
-              <span className="mt-5 inline-flex min-h-11 items-center gap-1 text-base font-semibold text-[#D3126A] transition-colors hover:text-[#f0187a] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A]/70 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--de-bg)]">
+              <span className="mt-5 inline-flex min-h-11 items-center gap-1 text-base font-semibold text-de-magenta-ink transition-colors hover:text-[#f0187a] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A]/70 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--de-bg)]">
                 {tier.label}
                 <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
               </span>

--- a/client/src/components/ErrorBoundary.tsx
+++ b/client/src/components/ErrorBoundary.tsx
@@ -74,7 +74,7 @@ export class ErrorBoundary extends Component<Props, State> {
               </Button>
               <Button
                 onClick={this.handleGoHome}
-                className="gap-2 bg-violet-600 hover:bg-violet-500"
+                className="gap-2 bg-de-accent hover:bg-de-accent"
                 data-testid="button-error-home"
               >
                 <Home className="w-4 h-4" aria-hidden="true" />

--- a/client/src/components/FormSuccess.tsx
+++ b/client/src/components/FormSuccess.tsx
@@ -91,8 +91,8 @@ export function FormSubmitting({ message = "Submitting..." }: { message?: string
       aria-busy="true"
     >
       <div className="relative mb-4">
-        <div className="w-12 h-12 rounded-full border-2 border-violet-500/30 border-t-violet-500 animate-spin" />
-        <div className="absolute inset-0 w-12 h-12 rounded-full bg-violet-500/20 blur-xl animate-pulse" />
+        <div className="w-12 h-12 rounded-full border-2 border-de-hairline border-t-de-accent animate-spin" />
+        <div className="absolute inset-0 w-12 h-12 rounded-full bg-de-raised blur-xl animate-pulse" />
       </div>
       <p className="text-white/60 text-base animate-pulse">{message}</p>
       <span className="sr-only">Form is being submitted, please wait</span>

--- a/client/src/components/HomepageOnPageNav.tsx
+++ b/client/src/components/HomepageOnPageNav.tsx
@@ -83,7 +83,7 @@ export function HomepageOnPageNav() {
                     event.preventDefault();
                     goTo(index);
                   }}
-                  className={`relative inline-flex min-h-9 w-full items-center justify-center px-1 py-1.5 text-[10px] font-semibold tracking-wide whitespace-nowrap transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-violet-400 focus-visible:ring-inset sm:px-2 sm:text-[11px] lg:min-h-8 lg:w-auto lg:px-3.5 lg:text-[13px] ${
+                  className={`relative inline-flex min-h-9 w-full items-center justify-center px-1 py-1.5 text-[10px] font-semibold tracking-wide whitespace-nowrap transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-de-accent focus-visible:ring-inset sm:px-2 sm:text-[11px] lg:min-h-8 lg:w-auto lg:px-3.5 lg:text-[13px] ${
                     isActive
                       ? "text-white"
                       : "text-white/55 hover:text-white/90"

--- a/client/src/components/HomepageSectionNav.tsx
+++ b/client/src/components/HomepageSectionNav.tsx
@@ -103,7 +103,7 @@ export function HomepageOnPageNav() {
                     event.preventDefault();
                     scrollToSection?.(index);
                   }}
-                  className={`relative inline-flex min-h-9 items-center justify-center px-2.5 py-1.5 text-base font-semibold tracking-wide whitespace-nowrap transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-violet-400 focus-visible:ring-inset sm:px-3 md:px-1.5 lg:min-h-9 lg:w-auto lg:px-2 ${
+                  className={`relative inline-flex min-h-9 items-center justify-center px-2.5 py-1.5 text-base font-semibold tracking-wide whitespace-nowrap transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-de-accent focus-visible:ring-inset sm:px-3 md:px-1.5 lg:min-h-9 lg:w-auto lg:px-2 ${
                     isActive ? "text-white" : "text-white/55 hover:text-white/90"
                   }`}
                   aria-current={isActive ? "true" : undefined}

--- a/client/src/components/LoadingSkeleton.tsx
+++ b/client/src/components/LoadingSkeleton.tsx
@@ -70,8 +70,8 @@ export function PageLoadingSkeleton() {
       aria-label="Loading page"
     >
       <div className="relative">
-        <div className="w-12 h-12 rounded-full border-2 border-violet-500/30 border-t-violet-500 animate-spin" />
-        <div className="absolute inset-0 w-12 h-12 rounded-full bg-violet-500/20 blur-xl animate-pulse" />
+        <div className="w-12 h-12 rounded-full border-2 border-de-hairline border-t-de-accent animate-spin" />
+        <div className="absolute inset-0 w-12 h-12 rounded-full bg-de-raised blur-xl animate-pulse" />
       </div>
       <p className="mt-4 text-white/50 text-base animate-pulse">Loading...</p>
       <span className="sr-only">Page is loading, please wait</span>

--- a/client/src/components/MegaMenu.tsx
+++ b/client/src/components/MegaMenu.tsx
@@ -81,10 +81,10 @@ const CircuitLines = ({ id }: { id: string }) => (
 
 const DiagonalLinesBadge = ({ children, variant }: { children: React.ReactNode; variant: 'popular' | 'bestValue' | 'compliance' }) => {
   const baseClasses = variant === 'popular' 
-    ? 'bg-violet-500/20 text-violet-300 border border-violet-500/30'
+    ? 'bg-de-raised text-de-accent-ink border border-de-hairline'
     : variant === 'bestValue'
     ? 'bg-emerald-500/20 text-emerald-300 border border-emerald-500/30'
-    : 'bg-purple-500/20 text-purple-300 border border-purple-500/30';
+    : 'bg-de-raised text-de-accent-ink border border-de-hairline';
     
   return (
     <span className={`relative text-[10px] px-1.5 py-0.5 rounded font-medium overflow-hidden ${baseClasses}`}>
@@ -676,7 +676,7 @@ export function MegaMenu() {
             {/* Logo */}
             <a
               href="/"
-              className="flex items-center flex-shrink-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-violet-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black rounded"
+              className="flex items-center flex-shrink-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-de-accent focus-visible:ring-offset-2 focus-visible:ring-offset-black rounded"
               aria-label="Digerati Experts home"
             >
               <img 
@@ -702,20 +702,20 @@ export function MegaMenu() {
                   {item.isSimple ? (
                     <a
                       href={item.href}
-                      className="group relative inline-flex items-center px-3 xl:px-4 py-2 text-lg xl:text-xl leading-normal text-white/85 hover:text-white font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-violet-400 focus:ring-offset-2 focus:ring-offset-black rounded whitespace-nowrap overflow-visible"
+                      className="group relative inline-flex items-center px-3 xl:px-4 py-2 text-lg xl:text-xl leading-normal text-white/85 hover:text-white font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-de-accent focus:ring-offset-2 focus:ring-offset-black rounded whitespace-nowrap overflow-visible"
                       data-testid={`nav-${item.name.toLowerCase()}`}
                       onClick={handleLinkClick}
                       aria-label={`Go to ${item.name}`}
                     >
                       {item.name}
-                      <span className="absolute bottom-1 left-1/2 -translate-x-1/2 w-0 h-0.5 bg-violet-400 group-hover:w-full transition-all duration-300" />
+                      <span className="absolute bottom-1 left-1/2 -translate-x-1/2 w-0 h-0.5 bg-de-accent group-hover:w-full transition-all duration-300" />
                     </a>
                   ) : (
                     <button
                       ref={(el) => {
                         if (el) navButtonsRef.current.set(item.name, el);
                       }}
-                      className={`group relative inline-flex items-center px-3 xl:px-4 py-2 text-lg xl:text-xl leading-normal text-white/85 hover:text-white font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-violet-400 focus:ring-offset-2 focus:ring-offset-black rounded whitespace-nowrap overflow-visible ${
+                      className={`group relative inline-flex items-center px-3 xl:px-4 py-2 text-lg xl:text-xl leading-normal text-white/85 hover:text-white font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-de-accent focus:ring-offset-2 focus:ring-offset-black rounded whitespace-nowrap overflow-visible ${
                         activeMenu === item.name ? 'text-white' : ''
                       }`}
                       data-testid={`nav-${item.name.toLowerCase()}`}
@@ -732,7 +732,7 @@ export function MegaMenu() {
                         }`} 
                         aria-hidden="true"
                       />
-                      <span className={`absolute bottom-1 left-1/2 -translate-x-1/2 h-0.5 bg-violet-400 transition-all duration-300 ${
+                      <span className={`absolute bottom-1 left-1/2 -translate-x-1/2 h-0.5 bg-de-accent transition-all duration-300 ${
                         activeMenu === item.name ? 'w-full' : 'w-0 group-hover:w-full'
                       }`} />
                     </button>
@@ -808,7 +808,7 @@ export function MegaMenu() {
                               <div className="mb-4">
                                 <h3 
                                   className={`font-bold text-xs uppercase tracking-[0.18em] flex items-center gap-2 ${
-                                    section.featured ? 'text-violet-400' : 'text-gray-400'
+                                    section.featured ? 'text-de-accent-ink' : 'text-gray-400'
                                   }`}
                                   id={`menu-section-${section.title.replace(/\s+/g, '-')}`}
                                 >
@@ -816,7 +816,7 @@ export function MegaMenu() {
                                 </h3>
                                 <div className={`h-px mt-2 ${
                                   section.featured 
-                                    ? 'bg-violet-500/30' 
+                                    ? 'bg-de-raised' 
                                     : 'bg-white/5'
                                 }`} />
                               </div>
@@ -843,9 +843,9 @@ export function MegaMenu() {
                                       <Tooltip.Trigger asChild>
                                         <a
                                           href={subItem.url || '#'}
-                                          className={`group/item flex items-start gap-3.5 px-3 py-3 rounded-xl transition-all duration-200 focus:outline-none focus:ring-1 focus:ring-violet-500/50 border ${
+                                          className={`group/item flex items-start gap-3.5 px-3 py-3 rounded-xl transition-all duration-200 focus:outline-none focus:ring-1 focus:ring-de-accent border ${
                                             isHovered 
-                                              ? 'bg-violet-600/10 border-violet-500/20' 
+                                              ? 'bg-de-raised border-de-hairline' 
                                               : 'border-transparent hover:bg-white/[0.03]'
                                           }`}
                                           onClick={handleLinkClick}
@@ -854,7 +854,7 @@ export function MegaMenu() {
                                         >
                                           {subItem.icon && (
                                             <span className={`mt-0.5 transition-colors flex-shrink-0 ${
-                                              isHovered ? 'text-violet-400' : 'text-violet-400/60 group-hover/item:text-violet-400'
+                                              isHovered ? 'text-de-accent-ink' : 'text-de-accent-ink/60 group-hover/item:text-de-accent-ink'
                                             }`} aria-hidden="true">
                                               <div className="scale-100">{subItem.icon}</div>
                                             </span>
@@ -877,7 +877,7 @@ export function MegaMenu() {
                                               )}
                                             </div>
                                             {subItem.description && (
-                                              <p className="text-[13px] text-gray-500 group-hover/item:text-gray-400 mt-1 transition-colors leading-snug line-clamp-2">
+                                              <p className="text-[13px] text-white/70 group-hover/item:text-gray-400 mt-1 transition-colors leading-snug line-clamp-2">
                                                 {subItem.description}
                                               </p>
                                             )}
@@ -906,7 +906,7 @@ export function MegaMenu() {
                               {section.viewAllUrl && (
                                 <a
                                   href={section.viewAllUrl}
-                                  className="inline-flex items-center gap-1.5 mt-3 px-3 text-xs font-bold text-gray-500 hover:text-violet-400 transition-colors group/view uppercase tracking-wider"
+                                  className="inline-flex items-center gap-1.5 mt-3 px-3 text-xs font-bold text-white/70 hover:text-de-accent-ink transition-colors group/view uppercase tracking-wider"
                                   onClick={handleLinkClick}
                                 >
                                   Explore
@@ -934,7 +934,7 @@ export function MegaMenu() {
                                   {item.featuredPanel.stats.map((stat, idx) => (
                                     <div key={idx} className="flex items-center justify-between py-2 border-b border-white/5 last:border-0">
                                       <span className="text-gray-400 text-xs uppercase tracking-wider font-semibold">{stat.label}</span>
-                                      <span className="text-violet-300 font-bold text-base">{stat.value}</span>
+                                      <span className="text-de-accent-ink font-bold text-base">{stat.value}</span>
                                     </div>
                                   ))}
                                 </div>
@@ -943,7 +943,7 @@ export function MegaMenu() {
                                 href={item.featuredPanel.cta.url}
                                 target="_blank"
                                 rel="noopener noreferrer"
-                                className="relative z-10 mt-6 w-full inline-flex items-center justify-center px-4 py-3 bg-violet-600 hover:bg-violet-500 text-white text-sm font-bold rounded-lg transition-all shadow-lg shadow-violet-500/20"
+                                className="relative z-10 mt-6 w-full inline-flex items-center justify-center px-4 py-3 bg-de-accent hover:bg-de-accent text-white text-sm font-bold rounded-lg transition-all shadow-lg shadow-none"
                                 onClick={handleLinkClick}
                               >
                                 {item.featuredPanel.cta.text}
@@ -1126,7 +1126,7 @@ export function MegaMenu() {
                       aria-label={`Go to ${item.name}`}
                     >
                       {item.name}
-                      <ArrowRight className="w-5 h-5 text-white/35 group-hover:text-[#D3126A] transform group-hover:translate-x-1 transition-all" />
+                      <ArrowRight className="w-5 h-5 text-white/55 group-hover:text-[#D3126A] transform group-hover:translate-x-1 transition-all" />
                     </a>
                   ) : (
                     <details className="group">
@@ -1137,7 +1137,7 @@ export function MegaMenu() {
                         <span className="flex items-center gap-3">
                           {item.name}
                         </span>
-                        <ChevronDown className="h-5 w-5 text-white/40 transition-transform duration-300 group-open:rotate-180 group-open:text-[#D3126A]" aria-hidden="true" />
+                        <ChevronDown className="h-5 w-5 text-white/55 transition-transform duration-300 group-open:rotate-180 group-open:text-[#D3126A]" aria-hidden="true" />
                       </summary>
                       {item.sections && (
                         <div className="mt-2 ml-1 space-y-1 rounded-xl border border-de-hairline bg-de-raised p-3">

--- a/client/src/components/MegaMenu.tsx
+++ b/client/src/components/MegaMenu.tsx
@@ -1004,7 +1004,7 @@ export function MegaMenu() {
           <div className="flex items-center space-x-2 lg:space-x-3 flex-shrink-0">
             <button
               type="button"
-              className="hidden lg:inline-flex items-center justify-center bg-gradient-to-r from-fuchsia-600 via-pink-600 to-rose-500 hover:from-fuchsia-500 hover:via-pink-500 hover:to-rose-400 text-white px-3 xl:px-4 py-2 rounded-lg text-base font-semibold whitespace-nowrap shadow-[0_0_22px_rgba(236,72,153,0.35)] hover:shadow-[0_0_30px_rgba(236,72,153,0.45)] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-pink-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black border border-pink-300/25"
+              className="hidden lg:inline-flex items-center justify-center bg-[#D3126A] hover:bg-[#e01874] text-white px-3 xl:px-4 py-2 rounded-lg text-base font-semibold whitespace-nowrap transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A] focus-visible:ring-offset-2 focus-visible:ring-offset-black"
               data-testid="nav-cta"
               onClick={() => { handleLinkClick(); openBooking("megamenu"); }}
               aria-label={CTA.primary}

--- a/client/src/components/PageTemplate.tsx
+++ b/client/src/components/PageTemplate.tsx
@@ -31,8 +31,8 @@ const FloatingOrbs = ({ prefersReducedMotion }: { prefersReducedMotion: boolean 
       transition={{ duration: 12, repeat: Infinity, ease: "easeInOut" }}
     />
     <motion.div
-      className="absolute -bottom-32 -left-32 w-80 h-80 rounded-full"
-      style={{ background: "radial-gradient(circle, rgba(217, 70, 239, 0.16) 0%, transparent 65%)" }}
+      className="de-hero-glow absolute -bottom-32 -left-32 w-80 h-80 rounded-full"
+      style={{ background: "radial-gradient(circle, rgba(211, 18, 106, 0.14) 0%, transparent 65%)" }}
       animate={prefersReducedMotion ? {} : {
         x: [0, -15, 0],
         y: [0, 20, 0],

--- a/client/src/components/PageTemplate.tsx
+++ b/client/src/components/PageTemplate.tsx
@@ -21,8 +21,8 @@ interface PageTemplateProps {
 const FloatingOrbs = ({ prefersReducedMotion }: { prefersReducedMotion: boolean }) => (
   <div className="absolute inset-0 overflow-hidden pointer-events-none">
     <motion.div
-      className="absolute -top-20 -right-20 w-96 h-96 rounded-full"
-      style={{ background: "radial-gradient(circle, rgba(236, 72, 153, 0.2) 0%, rgba(139, 92, 246, 0.12) 45%, transparent 68%)" }}
+      className="de-hero-glow absolute -top-20 -right-20 w-96 h-96 rounded-full"
+      style={{ background: "radial-gradient(circle, rgba(211, 18, 106, 0.2) 0%, rgba(91, 69, 224, 0.1) 45%, transparent 68%)" }}
       animate={prefersReducedMotion ? {} : {
         x: [0, 20, 0],
         y: [0, -15, 0],
@@ -57,7 +57,7 @@ const GridPattern = () => (
     <svg className="absolute w-full h-full" xmlns="http://www.w3.org/2000/svg">
       <defs>
         <pattern id="grid-pattern" width="48" height="48" patternUnits="userSpaceOnUse">
-          <path d="M 48 0 L 0 0 0 48" fill="none" stroke="currentColor" strokeWidth="0.5" className="text-white/30" />
+          <path d="M 48 0 L 0 0 0 48" fill="none" stroke="currentColor" strokeWidth="0.5" className="text-white/55" />
         </pattern>
       </defs>
       <rect width="100%" height="100%" fill="url(#grid-pattern)" />
@@ -91,9 +91,11 @@ const ShieldBadge = () => (
     transition={{ delay: 0.5, duration: 0.6 }}
   >
     <div className="relative">
-      <div className="absolute inset-0 bg-gradient-to-br from-fuchsia-400/40 to-pink-600/40 rounded-full blur-xl" />
+      {/* Glow follows the page accent, so a support page reads cyan and the
+          store reads electric without either leaving the shared system. */}
+      <div className="absolute inset-0 bg-de-accent/35 rounded-full blur-xl" />
       <div className="relative w-28 h-28 bg-white/[0.07] backdrop-blur-sm rounded-full border border-white/15 flex items-center justify-center">
-        <Shield className="w-14 h-14 text-pink-300/85" />
+        <Shield className="w-14 h-14 text-de-accent-ink" />
       </div>
     </div>
   </motion.div>
@@ -104,7 +106,7 @@ export const PageTemplate = ({
   subtitle, 
   children, 
   showBackButton = true,
-  gradientColors = "from-[#2a0a32] via-[#1a0b3a] to-[#050312]",
+  gradientColors = "from-[#050312] via-[#0a0a0a] to-[#050312]",
   icon,
   breadcrumbs,
   variant = "dark",
@@ -119,10 +121,10 @@ export const PageTemplate = ({
       : "bg-[#050312]";
   
   const contentBgClass = variant === "dark"
-    ? "bg-[#0a0714]"
+    ? "bg-de-surface"
     : variant === "light"
       ? "bg-white"
-      : "bg-[#0a0714]";
+      : "bg-de-surface";
   
   const textClass = variant === "dark" ? "text-white" : "text-gray-900";
   const proseClass = variant === "dark" ? "de-prose-dark" : "de-prose-light";

--- a/client/src/components/PremiumCTASection.tsx
+++ b/client/src/components/PremiumCTASection.tsx
@@ -37,7 +37,7 @@ export function PremiumCTASection({
           <div 
             className="absolute inset-0"
             style={{
-              background: "linear-gradient(135deg, #7c3aed 0%, #a855f7 35%, #c026d3 70%, #a855f7 100%)",
+              background: "var(--de-magenta)",
             }}
           />
           
@@ -88,7 +88,7 @@ export function PremiumCTASection({
             >
               <Button 
                 size="lg"
-                className="h-14 px-8 bg-white text-violet-700 hover:bg-white/90 font-semibold text-base rounded-full shadow-lg shadow-black/20"
+                className="h-14 px-8 bg-white text-de-accent hover:bg-white/90 font-semibold text-base rounded-full shadow-lg shadow-black/20"
                 data-testid="button-premium-cta-primary"
                 onClick={(e) => { e.preventDefault(); openBooking("cta_section"); }}
               >

--- a/client/src/components/ReadingProgressBar.tsx
+++ b/client/src/components/ReadingProgressBar.tsx
@@ -38,7 +38,7 @@ export function ReadingProgressBar({ targetRef }: ReadingProgressBarProps) {
     >
       <div className="h-1 bg-white/10 w-full">
         <div 
-          className="h-full bg-gradient-to-r from-violet-500 via-purple-500 to-fuchsia-500 transition-transform duration-150 ease-out origin-left"
+          className="h-full bg-de-raised transition-transform duration-150 ease-out origin-left"
           style={{ transform: `scaleX(${progress / 100})` }}
           role="progressbar"
           aria-valuenow={Math.round(progress)}

--- a/client/src/components/ScrollToTop.tsx
+++ b/client/src/components/ScrollToTop.tsx
@@ -70,7 +70,7 @@ export const ScrollToTop = () => {
           exit={{ opacity: 0, scale: 0.8, y: 20 }}
           transition={{ duration: prefersReducedMotion ? 0 : 0.2 }}
           onClick={scrollToTop}
-          className="de-scroll-top p-3 bg-violet-600/90 hover:bg-violet-500 text-white rounded-full shadow-lg shadow-violet-500/25 backdrop-blur-sm border border-violet-500/30 transition-colors duration-200 group"
+          className="de-scroll-top p-3 bg-de-raised hover:bg-de-accent text-white rounded-full shadow-lg shadow-none backdrop-blur-sm border border-de-hairline transition-colors duration-200 group"
           aria-label="Scroll to top"
           data-testid="button-scroll-to-top"
         >

--- a/client/src/components/ServiceCapabilityMatrix.tsx
+++ b/client/src/components/ServiceCapabilityMatrix.tsx
@@ -171,7 +171,7 @@ export function ServiceCapabilityMatrix({
     if (value === true) {
       return (
         <span className={`inline-flex items-center justify-center w-6 h-6 rounded-full ${
-          isHighlighted ? 'bg-violet-500/30 text-violet-300' : 'bg-emerald-500/20 text-emerald-400'
+          isHighlighted ? 'bg-de-raised text-de-accent-ink' : 'bg-emerald-500/20 text-emerald-400'
         }`}>
           <Check className="w-4 h-4" />
         </span>
@@ -184,7 +184,7 @@ export function ServiceCapabilityMatrix({
       return (
         <span className={`px-2 py-0.5 rounded-full text-[11px] font-medium ${
           isHighlighted 
-            ? 'bg-violet-500/20 text-violet-300 border border-violet-500/30' 
+            ? 'bg-de-raised text-de-accent-ink border border-de-hairline' 
             : 'bg-amber-500/15 text-amber-400 border border-amber-500/20'
         }`}>
           {value}
@@ -194,7 +194,7 @@ export function ServiceCapabilityMatrix({
     return (
       <span className={`px-2 py-0.5 rounded-full text-[11px] font-medium ${
         isHighlighted 
-          ? 'bg-violet-500/20 text-violet-300 border border-violet-500/30' 
+          ? 'bg-de-raised text-de-accent-ink border border-de-hairline' 
           : 'bg-white/5 text-white/70 border border-white/10'
       }`}>
         {value}
@@ -213,7 +213,7 @@ export function ServiceCapabilityMatrix({
     >
       {/* Tier Headers */}
       <div className="grid grid-cols-5 gap-1 p-3 bg-white/[0.03] border-b border-white/10">
-        <div className="text-white/40 text-xs font-medium uppercase tracking-wider flex items-center">
+        <div className="text-white/55 text-xs font-medium uppercase tracking-wider flex items-center">
           Capability
         </div>
         {tiers.map((tier) => (
@@ -221,20 +221,20 @@ export function ServiceCapabilityMatrix({
             key={tier.id}
             className={`text-center p-2 rounded-lg transition-all ${
               highlightTier === tier.id 
-                ? 'bg-violet-500/20 border border-violet-500/30' 
+                ? 'bg-de-raised border border-de-hairline' 
                 : tier.featured 
                   ? 'bg-emerald-500/10 border border-emerald-500/20' 
                   : ''
             }`}
           >
             <div className={`text-xs font-bold ${
-              highlightTier === tier.id ? 'text-violet-300' : 'text-white'
+              highlightTier === tier.id ? 'text-de-accent-ink' : 'text-white'
             }`}>
               {tier.name}
             </div>
             <div className="text-[10px] text-white/50">{tier.price}</div>
             {highlightTier === tier.id && (
-              <div className="text-[9px] text-violet-400 mt-0.5">Recommended</div>
+              <div className="text-[9px] text-de-accent-ink mt-0.5">Recommended</div>
             )}
           </div>
         ))}
@@ -260,22 +260,22 @@ export function ServiceCapabilityMatrix({
                 {row.capability}
               </div>
               <div className={`text-center flex items-center justify-center ${
-                highlightTier === 'essentials' ? 'bg-violet-500/5 rounded' : ''
+                highlightTier === 'essentials' ? 'bg-de-raised rounded' : ''
               }`}>
                 {renderCellValue(row.essentials, 'essentials')}
               </div>
               <div className={`text-center flex items-center justify-center ${
-                highlightTier === 'office' ? 'bg-violet-500/5 rounded' : ''
+                highlightTier === 'office' ? 'bg-de-raised rounded' : ''
               }`}>
                 {renderCellValue(row.office, 'office')}
               </div>
               <div className={`text-center flex items-center justify-center ${
-                highlightTier === 'business' ? 'bg-violet-500/5 rounded' : ''
+                highlightTier === 'business' ? 'bg-de-raised rounded' : ''
               }`}>
                 {renderCellValue(row.business, 'business')}
               </div>
               <div className={`text-center flex items-center justify-center ${
-                highlightTier === 'enterprise' ? 'bg-violet-500/5 rounded' : ''
+                highlightTier === 'enterprise' ? 'bg-de-raised rounded' : ''
               }`}>
                 {renderCellValue(row.enterprise, 'enterprise')}
               </div>
@@ -287,7 +287,7 @@ export function ServiceCapabilityMatrix({
       {/* Footer Link */}
       <div className="p-4 bg-white/[0.02] border-t border-white/10">
         <Link href="/ecosystem-pricing">
-          <span className="inline-flex items-center gap-2 text-sm text-violet-400 hover:text-violet-300 transition-colors cursor-pointer">
+          <span className="inline-flex items-center gap-2 text-sm text-de-accent-ink hover:text-de-accent-ink transition-colors cursor-pointer">
             View complete service matrix
             <ChevronRight className="w-4 h-4" />
           </span>

--- a/client/src/components/ServiceMatrix.tsx
+++ b/client/src/components/ServiceMatrix.tsx
@@ -99,7 +99,7 @@ export function ServiceMatrix({
           </div>
           <Link href="/pricing">
             <Button 
-              className="bg-violet-600 hover:bg-violet-700 text-white"
+              className="bg-de-accent hover:bg-de-accent text-white"
               data-testid="button-view-pricing"
             >
               View Full Pricing

--- a/client/src/components/StatCallout.tsx
+++ b/client/src/components/StatCallout.tsx
@@ -58,17 +58,17 @@ export const StatCallout = ({ stat, variant = "dark", size = "md" }: StatCallout
       data-testid="stat-callout"
     >
       <div className="flex items-start gap-4">
-        <div className={`p-3 rounded-xl ${variant === "light" ? "bg-violet-100" : "bg-violet-500/20"}`}>
-          <Icon className={`h-6 w-6 ${variant === "light" ? "text-violet-600" : "text-violet-400"}`} />
+        <div className={`p-3 rounded-xl ${variant === "light" ? "bg-de-paper-raised" : "bg-de-raised"}`}>
+          <Icon className={`h-6 w-6 ${variant === "light" ? "text-de-accent" : "text-de-accent-ink"}`} />
         </div>
         <div className="flex-1">
-          <div className={`${valueSizes[size]} font-bold bg-gradient-to-r from-violet-400 to-purple-400 bg-clip-text text-transparent`}>
+          <div className={`${valueSizes[size]} font-bold text-de-accent-ink`}>
             {stat.value}
           </div>
           <p className={`mt-2 ${variant === "light" ? "text-gray-700" : "text-white/80"} leading-relaxed`}>
             {stat.label}
           </p>
-          <p className={`mt-2 text-sm ${variant === "light" ? "text-gray-500" : "text-white/50"}`}>
+          <p className={`mt-2 text-sm ${variant === "light" ? "text-white/70" : "text-white/50"}`}>
             — {stat.source}
           </p>
         </div>
@@ -93,15 +93,15 @@ export const StatBanner = ({ stat, variant = "dark" }: StatBannerProps) => {
       transition={{ duration: 0.5 }}
       className={`py-4 px-6 rounded-xl text-center ${
         variant === "dark" 
-          ? "bg-violet-500/10 border border-violet-500/20" 
-          : "bg-violet-50 border border-violet-200"
+          ? "bg-de-raised border border-de-hairline" 
+          : "bg-de-paper-raised border border-de-hairline"
       }`}
       data-testid="stat-banner"
     >
       <p className={variant === "dark" ? "text-white/90" : "text-gray-800"}>
-        <span className="font-bold text-violet-400">{stat.value}</span>{" "}
-        <span className={variant === "dark" ? "text-white/70" : "text-gray-600"}>{stat.label}</span>
-        <span className={`ml-2 text-sm ${variant === "dark" ? "text-white/50" : "text-gray-500"}`}>
+        <span className="font-bold text-de-accent-ink">{stat.value}</span>{" "}
+        <span className={variant === "dark" ? "text-white/70" : "text-white/70"}>{stat.label}</span>
+        <span className={`ml-2 text-sm ${variant === "dark" ? "text-white/50" : "text-white/70"}`}>
           — {stat.source}
         </span>
       </p>
@@ -140,13 +140,13 @@ export const StatGrid = ({ stats, variant = "dark", columns = 3 }: StatGridProps
           }`}
           data-testid={`stat-item-${index}`}
         >
-          <div className="text-3xl md:text-4xl font-bold bg-gradient-to-r from-violet-400 to-purple-400 bg-clip-text text-transparent">
+          <div className="text-3xl md:text-4xl font-bold text-de-accent-ink">
             {stat.value}
           </div>
-          <p className={`mt-2 ${variant === "dark" ? "text-white/70" : "text-gray-600"}`}>
+          <p className={`mt-2 ${variant === "dark" ? "text-white/70" : "text-white/70"}`}>
             {stat.label}
           </p>
-          <p className={`mt-1 text-xs ${variant === "dark" ? "text-white/40" : "text-gray-400"}`}>
+          <p className={`mt-1 text-xs ${variant === "dark" ? "text-white/55" : "text-gray-400"}`}>
             {stat.source}
           </p>
         </motion.div>

--- a/client/src/components/StickyCTABar.tsx
+++ b/client/src/components/StickyCTABar.tsx
@@ -79,7 +79,7 @@ export function StickyCTABar() {
           className="de-bottom-bar"
           data-testid="sticky-cta-bar"
         >
-          <div className="relative overflow-hidden rounded-2xl border border-pink-400/35 bg-gradient-to-r from-fuchsia-900/95 via-pink-900/95 to-violet-900/95 backdrop-blur-lg shadow-lg shadow-pink-500/20">
+          <div className="relative overflow-hidden rounded-2xl border border-pink-400/35 bg-de-raised backdrop-blur-lg shadow-lg shadow-pink-500/20">
             <button
               onClick={handleDismiss}
               className="absolute top-2 right-2 z-10 p-1.5 rounded-full hover:bg-white/10 transition-colors"
@@ -93,7 +93,7 @@ export function StickyCTABar() {
               <div className="flex flex-col lg:flex-row items-center justify-between gap-3 lg:gap-5">
                 <div className="flex items-center gap-3 min-w-0">
                   <div className="hidden sm:flex w-10 h-10 rounded-full bg-white/10 items-center justify-center shrink-0">
-                    <Shield className="w-5 h-5 text-violet-300" />
+                    <Shield className="w-5 h-5 text-de-accent-ink" />
                   </div>
                   <div className="text-center lg:text-left min-w-0">
                     <p className="text-white font-semibold text-base md:text-lg">

--- a/client/src/components/TierDetailTemplate.tsx
+++ b/client/src/components/TierDetailTemplate.tsx
@@ -117,7 +117,7 @@ export function TierDetailTemplate({ config }: { config: TierPageConfig }) {
             <ul className="space-y-3">
               {config.notIncluded.map((item) => (
                 <li key={item} className="flex items-start gap-3 text-white/70 leading-relaxed">
-                  <XCircle className="w-5 h-5 text-white/40 mt-0.5 flex-shrink-0" />
+                  <XCircle className="w-5 h-5 text-white/55 mt-0.5 flex-shrink-0" />
                   <span>{item}</span>
                 </li>
               ))}
@@ -145,7 +145,7 @@ export function TierDetailTemplate({ config }: { config: TierPageConfig }) {
           <p className="text-white/85 leading-relaxed">{config.reviewCadence}</p>
         </section>
 
-        <section className="rounded-xl border border-pink-400/25 bg-gradient-to-br from-fuchsia-950/40 via-pink-950/30 to-violet-950/40 p-6">
+        <section className="rounded-xl border border-pink-400/25 bg-de-raised p-6">
           <SectionHeading icon={BadgeDollarSign}>Pricing</SectionHeading>
           <p className="text-white/85 leading-relaxed mb-6">{config.pricingNote}</p>
           <div className="flex flex-col sm:flex-row gap-4">

--- a/client/src/components/VirtualMspAdvisor.tsx
+++ b/client/src/components/VirtualMspAdvisor.tsx
@@ -346,12 +346,12 @@ export function VirtualMspAdvisor() {
           className="absolute bottom-0 right-0 w-[min(420px,92vw)] h-[min(640px,80vh)] bg-white rounded-xl shadow-2xl overflow-hidden border border-slate-200 flex flex-col"
           data-testid="panel-msp-advisor"
         >
-          <div className="bg-gradient-to-r from-violet-800 to-slate-900 text-white p-4 flex justify-between items-start flex-shrink-0">
+          <div className="bg-de-raised text-white p-4 flex justify-between items-start flex-shrink-0">
             <div>
               <h3 className="font-semibold text-base" data-testid="text-advisor-title">
                 DE Desk
               </h3>
-              <p className="text-xs text-violet-100 mt-0.5">
+              <p className="text-xs text-white/80 mt-0.5">
                 Digerati Experts · IT, cybersecurity & compliance
               </p>
             </div>
@@ -374,7 +374,7 @@ export function VirtualMspAdvisor() {
                 <div
                   className={`max-w-[90%] rounded-2xl px-3 py-2 text-sm leading-relaxed whitespace-pre-wrap ${
                     t.role === "user"
-                      ? "bg-violet-700 text-white rounded-br-md"
+                      ? "bg-de-accent text-white rounded-br-md"
                       : "bg-white text-slate-800 border border-slate-200 rounded-bl-md shadow-sm"
                   }`}
                   data-testid={t.role === "user" ? "advisor-msg-user" : "advisor-msg-assistant"}
@@ -387,7 +387,7 @@ export function VirtualMspAdvisor() {
                           key={`${a.type}-${a.label}`}
                           type="button"
                           onClick={() => runAction(a)}
-                          className="text-xs font-medium px-2.5 py-1 rounded-full bg-violet-50 text-violet-800 border border-violet-200 hover:bg-violet-100"
+                          className="text-xs font-medium px-2.5 py-1 rounded-full bg-de-paper-raised text-de-accent border border-de-hairline hover:bg-de-paper-raised"
                           data-testid={`advisor-action-${a.type}`}
                         >
                           {a.label}
@@ -455,7 +455,7 @@ export function VirtualMspAdvisor() {
                 <div className="flex gap-2">
                   <Button
                     size="sm"
-                    className="flex-1 bg-violet-700 hover:bg-violet-800"
+                    className="flex-1 bg-de-accent hover:bg-de-accent"
                     onClick={submitLeadForm}
                     disabled={loading}
                     data-testid="advisor-lead-submit"
@@ -494,7 +494,7 @@ export function VirtualMspAdvisor() {
             <Button
               type="submit"
               disabled={loading || !input.trim()}
-              className="h-10 px-3 bg-violet-700 hover:bg-violet-800"
+              className="h-10 px-3 bg-de-accent hover:bg-de-accent"
               data-testid="advisor-send"
               aria-label="Send message"
             >

--- a/client/src/components/WaveSeparator.tsx
+++ b/client/src/components/WaveSeparator.tsx
@@ -134,7 +134,7 @@ export const WaveSeparator = ({ variant = 'default', className = '' }: WaveSepar
     return (
       <div className={`wave-separator relative h-20 md:h-24 ${className}`}>
         {/* Gradient background layer */}
-        <div className="absolute inset-0 bg-gradient-to-r from-purple-600 via-blue-600 to-purple-600 opacity-10"></div>
+        <div className="absolute inset-0 bg-de-raised opacity-10"></div>
         
         {/* Main wave */}
         <svg

--- a/client/src/components/store/CartButton.tsx
+++ b/client/src/components/store/CartButton.tsx
@@ -19,7 +19,7 @@ export function CartButton() {
       <Layers className="h-5 w-5" />
       {itemCount > 0 && (
         <span
-          className="absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center rounded-full bg-[#5034ff] text-xs font-medium text-white"
+          className="absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center rounded-full bg-de-accent text-xs font-medium text-white"
           data-testid="cart-item-count"
         >
           {itemCount > 99 ? "99+" : itemCount}

--- a/client/src/components/store/ConfigureProductDrawer.tsx
+++ b/client/src/components/store/ConfigureProductDrawer.tsx
@@ -157,8 +157,8 @@ export function ConfigureProductDrawer({
           >
             <div className="flex items-center justify-between border-b border-white/10 px-6 py-5">
               <div className="flex items-center gap-3">
-                <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-[#5034ff]/30 bg-[#5034ff]/15">
-                  <Settings2 className="h-5 w-5 text-[#a78bfa]" />
+                <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-de-accent/30 bg-de-accent/15">
+                  <Settings2 className="h-5 w-5 text-de-accent-ink" />
                 </div>
                 <div>
                   <h2 id="configure-drawer-title" className="text-lg font-semibold text-white">
@@ -192,7 +192,7 @@ export function ConfigureProductDrawer({
                   <p className="mt-1 text-sm leading-relaxed text-white/65">
                     {getOutcomeLead(product)}
                   </p>
-                  <p className="mt-2 text-sm text-white/45">{formatPrice(product)}</p>
+                  <p className="mt-2 text-sm text-white/55">{formatPrice(product)}</p>
                 </div>
               </div>
 
@@ -202,7 +202,7 @@ export function ConfigureProductDrawer({
                   <ul className="space-y-2">
                     {product.features.slice(0, 4).map((feature) => (
                       <li key={feature} className="flex items-start gap-2 text-sm text-white/60">
-                        <Check className="mt-0.5 h-4 w-4 flex-shrink-0 text-[#a78bfa]" />
+                        <Check className="mt-0.5 h-4 w-4 flex-shrink-0 text-de-accent-ink" />
                         <span>{feature}</span>
                       </li>
                     ))}
@@ -213,7 +213,7 @@ export function ConfigureProductDrawer({
               {(includedHint || upgradeName) && (
                 <div className="space-y-1.5 text-sm text-white/50">
                   {includedHint && (
-                    <p className="text-[#a78bfa]/90" data-testid="configure-included-hint">
+                    <p className="text-de-accent-ink/90" data-testid="configure-included-hint">
                       {includedHint}
                     </p>
                   )}
@@ -264,7 +264,7 @@ export function ConfigureProductDrawer({
                     <Plus className="h-4 w-4" />
                   </Button>
                 </div>
-                <p className="mt-3 text-sm text-white/45">
+                <p className="mt-3 text-sm text-white/55">
                   Minimum {product.minimumQuantity || 1} {unit}
                 </p>
               </div>
@@ -278,7 +278,7 @@ export function ConfigureProductDrawer({
                       variant="outline"
                       className={
                         billingPeriod === "monthly"
-                          ? "h-10 flex-1 border-[#5034ff]/40 bg-[#5034ff]/20 text-white"
+                          ? "h-10 flex-1 border-de-accent/40 bg-de-accent/20 text-white"
                           : "h-10 flex-1 border-white/15 bg-transparent text-white/70"
                       }
                       onClick={() => setBillingPeriod("monthly")}
@@ -291,7 +291,7 @@ export function ConfigureProductDrawer({
                       variant="outline"
                       className={
                         billingPeriod === "yearly"
-                          ? "h-10 flex-1 border-[#5034ff]/40 bg-[#5034ff]/20 text-white"
+                          ? "h-10 flex-1 border-de-accent/40 bg-de-accent/20 text-white"
                           : "h-10 flex-1 border-white/15 bg-transparent text-white/70"
                       }
                       onClick={() => setBillingPeriod("yearly")}
@@ -300,7 +300,7 @@ export function ConfigureProductDrawer({
                       Annual estimate
                     </Button>
                   </div>
-                  <p className="mt-2 text-xs text-white/45">
+                  <p className="mt-2 text-xs text-white/55">
                     Cart keeps the catalog billing type; annual is an estimate (×12).
                   </p>
                 </div>
@@ -309,7 +309,7 @@ export function ConfigureProductDrawer({
               {addonProducts.length > 0 && (
                 <div className="rounded-xl border border-white/10 bg-[#141414] p-5">
                   <p className="mb-1 text-sm font-medium text-white/70">Recommended add-ons</p>
-                  <p className="mb-3 text-xs text-white/45">
+                  <p className="mb-3 text-xs text-white/55">
                     From catalog relationships — not a hardware quiz.
                   </p>
                   <ul className="space-y-2">
@@ -323,7 +323,7 @@ export function ConfigureProductDrawer({
                             onClick={() => toggleAddon(addon.id)}
                             className={`flex w-full items-start gap-3 rounded-lg border px-3 py-2.5 text-left transition-colors ${
                               checked
-                                ? "border-[#5034ff]/40 bg-[#5034ff]/15"
+                                ? "border-de-accent/40 bg-de-accent/15"
                                 : "border-white/10 bg-[#0a0a0a] hover:border-white/20"
                             }`}
                             data-testid={`toggle-addon-${addon.sku}`}
@@ -332,7 +332,7 @@ export function ConfigureProductDrawer({
                             <span
                               className={`mt-0.5 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded border ${
                                 checked
-                                  ? "border-[#5034ff] bg-[#5034ff] text-white"
+                                  ? "border-de-accent bg-de-accent text-white"
                                   : "border-white/25"
                               }`}
                             >
@@ -361,7 +361,7 @@ export function ConfigureProductDrawer({
                   htmlFor="configure-env-notes"
                   className="mb-2 flex items-center gap-2 text-sm font-medium text-white/70"
                 >
-                  <FileText className="h-4 w-4 text-[#a78bfa]" />
+                  <FileText className="h-4 w-4 text-de-accent-ink" />
                   Environment notes
                 </label>
                 <Textarea
@@ -369,12 +369,12 @@ export function ConfigureProductDrawer({
                   value={environmentNotes}
                   onChange={(e) => setEnvironmentNotes(e.target.value)}
                   placeholder="Sites, identity stack, backup targets, constraints — optional context for quote or onboarding."
-                  className="min-h-[88px] border-white/15 bg-[#0a0a0a] text-sm text-white placeholder:text-white/35"
+                  className="min-h-[88px] border-white/15 bg-[#0a0a0a] text-sm text-white placeholder:text-white/55"
                   data-testid="input-configure-notes"
                 />
               </div>
 
-              <div className="rounded-xl border border-[#5034ff]/25 bg-[#5034ff]/10 p-5">
+              <div className="rounded-xl border border-de-accent/25 bg-de-accent/10 p-5">
                 <p className="text-sm text-white/60">
                   {qty} × ${unitPrice.toFixed(2)}
                   {recurring ? (billingPeriod === "yearly" ? " × 12" : " / mo") : ""}
@@ -393,7 +393,7 @@ export function ConfigureProductDrawer({
 
             <div className="space-y-3 border-t border-white/10 p-6">
               <Button
-                className="h-12 w-full bg-[#5034ff] text-base text-white hover:bg-[#6548ff]"
+                className="h-12 w-full bg-de-accent text-base text-white hover:bg-[#6548ff]"
                 onClick={() => onConfirm(buildPayload())}
                 data-testid="button-add-configured"
               >

--- a/client/src/components/store/CoverageScorePanel.tsx
+++ b/client/src/components/store/CoverageScorePanel.tsx
@@ -28,20 +28,20 @@ export function CoverageScorePanel({
     >
       <div className="mb-3 flex items-center justify-between gap-2">
         <div className="flex items-center gap-2">
-          <Shield className="h-4 w-4 text-[#a78bfa]" />
+          <Shield className="h-4 w-4 text-de-accent-ink" />
           <h3 className="text-sm font-semibold text-white">Solution coverage</h3>
         </div>
         <div className="text-right">
           <span className="text-lg font-bold text-white" data-testid="text-coverage-score">
             {score.total}
-            <span className="text-sm font-medium text-white/45"> / 100</span>
+            <span className="text-sm font-medium text-white/55"> / 100</span>
           </span>
-          <p className="text-[11px] text-white/45" data-testid="text-coverage-areas">
+          <p className="text-[11px] text-white/55" data-testid="text-coverage-areas">
             {score.coveredCount} of {score.dimensionCount} areas
           </p>
         </div>
       </div>
-      <p className="mb-4 text-xs leading-relaxed text-white/45">
+      <p className="mb-4 text-xs leading-relaxed text-white/55">
         Heuristic stack coverage (endpoint, identity, email, backup, network, compliance) —
         not a security audit or certification claim.
       </p>
@@ -56,13 +56,13 @@ export function CoverageScorePanel({
             <div className="h-2 flex-1 overflow-hidden rounded-full bg-white/10">
               <div
                 className={`h-full rounded-full transition-all ${
-                  bar.covered ? "bg-[#5034ff]" : "bg-white/15"
+                  bar.covered ? "bg-de-accent" : "bg-white/15"
                 }`}
                 style={{ width: bar.covered ? "100%" : "18%" }}
               />
             </div>
             {bar.coveredBy && (
-              <span className="hidden w-28 truncate text-[10px] text-white/35 sm:inline">
+              <span className="hidden w-28 truncate text-[10px] text-white/55 sm:inline">
                 {bar.coveredBy}
               </span>
             )}
@@ -80,16 +80,16 @@ export function CoverageScorePanel({
                 className="flex items-start justify-between gap-2 rounded-lg border border-white/10 bg-white/[0.03] p-3"
               >
                 <div className="min-w-0">
-                  <p className="text-[10px] uppercase tracking-wide text-white/40">{s.label}</p>
+                  <p className="text-[10px] uppercase tracking-wide text-white/55">{s.label}</p>
                   <p className="truncate text-sm text-white">{s.product.name}</p>
-                  <p className="text-xs text-white/45">
+                  <p className="text-xs text-white/55">
                     Coverage {s.from} → {s.to}
                   </p>
                 </div>
                 {onAddSuggestion ? (
                   <Button
                     size="sm"
-                    className="h-8 shrink-0 bg-[#5034ff] text-xs text-white hover:bg-[#6548ff]"
+                    className="h-8 shrink-0 bg-de-accent text-xs text-white hover:bg-[#6548ff]"
                     onClick={() => onAddSuggestion(s.product!)}
                     data-testid={`button-improve-${s.product.id}`}
                   >
@@ -97,7 +97,7 @@ export function CoverageScorePanel({
                   </Button>
                 ) : (
                   <Link href={`/store/product/${s.product.sku}`}>
-                    <span className="text-xs text-[#a78bfa] hover:text-[#c4b5fd]">View</span>
+                    <span className="text-xs text-de-accent-ink hover:text-de-accent-ink">View</span>
                   </Link>
                 )}
               </div>

--- a/client/src/components/store/GuidedBuyingWizard.tsx
+++ b/client/src/components/store/GuidedBuyingWizard.tsx
@@ -141,8 +141,8 @@ export function GuidedBuyingWizard({ open, onClose, onAddStack }: GuidedBuyingWi
           >
             <div className="flex items-center justify-between border-b border-white/10 px-6 py-5">
               <div className="flex items-center gap-3">
-                <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-[#5034ff]/30 bg-[#5034ff]/15">
-                  <Sparkles className="h-5 w-5 text-[#a78bfa]" />
+                <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-de-accent/30 bg-de-accent/15">
+                  <Sparkles className="h-5 w-5 text-de-accent-ink" />
                 </div>
                 <div>
                   <h2 className="text-lg font-semibold text-white">Build my solution</h2>
@@ -163,7 +163,7 @@ export function GuidedBuyingWizard({ open, onClose, onAddStack }: GuidedBuyingWi
             <div className="border-b border-white/10 px-6 py-3">
               <div className="h-1.5 overflow-hidden rounded-full bg-white/10">
                 <div
-                  className="h-full rounded-full bg-[#5034ff] transition-all"
+                  className="h-full rounded-full bg-de-accent transition-all"
                   style={{ width: `${progress}%` }}
                 />
               </div>
@@ -172,7 +172,7 @@ export function GuidedBuyingWizard({ open, onClose, onAddStack }: GuidedBuyingWi
             <div className="flex-1 overflow-y-auto p-6">
               {!showResult ? (
                 <div>
-                  <p className="mb-2 text-sm text-white/45">
+                  <p className="mb-2 text-sm text-white/55">
                     Step {step + 1} of {STEPS.length}
                   </p>
                   <h3 className="mb-5 text-2xl font-semibold text-white">{current.title}</h3>
@@ -191,7 +191,7 @@ export function GuidedBuyingWizard({ open, onClose, onAddStack }: GuidedBuyingWi
                           }
                           className={`flex w-full items-center rounded-xl border px-4 py-3.5 text-left text-base transition-colors ${
                             selected
-                              ? "border-[#5034ff]/50 bg-[#5034ff]/15 text-white"
+                              ? "border-de-accent/50 bg-de-accent/15 text-white"
                               : "border-white/10 bg-[#141414] text-white/75 hover:border-white/20 hover:bg-[#171717]"
                           }`}
                           data-testid={`guided-option-${current.key}-${opt.value}`}
@@ -223,7 +223,7 @@ export function GuidedBuyingWizard({ open, onClose, onAddStack }: GuidedBuyingWi
                       </li>
                     ))}
                   </ul>
-                  <div className="rounded-xl border border-[#5034ff]/25 bg-[#5034ff]/10 p-4">
+                  <div className="rounded-xl border border-de-accent/25 bg-de-accent/10 p-4">
                     <p className="text-sm text-white/60">Estimated list total (soft)</p>
                     <p className="mt-1 text-3xl font-bold text-white">
                       ${recommendation.recurringEstimate.toLocaleString()}
@@ -253,7 +253,7 @@ export function GuidedBuyingWizard({ open, onClose, onAddStack }: GuidedBuyingWi
                     Back
                   </Button>
                   <Button
-                    className="h-11 flex-1 bg-[#5034ff] text-white hover:bg-[#6548ff]"
+                    className="h-11 flex-1 bg-de-accent text-white hover:bg-[#6548ff]"
                     onClick={() => {
                       if (step >= STEPS.length - 1) {
                         setShowResult(true);
@@ -270,7 +270,7 @@ export function GuidedBuyingWizard({ open, onClose, onAddStack }: GuidedBuyingWi
               ) : (
                 <>
                   <Button
-                    className="h-12 w-full bg-[#5034ff] text-base text-white hover:bg-[#6548ff]"
+                    className="h-12 w-full bg-de-accent text-base text-white hover:bg-[#6548ff]"
                     disabled={!recommendation?.products.length}
                     onClick={() => {
                       if (!recommendation) return;

--- a/client/src/components/store/ProductCompare.tsx
+++ b/client/src/components/store/ProductCompare.tsx
@@ -40,13 +40,13 @@ export function ProductCompareBar({
       data-testid="compare-bar"
     >
       <div className="pointer-events-auto flex items-center gap-3 rounded-full border border-white/15 bg-[#121212]/95 px-5 py-3 shadow-xl backdrop-blur">
-      <GitCompare className="h-5 w-5 text-[#a78bfa]" />
+      <GitCompare className="h-5 w-5 text-de-accent-ink" />
       <span className="text-sm font-medium text-white">
         {selected.length} selected for compare
       </span>
       <Button
         size="sm"
-        className="h-9 bg-[#5034ff] text-white hover:bg-[#6548ff]"
+        className="h-9 bg-de-accent text-white hover:bg-[#6548ff]"
         onClick={onOpen}
         data-testid="button-open-compare"
       >
@@ -123,7 +123,7 @@ export function ProductCompareDrawer({
                     {selected.map((p) => (
                       <th key={p.id} className="p-3 align-top">
                         <p className="text-base font-semibold text-white">{p.name}</p>
-                        <p className="mt-1 text-sm text-[#a78bfa]">{formatPrice(p)}</p>
+                        <p className="mt-1 text-sm text-de-accent-ink">{formatPrice(p)}</p>
                         <div className="mt-2 flex flex-wrap gap-1">
                           {getProductTags(p).map((t) => (
                             <span

--- a/client/src/components/store/ShoppingCart.tsx
+++ b/client/src/components/store/ShoppingCart.tsx
@@ -143,7 +143,7 @@ export function ShoppingCart() {
           >
             <div className="flex items-center justify-between border-b border-white/10 p-6">
               <div className="flex items-center gap-3">
-                <Layers className="h-5 w-5 text-[#a78bfa]" />
+                <Layers className="h-5 w-5 text-de-accent-ink" />
                 <div>
                   <h2 className="text-xl font-semibold text-white">Your Solution</h2>
                   <span className="text-sm text-white/50">
@@ -156,7 +156,7 @@ export function ShoppingCart() {
                   variant="ghost"
                   size="icon"
                   onClick={() => setIsMinimized(!isMinimized)}
-                  className="text-white/60 hover:bg-[#5034ff]/10 hover:text-white"
+                  className="text-white/60 hover:bg-de-accent/10 hover:text-white"
                   data-testid="button-minimize-cart"
                   title={isMinimized ? "Expand solution" : "Minimize"}
                 >
@@ -168,7 +168,7 @@ export function ShoppingCart() {
                   variant="ghost"
                   size="icon"
                   onClick={closeCart}
-                  className="text-white/60 hover:bg-[#5034ff]/10 hover:text-white"
+                  className="text-white/60 hover:bg-de-accent/10 hover:text-white"
                   data-testid="button-close-cart"
                 >
                   <X className="h-5 w-5" />
@@ -181,7 +181,7 @@ export function ShoppingCart() {
                 {items.length === 0 ? (
                   <div className="flex h-full flex-col items-center justify-center text-center">
                     <div className="mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-white/5">
-                      <Layers className="h-10 w-10 text-white/30" />
+                      <Layers className="h-10 w-10 text-white/55" />
                     </div>
                     <h3 className="mb-2 text-lg font-medium text-white">No services yet</h3>
                     <p className="mb-6 text-white/50">
@@ -189,7 +189,7 @@ export function ShoppingCart() {
                     </p>
                     <Link href="/store/co-managed">
                       <Button
-                        className="bg-[#5034ff] text-white hover:bg-[#6548ff]"
+                        className="bg-de-accent text-white hover:bg-[#6548ff]"
                         onClick={closeCart}
                         data-testid="button-browse-products"
                       >
@@ -213,7 +213,7 @@ export function ShoppingCart() {
 
                     {grouped.map(([group, groupItems]) => (
                       <div key={group}>
-                        <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-white/45">
+                        <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-white/55">
                           {group}
                         </h3>
                         <div className="space-y-3">
@@ -228,7 +228,7 @@ export function ShoppingCart() {
                                   <h4 className="line-clamp-1 font-medium text-white">
                                     {item.product.name}
                                   </h4>
-                                  <p className="truncate text-[11px] text-white/35">
+                                  <p className="truncate text-[11px] text-white/55">
                                     {item.product.sku}
                                   </p>
                                   <p className="text-sm text-white/50">
@@ -255,7 +255,7 @@ export function ShoppingCart() {
                                       updateQuantity(item.product.id, item.quantity - 1)
                                     }
                                     disabled={item.quantity <= item.product.minimumQuantity}
-                                    className="h-8 w-8 border-[#5034ff]/30 bg-[#5034ff]/10 text-white hover:bg-[#5034ff]/20"
+                                    className="h-8 w-8 border-de-accent/30 bg-de-accent/10 text-white hover:bg-de-accent/20"
                                     data-testid={`button-decrease-${item.product.id}`}
                                   >
                                     <Minus className="h-3 w-3" />
@@ -272,13 +272,13 @@ export function ShoppingCart() {
                                     onClick={() =>
                                       updateQuantity(item.product.id, item.quantity + 1)
                                     }
-                                    className="h-8 w-8 border-[#5034ff]/30 bg-[#5034ff]/10 text-white hover:bg-[#5034ff]/20"
+                                    className="h-8 w-8 border-de-accent/30 bg-de-accent/10 text-white hover:bg-de-accent/20"
                                     data-testid={`button-increase-${item.product.id}`}
                                   >
                                     <Plus className="h-3 w-3" />
                                   </Button>
                                 </div>
-                                <span className="font-semibold text-[#a78bfa]">
+                                <span className="font-semibold text-de-accent-ink">
                                   $
                                   {(
                                     (item.clientPrice ?? item.product.basePrice) * item.quantity
@@ -296,7 +296,7 @@ export function ShoppingCart() {
                         className="rounded-xl border border-white/10 bg-white/[0.02] p-4"
                         data-testid="cart-complements"
                       >
-                        <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-white/45">
+                        <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-white/55">
                           Works with your stack
                         </p>
                         <div className="space-y-2">
@@ -307,7 +307,7 @@ export function ShoppingCart() {
                             >
                               <div className="min-w-0">
                                 <p className="truncate text-sm text-white">{product.name}</p>
-                                <p className="text-xs text-white/40">{formatPrice(product)}</p>
+                                <p className="text-xs text-white/55">{formatPrice(product)}</p>
                               </div>
                               <Button
                                 size="sm"
@@ -334,12 +334,12 @@ export function ShoppingCart() {
                       </div>
                     )}
 
-                    <p className="text-xs text-white/40">
+                    <p className="text-xs text-white/55">
                       Estimated onboarding: typically 7–10 business days after kickoff (varies by
                       stack). Questions?{" "}
                       <a
                         href="tel:+13254809870"
-                        className="inline-flex items-center gap-1 text-[#a78bfa] hover:text-[#c4b5fd]"
+                        className="inline-flex items-center gap-1 text-de-accent-ink hover:text-de-accent-ink"
                       >
                         <Phone className="h-3 w-3" />
                         325-480-9870
@@ -373,13 +373,13 @@ export function ShoppingCart() {
                   )}
                   <div className="flex items-center justify-between border-t border-white/10 pt-2">
                     <span className="font-medium text-white">Solution total</span>
-                    <span className="text-lg font-bold text-[#a78bfa]">${total.toFixed(2)}</span>
+                    <span className="text-lg font-bold text-de-accent-ink">${total.toFixed(2)}</span>
                   </div>
                 </div>
 
                 <div className="space-y-2.5">
                   <Button
-                    className="w-full bg-[#5034ff] text-white hover:bg-[#6548ff] disabled:opacity-50"
+                    className="w-full bg-de-accent text-white hover:bg-[#6548ff] disabled:opacity-50"
                     onClick={handleCheckout}
                     disabled={isCheckingOut}
                     data-testid="button-checkout"
@@ -409,7 +409,7 @@ export function ShoppingCart() {
                   <a href="/book" className="block" onClick={closeCart}>
                     <Button
                       variant="ghost"
-                      className="w-full text-white/70 hover:bg-[#5034ff]/10 hover:text-white"
+                      className="w-full text-white/70 hover:bg-de-accent/10 hover:text-white"
                       data-testid="button-schedule-from-cart"
                     >
                       <Calendar className="mr-2 h-4 w-4" />

--- a/client/src/components/store/StoreAssessmentPanel.tsx
+++ b/client/src/components/store/StoreAssessmentPanel.tsx
@@ -22,8 +22,8 @@ export function StoreAssessmentPanel({
   return (
     <aside className={shell} data-testid="store-assessment-panel">
       <div className="rounded-xl border border-white/10 bg-[#141414] p-5">
-        <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-lg border border-[#5034ff]/30 bg-[#5034ff]/15">
-          <ClipboardList className="h-5 w-5 text-[#a78bfa]" />
+        <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-lg border border-de-accent/30 bg-de-accent/15">
+          <ClipboardList className="h-5 w-5 text-de-accent-ink" />
         </div>
         <h3 className="text-lg font-semibold text-white">Not sure where to start?</h3>
         <p className="mt-2 text-sm leading-relaxed text-white/55">
@@ -33,7 +33,7 @@ export function StoreAssessmentPanel({
         <div className="mt-4 flex flex-col gap-2">
           <a href="/book">
             <Button
-              className="h-10 w-full bg-[#5034ff] text-white hover:bg-[#6548ff]"
+              className="h-10 w-full bg-de-accent text-white hover:bg-[#6548ff]"
               data-testid="button-assessment-book"
             >
               <Calendar className="mr-2 h-4 w-4" />
@@ -64,9 +64,9 @@ export function StoreAssessmentPanel({
             Build my solution
           </Button>
         </div>
-        <p className="mt-3 text-xs text-white/40">
+        <p className="mt-3 text-xs text-white/55">
           Or call{" "}
-          <a href="tel:+13254809870" className="text-[#a78bfa] hover:underline">
+          <a href="tel:+13254809870" className="text-de-accent-ink hover:underline">
             325-480-9870
           </a>
         </p>
@@ -78,7 +78,7 @@ export function StoreAssessmentPanel({
           ProActive Ecosystem packages include layered security and support in one plan.
         </p>
         <Link href="/store/managed">
-          <span className="mt-3 inline-flex items-center text-sm text-[#a78bfa] hover:text-[#c4b5fd]">
+          <span className="mt-3 inline-flex items-center text-sm text-de-accent-ink hover:text-de-accent-ink">
             View managed packages
             <ArrowRight className="ml-1 h-3.5 w-3.5" />
           </span>

--- a/client/src/components/store/StoreBundlesSection.tsx
+++ b/client/src/components/store/StoreBundlesSection.tsx
@@ -43,9 +43,9 @@ export function StoreBundlesSection({ isLoggedIn, onAddBundle }: StoreBundlesSec
                 {products.map((p) => (
                   <li key={p.id} className="flex items-center justify-between gap-3 text-sm">
                     <Link href={`/store/product/${p.sku}`}>
-                      <span className="text-white/80 hover:text-[#c4b5fd]">{p.name}</span>
+                      <span className="text-white/80 hover:text-de-accent-ink">{p.name}</span>
                     </Link>
-                    <span className="flex-shrink-0 text-white/45">{formatPrice(p)}</span>
+                    <span className="flex-shrink-0 text-white/55">{formatPrice(p)}</span>
                   </li>
                 ))}
               </ul>
@@ -53,7 +53,7 @@ export function StoreBundlesSection({ isLoggedIn, onAddBundle }: StoreBundlesSec
                 {onAddBundle && (
                   <Button
                     size="sm"
-                    className="bg-[#5034ff] text-white hover:bg-[#6548ff]"
+                    className="bg-de-accent text-white hover:bg-[#6548ff]"
                     onClick={() => onAddBundle(products.filter((p) => p.isCheckoutEnabled))}
                     data-testid={`button-add-bundle-${bundle.id}`}
                   >

--- a/client/src/components/store/StoreCatalogToolbar.tsx
+++ b/client/src/components/store/StoreCatalogToolbar.tsx
@@ -207,7 +207,7 @@ export function StoreCatalogToolbar({
         </Select>
 
         <div className="flex items-center gap-1.5">
-          <ArrowUpDown className="h-4 w-4 text-white/45" aria-hidden />
+          <ArrowUpDown className="h-4 w-4 text-white/55" aria-hidden />
           <Select value={sort} onValueChange={(v) => onSortChange(v as StoreSortOption)}>
             <SelectTrigger className={`${selectClass()} w-[180px]`} data-testid="select-sort">
               <SelectValue placeholder="Sort" />
@@ -223,7 +223,7 @@ export function StoreCatalogToolbar({
       </div>
 
       <div className="flex flex-wrap items-center gap-2.5 border-t border-white/10 pt-4">
-        <span className="text-sm text-white/45">Refine</span>
+        <span className="text-sm text-white/55">Refine</span>
         {onVendorChange && (
           <Select
             value={vendorValue}
@@ -353,12 +353,12 @@ export function StoreCatalogToolbar({
     >
       <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
         <div className="relative flex-1">
-          <Search className="pointer-events-none absolute left-3.5 top-1/2 h-5 w-5 -translate-y-1/2 text-white/40" />
+          <Search className="pointer-events-none absolute left-3.5 top-1/2 h-5 w-5 -translate-y-1/2 text-white/55" />
           <Input
             value={search}
             onChange={(e) => onSearchChange(e.target.value)}
             placeholder="Search within results (products, vendors, problems)"
-            className="h-12 border-white/15 bg-[#0a0a0a] pl-11 text-base text-white placeholder:text-white/35"
+            className="h-12 border-white/15 bg-[#0a0a0a] pl-11 text-base text-white placeholder:text-white/55"
             data-testid="input-store-search"
             aria-label="Search within catalog results"
           />
@@ -396,7 +396,7 @@ export function StoreCatalogToolbar({
               key={chip.key}
               type="button"
               onClick={chip.onClear}
-              className="inline-flex items-center gap-1.5 rounded-md border border-[#5034ff]/35 bg-[#5034ff]/15 px-2.5 py-1.5 text-sm text-[#c4b5fd] transition-colors hover:bg-[#5034ff]/25 hover:text-white"
+              className="inline-flex items-center gap-1.5 rounded-md border border-de-accent/35 bg-de-accent/15 px-2.5 py-1.5 text-sm text-de-accent-ink transition-colors hover:bg-de-accent/25 hover:text-white"
               data-testid={`chip-clear-${chip.key}`}
             >
               {chip.label}

--- a/client/src/components/store/StoreProductCard.tsx
+++ b/client/src/components/store/StoreProductCard.tsx
@@ -19,11 +19,20 @@ import {
 import { getProductVisual } from "@/data/productImages";
 import { ProductMedia } from "@/components/store/ProductMedia";
 
-/** Soft accent colors — pills only, not whole-card rainbow. */
-const categoryAccent: Record<ProductCategory, string> = {
+/**
+ * Soft accent colors — pills only, not whole-card rainbow.
+ *
+ * This is wayfinding, not decoration: every category has to stay tellable from
+ * every other one, so no two entries may share a hue. The pill also prints its
+ * category label, which keeps colour as reinforcement rather than the only
+ * channel. Violet, purple and indigo are deliberately absent — they read as the
+ * retired generic chrome. Colours here are exempt from the site accent sweep;
+ * see the store entry in scripts/brand-audit.mjs.
+ */
+export const categoryAccent: Record<ProductCategory, string> = {
   contract_services: "text-amber-300",
-  comanaged_subscriptions: "text-violet-300",
-  comanaged_onboarding: "text-purple-300",
+  comanaged_subscriptions: "text-teal-300",
+  comanaged_onboarding: "text-lime-300",
   networking_managed: "text-cyan-300",
   networking_projects: "text-sky-300",
   ucaas_subscriptions: "text-green-300",
@@ -32,9 +41,9 @@ const categoryAccent: Record<ProductCategory, string> = {
   hardware_physical: "text-rose-300",
   hardware_handling: "text-red-300",
   digital_assessments: "text-blue-300",
-  digital_templates: "text-indigo-300",
+  digital_templates: "text-yellow-300",
   digital_training: "text-fuchsia-300",
-  professional_services: "text-teal-300",
+  professional_services: "text-pink-300",
 };
 
 export interface StoreProductCardProps {
@@ -81,7 +90,7 @@ export function StoreProductCard({
 
   return (
     <article
-      className="relative flex h-full flex-col overflow-hidden rounded-2xl border border-white/10 bg-[#141414] transition-all duration-200 hover:border-[#5034ff]/35 hover:bg-[#171717]"
+      className="relative flex h-full flex-col overflow-hidden rounded-2xl border border-white/10 bg-[#141414] transition-all duration-200 hover:border-de-accent/35 hover:bg-[#171717]"
       data-testid={`product-${product.id}`}
     >
       {onCompareToggle && !isContract && (
@@ -91,7 +100,7 @@ export function StoreProductCard({
             checked={compareSelected}
             disabled={!compareSelected && compareDisabled}
             onChange={() => onCompareToggle(product)}
-            className="h-4 w-4 rounded border-white/30 bg-transparent accent-[#5034ff]"
+            className="h-4 w-4 rounded border-white/30 bg-transparent accent-de-accent"
             data-testid={`compare-check-${product.id}`}
           />
           Compare
@@ -116,12 +125,12 @@ export function StoreProductCard({
               </span>
             )}
             <span
-              className={`rounded-full border border-white/10 bg-white/[0.04] px-2.5 py-0.5 text-[11px] font-medium uppercase tracking-wide ${accent}`}
+              className={`de-store-category rounded-full border border-white/10 bg-white/[0.04] px-2.5 py-0.5 text-[11px] font-medium uppercase tracking-wide ${accent}`}
             >
               {categoryLabels[product.category]}
             </span>
             {product.isClientOnly && (
-              <span className="rounded-full border border-[#5034ff]/30 bg-[#5034ff]/15 px-2.5 py-0.5 text-[11px] font-medium text-[#c4b5fd]">
+              <span className="rounded-full border border-de-accent/30 bg-de-accent/15 px-2.5 py-0.5 text-[11px] font-medium text-de-accent-ink">
                 Client pricing
               </span>
             )}
@@ -135,7 +144,7 @@ export function StoreProductCard({
             className={`font-semibold leading-snug text-white ${compact ? "text-lg" : "text-xl md:text-2xl"}`}
           >
             <Link href={`/store/product/${product.sku}`}>
-              <span className="transition-colors hover:text-[#c4b5fd]" title={product.name}>
+              <span className="transition-colors hover:text-de-accent-ink" title={product.name}>
                 {product.name}
               </span>
             </Link>
@@ -152,12 +161,12 @@ export function StoreProductCard({
           <ul className="mb-4 space-y-2">
             {product.features.slice(0, 3).map((feature) => (
               <li key={feature} className="flex items-start gap-2 text-sm text-white/50">
-                <span className="mt-2 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-[#5034ff]/80" />
+                <span className="mt-2 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-de-accent/80" />
                 <span className="line-clamp-1">{feature}</span>
               </li>
             ))}
             {product.features.length > 3 && (
-              <li className="pl-3.5 text-sm text-white/40">+{product.features.length - 3} more</li>
+              <li className="pl-3.5 text-sm text-white/55">+{product.features.length - 3} more</li>
             )}
           </ul>
         )}
@@ -174,15 +183,15 @@ export function StoreProductCard({
         </div>
 
         {(includedHint || worksWithNames.length > 0 || relationships?.upgradeTo?.length) && (
-          <div className="mb-4 space-y-1 text-sm text-[#a78bfa]/90">
+          <div className="mb-4 space-y-1 text-sm text-de-accent-ink/90">
             {includedHint && (
               <p data-testid={`included-hint-${product.id}`}>{includedHint}</p>
             )}
             {worksWithNames.length > 0 && (
-              <p className="text-white/45">Works with: {worksWithNames.join(", ")}</p>
+              <p className="text-white/55">Works with: {worksWithNames.join(", ")}</p>
             )}
             {relationships?.upgradeTo?.[0] && (
-              <p className="text-white/45">
+              <p className="text-white/55">
                 Upgrade:{" "}
                 {getProductBySku(relationships.upgradeTo[0])?.name || relationships.upgradeTo[0]}
               </p>
@@ -198,11 +207,11 @@ export function StoreProductCard({
                   <span className="text-2xl font-bold text-white" data-testid={`price-${product.id}`}>
                     ${price.toFixed(2)}
                   </span>
-                  <span className="text-sm text-white/40 line-through">
+                  <span className="text-sm text-white/55 line-through">
                     ${product.basePrice.toFixed(2)}
                   </span>
                 </div>
-                <span className="mt-0.5 inline-flex items-center gap-1 text-sm text-[#a78bfa]">
+                <span className="mt-0.5 inline-flex items-center gap-1 text-sm text-de-accent-ink">
                   <Tag className="h-3.5 w-3.5" />
                   {discountPercent}% off
                 </span>
@@ -231,7 +240,7 @@ export function StoreProductCard({
               <a href="/book" className="flex-1">
                 <Button
                   size="sm"
-                  className="h-12 w-full bg-[#5034ff] text-base text-white hover:bg-[#6548ff]"
+                  className="h-12 w-full bg-de-accent text-base text-white hover:bg-[#6548ff]"
                   data-testid={`button-consult-${product.id}`}
                 >
                   Schedule
@@ -240,7 +249,7 @@ export function StoreProductCard({
             ) : product.isClientOnly && !isLoggedIn ? (
               <Button
                 size="sm"
-                className="h-12 flex-1 bg-[#5034ff] text-base text-white hover:bg-[#6548ff]"
+                className="h-12 flex-1 bg-de-accent text-base text-white hover:bg-[#6548ff]"
                 onClick={(e) => {
                   e.preventDefault();
                   onLoginRequired?.();
@@ -253,7 +262,7 @@ export function StoreProductCard({
             ) : configurable ? (
               <Button
                 size="sm"
-                className="h-12 flex-1 bg-[#5034ff] text-base text-white hover:bg-[#6548ff]"
+                className="h-12 flex-1 bg-de-accent text-base text-white hover:bg-[#6548ff]"
                 onClick={(e) => {
                   e.preventDefault();
                   onConfigure?.(product);
@@ -266,7 +275,7 @@ export function StoreProductCard({
             ) : (
               <Button
                 size="sm"
-                className="h-12 flex-1 bg-[#5034ff] text-base text-white hover:bg-[#6548ff]"
+                className="h-12 flex-1 bg-de-accent text-base text-white hover:bg-[#6548ff]"
                 onClick={(e) => onAddToCart(product, e)}
                 data-testid={`button-add-${product.id}`}
               >

--- a/client/src/components/store/StoreTrustStrip.tsx
+++ b/client/src/components/store/StoreTrustStrip.tsx
@@ -15,8 +15,8 @@ export function StoreTrustStrip() {
           const Icon = icons[i] ?? Shield;
           return (
             <li key={claim.label} className="flex items-start gap-3.5">
-              <div className="mt-0.5 flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-[#5034ff]/15 border border-[#5034ff]/25">
-                <Icon className="h-5 w-5 text-[#a78bfa]" />
+              <div className="mt-0.5 flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-de-accent/15 border border-de-accent/25">
+                <Icon className="h-5 w-5 text-de-accent-ink" />
               </div>
               <div>
                 <p className="text-base font-medium text-white">{claim.label}</p>

--- a/client/src/components/store/categoryAccent.test.ts
+++ b/client/src/components/store/categoryAccent.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { categoryAccent } from "./StoreProductCard";
+
+/**
+ * Store category pills are wayfinding, so two categories sharing a hue is a
+ * real defect rather than a cosmetic one. A site-wide colour sweep already
+ * collapsed three of these into a single accent once; these assertions make
+ * that fail loudly instead of shipping.
+ */
+describe("store category accents", () => {
+  const entries = Object.entries(categoryAccent);
+
+  it("gives every category its own hue", () => {
+    const hueOf = (token: string) => token.replace(/^text-/, "").replace(/-\d+$/, "");
+    const byHue = new Map<string, string[]>();
+
+    for (const [category, token] of entries) {
+      const hue = hueOf(token);
+      byHue.set(hue, [...(byHue.get(hue) ?? []), category]);
+    }
+
+    const shared = [...byHue.entries()].filter(([, categories]) => categories.length > 1);
+    expect(shared).toEqual([]);
+  });
+
+  it("never reaches for the retired violet chrome", () => {
+    const retired = entries.filter(([, token]) => /-(violet|purple|indigo)-/.test(token));
+    expect(retired).toEqual([]);
+  });
+
+  it("keeps the accents to text tokens so pills stay pills", () => {
+    const nonText = entries.filter(([, token]) => !/^text-[a-z]+-\d{3}$/.test(token));
+    expect(nonText).toEqual([]);
+  });
+});

--- a/client/src/components/ui/button.tsx
+++ b/client/src/components/ui/button.tsx
@@ -4,14 +4,14 @@ import * as React from "react";
 import { cn } from "../../lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 active:scale-[0.98]",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A] focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 active:scale-[0.98]",
   {
     variants: {
       variant: {
         default:
           "bg-primary text-primary-foreground shadow-md hover:bg-primary/90 hover:shadow-lg hover:-translate-y-0.5",
         brand:
-          "bg-gradient-to-r from-fuchsia-600 via-pink-600 to-rose-500 text-white border border-pink-300/30 shadow-lg shadow-pink-500/30 hover:from-fuchsia-500 hover:via-pink-500 hover:to-rose-400 hover:shadow-xl hover:shadow-pink-500/40 hover:-translate-y-0.5 focus-visible:ring-pink-400",
+          "bg-[#D3126A] text-white border-0 shadow-none hover:bg-[#e01874] hover:shadow-none focus-visible:ring-[#D3126A]",
         destructive:
           "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90 hover:shadow-md",
         outline:

--- a/client/src/components/ui/button.tsx
+++ b/client/src/components/ui/button.tsx
@@ -14,8 +14,12 @@ const buttonVariants = cva(
           "bg-[#D3126A] text-white border-0 shadow-none hover:bg-[#e01874] hover:shadow-none focus-visible:ring-[#D3126A]",
         destructive:
           "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90 hover:shadow-md",
+        // Transparent rather than bg-background: the filled variant is white,
+        // so every outline button a dark page styled with text-white rendered
+        // white-on-white and disappeared. Transparent works on both fields
+        // because the label keeps the surrounding text colour.
         outline:
-          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground hover:border-pink-400/50",
+          "border border-input bg-transparent hover:border-[#D3126A] hover:bg-[#D3126A]/10",
         secondary:
           "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80 hover:shadow-md",
         ghost: "hover:bg-accent hover:text-accent-foreground",

--- a/client/src/components/ui/card.tsx
+++ b/client/src/components/ui/card.tsx
@@ -8,7 +8,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-xl border bg-card text-card-foreground shadow transition-all duration-300 hover:shadow-lg hover:border-purple-400/20",
+      "rounded-xl border bg-card text-card-foreground shadow transition-all duration-300 hover:shadow-lg hover:border-de-accent/20",
       className,
     )}
     {...props}

--- a/client/src/components/ui/enhanced-input.tsx
+++ b/client/src/components/ui/enhanced-input.tsx
@@ -58,7 +58,7 @@ export const EnhancedInput = forwardRef<HTMLInputElement, EnhancedInputProps>(
             htmlFor={inputId}
             className={cn(
               "block text-sm font-medium transition-colors duration-200",
-              isFocused ? "text-violet-400" : "text-white/70",
+              isFocused ? "text-de-accent-ink" : "text-white/70",
               error && "text-red-400",
               disabled && "opacity-50"
             )}
@@ -73,7 +73,7 @@ export const EnhancedInput = forwardRef<HTMLInputElement, EnhancedInputProps>(
               className={cn(
                 "absolute left-3.5 top-1/2 -translate-y-1/2 pointer-events-none transition-colors duration-200",
                 iconSizeClasses[size],
-                isFocused ? "text-violet-400" : "text-white/30",
+                isFocused ? "text-de-accent-ink" : "text-white/30",
                 error && "text-red-400/70"
               )}
               aria-hidden="true"
@@ -92,7 +92,7 @@ export const EnhancedInput = forwardRef<HTMLInputElement, EnhancedInputProps>(
               sizeClasses[size],
               icon && "pl-11",
               (isPassword && showPasswordToggle) && "pr-11",
-              !error && !success && "border-white/10 hover:border-white/20 focus:border-violet-500/60 focus:ring-violet-500/30",
+              !error && !success && "border-white/10 hover:border-white/20 focus:border-de-accent/60 focus:ring-de-accent/30",
               error && "border-red-500/60 focus:border-red-500 focus:ring-red-500/30",
               success && "border-emerald-500/60 focus:border-emerald-500 focus:ring-emerald-500/30",
               disabled && "opacity-50 cursor-not-allowed",
@@ -122,7 +122,7 @@ export const EnhancedInput = forwardRef<HTMLInputElement, EnhancedInputProps>(
               className={cn(
                 "absolute right-3 top-1/2 -translate-y-1/2 p-1 rounded",
                 "text-white/40 hover:text-white/70 transition-colors",
-                "focus:outline-none focus:ring-2 focus:ring-violet-500/50"
+                "focus:outline-none focus:ring-2 focus:ring-de-accent/50"
               )}
               onClick={() => setShowPassword(!showPassword)}
               aria-label={showPassword ? "Hide password" : "Show password"}

--- a/client/src/components/ui/input.tsx
+++ b/client/src/components/ui/input.tsx
@@ -7,7 +7,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-all duration-200 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-500/50 focus-visible:border-purple-500 hover:border-purple-400/50 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-all duration-200 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-de-accent/50 focus-visible:border-de-accent hover:border-de-accent/50 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
           className,
         )}
         ref={ref}

--- a/client/src/components/ui/premium-slider.tsx
+++ b/client/src/components/ui/premium-slider.tsx
@@ -31,19 +31,16 @@ const PremiumSlider = React.forwardRef<
         <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-white/10">
           {/* Gradient range fill */}
           <SliderPrimitive.Range 
-            className="absolute h-full rounded-full"
-            style={{
-              background: "linear-gradient(90deg, #8b5cf6 0%, #a855f7 50%, #c026d3 100%)",
-            }}
+            className="absolute h-full rounded-full bg-de-accent"
           />
         </SliderPrimitive.Track>
         
         {/* Premium thumb with glow effect */}
         <SliderPrimitive.Thumb 
-          className="block h-5 w-5 rounded-full bg-white shadow-[0_0_0_3px_rgba(139,92,246,0.3),0_4px_12px_rgba(0,0,0,0.3)] 
+          className="block h-5 w-5 rounded-full bg-white shadow-[0_0_0_3px_rgb(var(--de-accent-rgb)/0.3),0_4px_12px_rgba(0,0,0,0.3)] 
                      ring-offset-background transition-all duration-200 
-                     focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 focus-visible:ring-offset-2 
-                     hover:scale-110 hover:shadow-[0_0_0_4px_rgba(139,92,246,0.4),0_6px_16px_rgba(0,0,0,0.4)]
+                     focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-de-accent focus-visible:ring-offset-2 
+                     hover:scale-110 hover:shadow-[0_0_0_4px_rgb(var(--de-accent-rgb)/0.4),0_6px_16px_rgba(0,0,0,0.4)]
                      disabled:pointer-events-none disabled:opacity-50
                      cursor-grab active:cursor-grabbing"
         />
@@ -52,7 +49,7 @@ const PremiumSlider = React.forwardRef<
       {/* Optional floating value indicator */}
       {showValue && (
         <div 
-          className="absolute -top-6 text-xs font-medium text-violet-400 transition-all duration-200"
+          className="absolute -top-6 text-xs font-medium text-de-accent-ink transition-all duration-200"
           style={{ left: `calc(${percentage}% - 12px)` }}
         >
           {valuePrefix}{value}{valueSuffix}

--- a/client/src/components/ui/textarea.tsx
+++ b/client/src/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<
   return (
     <textarea
       className={cn(
-        "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-500/50 focus-visible:border-purple-500 hover:border-purple-400/50 transition-all duration-200 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-de-accent/50 focus-visible:border-de-accent hover:border-de-accent/50 transition-all duration-200 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         className
       )}
       ref={ref}

--- a/client/src/components/visual/MeshyStillAccent.tsx
+++ b/client/src/components/visual/MeshyStillAccent.tsx
@@ -38,8 +38,8 @@ export function MeshyStillAccent({
   const s = sizeMap[size];
   const frameClass =
     surface === "dark"
-      ? "rounded-xl border border-white/10 bg-gradient-to-br from-violet-500/10 via-fuchsia-500/[0.06] to-transparent"
-      : "rounded-xl border border-violet-200/70 bg-gradient-to-br from-violet-50 via-white to-fuchsia-50/50";
+      ? "rounded-xl border border-white/10 bg-gradient-to-br  via-fuchsia-500/[0.06] to-transparent"
+      : "rounded-xl border border-de-hairline bg-gradient-to-br  via-white to-fuchsia-50/50";
 
   return (
     <div

--- a/client/src/components/visual/SectionVisualStage.tsx
+++ b/client/src/components/visual/SectionVisualStage.tsx
@@ -42,8 +42,8 @@ export function SectionVisualStage({
   const s = sizeMap[size];
   const framed =
     surface === "dark"
-      ? "border-white/10 bg-gradient-to-br from-violet-500/15 via-fuchsia-500/[0.07] to-transparent shadow-[0_0_60px_-20px_rgba(168,85,247,0.45)]"
-      : "border-violet-200/80 bg-gradient-to-br from-violet-50 via-white to-fuchsia-50/60 shadow-lg shadow-violet-500/10";
+      ? "border-white/10 bg-gradient-to-br  via-fuchsia-500/[0.07] to-transparent shadow-[0_0_60px_-20px_rgba(168,85,247,0.45)]"
+      : "border-de-hairline bg-gradient-to-br  via-white to-fuchsia-50/60 shadow-lg shadow-none";
 
   return (
     <div

--- a/client/src/data/storeMerchandising.ts
+++ b/client/src/data/storeMerchandising.ts
@@ -192,7 +192,7 @@ export const storeOutcomes: StoreOutcome[] = [
       "DE-SVC-COMANAGED-CUSTOM-MO",
     ],
     keywords: ["managed", "outsource", "msp", "proactive", "full service", "ecosystem"],
-    accent: "text-violet-300",
+    accent: "text-lime-300",
   },
   {
     id: "secure_remote",

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -137,6 +137,14 @@ html {
   --de-accent: #ec4899;
   --de-accent-2: #d946ef;
   --de-magenta: #D3126A;
+  /*
+   * Brand magenta only reaches ~3.6:1 on the dark ladder, which clears WCAG's
+   * 3:1 bar for icons and large headings but fails the 4.5:1 bar for body-size
+   * text and inline links. This lighter tint holds the same hue and clears
+   * 4.5:1 on --de-bg, --de-surface, and --de-raised. Fills stay --de-magenta;
+   * this is for small text on dark only.
+   */
+  --de-magenta-ink: #F04C97;
   --de-violet: #5B45E0;
 
   /*
@@ -548,7 +556,7 @@ textarea:focus-visible {
   left: 50%;
   transform: translateX(-50%);
   padding: 0.75rem 1.5rem;
-  background: rgb(139, 92, 246);
+  background: var(--de-magenta);
   color: white;
   font-weight: 600;
   border-radius: 0 0 8px 8px;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -138,14 +138,6 @@ html {
   --de-accent-2: #d946ef;
   --de-magenta: #D3126A;
   --de-violet: #5B45E0;
-  --de-brand-energy: linear-gradient(
-    90deg,
-    #5b45e0 0%,
-    #8b3ad4 16%,
-    #d3126a 48%,
-    #e11d5a 74%,
-    #fb7185 100%
-  );
 
   /*
    * Contained marketing canvas — black outer gutters on ultrawide only.
@@ -457,14 +449,18 @@ html.de-marketing-canvas body {
   }
 }
 
-/* Homepage statement band — violet → magenta → coral. Not a page-wide wash. */
-.de-brand-energy-band {
-  background-color: #d3126a;
+/*
+ * Homepage process band — a charcoal slab that separates the paper "what we
+ * protect" chapter from the proof well below. Violet and magenta appear only as
+ * lighting so the magenta step numerals stay the brightest thing in the band.
+ */
+.de-process-band {
+  background-color: var(--de-surface);
   background-image:
-    radial-gradient(ellipse 36% 90% at 22% -18%, rgba(255, 255, 255, 0.42) 0%, transparent 58%),
-    radial-gradient(circle 4.5rem at 16% 10%, rgba(255, 255, 255, 0.28) 0%, transparent 68%),
-    radial-gradient(circle 2.75rem at 30% 6%, rgba(255, 255, 255, 0.2) 0%, transparent 70%),
-    var(--de-brand-energy);
+    radial-gradient(ellipse 42% 120% at 16% -30%, rgba(91, 69, 224, 0.22) 0%, transparent 62%),
+    radial-gradient(ellipse 34% 110% at 88% -24%, rgba(211, 18, 106, 0.14) 0%, transparent 60%);
+  border-top: 1px solid var(--de-hairline);
+  border-bottom: 1px solid var(--de-hairline);
 }
 
 /* Primary nav labels must never crop glyphs when type/logo scale up */

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -134,8 +134,6 @@ html {
   --de-fg: #ffffff;
   --de-muted: rgba(255, 255, 255, 0.85);
   --de-muted-soft: rgba(255, 255, 255, 0.72);
-  --de-accent: #ec4899;
-  --de-accent-2: #d946ef;
   --de-magenta: #D3126A;
   /*
    * Brand magenta only reaches ~3.6:1 on the dark ladder, which clears WCAG's
@@ -146,6 +144,22 @@ html {
    */
   --de-magenta-ink: #F04C97;
   --de-violet: #5B45E0;
+
+  /*
+   * Per-page accent. The field, type, spacing and primary CTA stay identical
+   * sitewide; this is the one hue a page family is allowed to own, and it is
+   * only ever used for topical signals — eyebrows, glyphs, step numerals,
+   * category chips, inline links. Pages opt in with data-accent on their root.
+   *
+   * Every `-ink` value clears 4.5:1 on --de-bg / --de-surface / --de-raised.
+   * Violet and indigo are deliberately absent: they read as the old generic
+   * chrome and the accent-pop rule bars them as fills.
+   *
+   * Held as raw channels so Tailwind's alpha modifiers work: the catalog leans
+   * on bg-de-accent/10 and border-de-accent/30, which a hex var cannot express.
+   */
+  --de-accent-rgb: 211 18 106;
+  --de-accent-ink-rgb: 240 76 151;
 
   /*
    * Contained marketing canvas — black outer gutters on ultrawide only.
@@ -462,6 +476,42 @@ html.de-marketing-canvas body {
  * protect" chapter from the proof well below. Violet and magenta appear only as
  * lighting so the magenta step numerals stay the brightest thing in the band.
  */
+/*
+ * Approved page accents. Only these five; violet and indigo are deliberately
+ * absent because they read as the old generic chrome and the accent-pop rule
+ * bars them as fills.
+ */
+[data-accent="magenta"] {
+  --de-accent-rgb: 211 18 106;
+  --de-accent-ink-rgb: 240 76 151;
+}
+[data-accent="cyan"] {
+  --de-accent-rgb: 8 145 178;
+  --de-accent-ink-rgb: 34 211 238;
+}
+[data-accent="amber"] {
+  --de-accent-rgb: 180 83 9;
+  --de-accent-ink-rgb: 251 191 36;
+}
+[data-accent="emerald"] {
+  --de-accent-rgb: 4 120 87;
+  --de-accent-ink-rgb: 52 211 153;
+}
+[data-accent="rose"] {
+  --de-accent-rgb: 190 18 60;
+  --de-accent-ink-rgb: 251 113 133;
+}
+/*
+ * Electric blue is the Store. It is close to the legacy #5034ff the catalog was
+ * already built in, so the store keeps the identity it had instead of being
+ * repainted — but as a token, and pulled off the indigo edge that reads as the
+ * retired chrome.
+ */
+[data-accent="electric"] {
+  --de-accent-rgb: 29 111 242;
+  --de-accent-ink-rgb: 111 179 255;
+}
+
 .de-process-band {
   background-color: var(--de-surface);
   background-image:
@@ -632,7 +682,7 @@ textarea:focus-visible {
 
 .hover-lift:hover {
   transform: translateY(-4px);
-  box-shadow: 0 12px 40px -12px rgba(139, 92, 246, 0.3);
+  box-shadow: 0 12px 40px -12px rgb(var(--de-accent-rgb) / 0.3);
 }
 
 .hover-glow {
@@ -640,17 +690,15 @@ textarea:focus-visible {
 }
 
 .hover-glow:hover {
-  box-shadow: 0 0 30px rgba(139, 92, 246, 0.3);
+  box-shadow: 0 0 30px rgb(var(--de-accent-rgb) / 0.3);
 }
 
 /* Text gradient animation */
 .text-gradient-animate {
-  background: linear-gradient(90deg, #a78bfa, #c084fc, #e879f9, #c084fc, #a78bfa);
-  background-size: 300% 100%;
+  background: var(--de-magenta);
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
-  animation: gradient-shift 4s ease infinite;
 }
 
 /* Glassmorphism utilities */
@@ -683,7 +731,7 @@ textarea:focus-visible {
   left: var(--de-canvas-gutter, 0px);
   width: calc(100vw - (2 * var(--de-canvas-gutter, 0px)));
   height: 3px;
-  background: linear-gradient(90deg, #8b5cf6, #a855f7);
+  background: var(--de-magenta);
   z-index: 9999;
   transform-origin: left;
   transition: transform 0.1s ease-out;
@@ -716,8 +764,8 @@ textarea:focus-visible {
 
 .card-interactive:hover {
   transform: translateY(-2px);
-  border-color: rgba(139, 92, 246, 0.3);
-  box-shadow: 0 8px 30px -12px rgba(139, 92, 246, 0.25);
+  border-color: rgb(var(--de-accent-rgb) / 0.3);
+  box-shadow: 0 8px 30px -12px rgb(var(--de-accent-rgb) / 0.25);
 }
 
 .card-interactive:active {
@@ -730,7 +778,7 @@ textarea:focus-visible {
 }
 
 .focus-ring:focus-visible {
-  outline: 2px solid rgb(139, 92, 246);
+  outline: 2px solid rgb(var(--de-accent-rgb) / 1);
   outline-offset: 2px;
   border-radius: 4px;
 }
@@ -747,7 +795,7 @@ textarea:focus-visible {
   left: 0;
   width: 0;
   height: 2px;
-  background: linear-gradient(90deg, #8b5cf6, #a855f7);
+  background: var(--de-magenta);
   transition: width 0.3s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
@@ -1404,8 +1452,8 @@ button, [role="button"], a {
   @apply scale-105 z-10;
   color: #ffffff;
   background: transparent;
-  border-color: var(--c1, rgba(139, 92, 246, 1));
-  box-shadow: 0 0 16px color-mix(in srgb, var(--c1, #8b5cf6) 25%, transparent 75%);
+  border-color: var(--c1, var(--de-magenta));
+  box-shadow: 0 0 16px color-mix(in srgb, var(--c1, var(--de-magenta)) 25%, transparent 75%);
 }
 
 .honeycomb-grid {

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -178,14 +178,14 @@ export function Dashboard() {
       <aside className="w-64 bg-white border-r border-slate-200 flex flex-col">
         <div className="p-4 border-b border-slate-200">
           <div className="flex items-center justify-between mb-4">
-            <h1 className="text-xl font-bold bg-gradient-to-r from-indigo-600 to-purple-600 bg-clip-text text-transparent">
+            <h1 className="text-xl font-bold text-de-accent-ink">
               TaskFlow
             </h1>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button variant="ghost" size="icon">
                   <Avatar className="h-8 w-8">
-                    <AvatarFallback className="bg-indigo-100 text-indigo-600">
+                    <AvatarFallback className="bg-de-paper-raised text-de-accent">
                       {user?.username?.[0]?.toUpperCase() || 'U'}
                     </AvatarFallback>
                   </Avatar>
@@ -293,7 +293,7 @@ export function Dashboard() {
                 onClick={() => setCurrentProjectId(project.id)}
                 className={`w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors ${
                   currentProjectId === project.id
-                    ? "bg-indigo-50 text-indigo-600 font-medium"
+                    ? "bg-de-paper-raised text-de-accent font-medium"
                     : "text-slate-700 hover:bg-slate-100"
                 }`}
               >

--- a/client/src/pages/Ecosystem.tsx
+++ b/client/src/pages/Ecosystem.tsx
@@ -81,7 +81,7 @@ export default function Ecosystem() {
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6 }}
         >
-          <h1 className="text-4xl md:text-5xl font-bold mb-4 bg-gradient-to-r from-white via-purple-200 to-cyan-200 bg-clip-text text-transparent">
+          <h1 className="text-4xl md:text-5xl font-bold mb-4 text-white">
             ProActive Ecosystem
           </h1>
           <p className="text-xl text-gray-300 max-w-3xl mx-auto">
@@ -104,8 +104,8 @@ export default function Ecosystem() {
                   key={pillar.name}
                   className="rounded-2xl p-6 bg-white/5 backdrop-blur-xl border border-white/10 hover:border-white/20 hover:bg-white/[0.08] transition-all duration-300"
                 >
-                  <div className={`inline-flex items-center justify-center w-12 h-12 rounded-xl bg-gradient-to-br ${pillar.color} mb-4`}>
-                    <Icon className="w-6 h-6 text-white" />
+                  <div className={`inline-flex items-center justify-center w-12 h-12 rounded-xl border border-de-hairline bg-de-bg mb-4`}>
+                    <Icon className="w-6 h-6 text-de-magenta" />
                   </div>
                   <h3 className="text-lg font-bold text-white mb-2">{pillar.name}</h3>
                   <p className="text-sm text-gray-400 mb-4">{pillar.desc}</p>
@@ -135,7 +135,7 @@ export default function Ecosystem() {
                 key={tier.name}
                 className="rounded-2xl p-8 bg-white/5 backdrop-blur-xl border border-white/10 hover:border-white/20 transition-all duration-300 flex flex-col"
               >
-                <div className={`inline-block px-4 py-1.5 rounded-lg bg-gradient-to-r ${tier.color} text-white text-sm font-bold mb-4 w-fit`}>
+                <div className={`inline-block px-4 py-1.5 rounded-lg bg-de-magenta text-white text-sm font-bold mb-4 w-fit`}>
                   {tier.name}
                 </div>
                 <div className="mb-4">

--- a/client/src/pages/Ecosystem.tsx
+++ b/client/src/pages/Ecosystem.tsx
@@ -6,7 +6,7 @@ export default function Ecosystem() {
   const servicePillars = [
     { 
       name: "DE WORKPLACE", 
-      color: "from-purple-600 to-indigo-600", 
+      color: " ", 
       icon: Users,
       desc: "SMART HR · SMART Identity · SMART Communications · Team Collaboration",
       details: ["Email + Calendar + Chat", "MFA + SSO + Password Manager", "UCaaS + Video Conferencing", "File Storage + Wiki + Projects"]
@@ -41,7 +41,7 @@ export default function Ecosystem() {
     },
     { 
       name: "DE COMPLIANCE", 
-      color: "from-violet-600 to-purple-600", 
+      color: " ", 
       icon: FileCheck,
       desc: "HIPAA · GDPR · FTC Safeguards · Cyber Insurance · Policy Enforcement",
       details: ["Compliance Modules", "Evidence Support", "Audit-Ready Documentation", "Framework Mapping"]
@@ -58,7 +58,7 @@ export default function Ecosystem() {
     },
     { 
       name: pricing.business.name, 
-      color: "from-purple-600 to-violet-600", 
+      color: " ", 
       price: `$${pricing.business.user}`,
       desc: "SOC/MDR + SMART HR + vCIO advisory",
       highlights: ["Everything in Office", "SOC / MDR Monitoring", "SMART HR Workflows", "Security Awareness + vCIO"]
@@ -111,7 +111,7 @@ export default function Ecosystem() {
                   <p className="text-sm text-gray-400 mb-4">{pillar.desc}</p>
                   <ul className="space-y-1">
                     {pillar.details.map((detail, idx) => (
-                      <li key={idx} className="text-xs text-gray-500 flex items-center gap-2">
+                      <li key={idx} className="text-xs text-white/70 flex items-center gap-2">
                         <span className="w-1 h-1 rounded-full bg-cyan-400" />
                         {detail}
                       </li>
@@ -163,7 +163,7 @@ export default function Ecosystem() {
         </motion.div>
 
         <motion.p 
-          className="text-center text-sm text-gray-500 mt-12"
+          className="text-center text-sm text-white/70 mt-12"
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           transition={{ delay: 0.6 }}

--- a/client/src/pages/EcosystemMatrixOfficial.tsx
+++ b/client/src/pages/EcosystemMatrixOfficial.tsx
@@ -97,7 +97,7 @@ export default function EcosystemMatrixOfficial() {
     const isPro = typeof value === 'string' && (value.includes("VIP") || value.includes("MDR") || value.includes("Full"));
     
     return (
-      <Badge variant="outline" className={`${isPro ? 'border-violet-500 text-violet-300 bg-violet-500/10' : 'border-white/10 text-white/70 bg-white/5'}`}>
+      <Badge variant="outline" className={`${isPro ? 'border-de-hairline text-de-magenta-ink bg-de-raised' : 'border-white/10 text-white/70 bg-white/5'}`}>
         {value}
       </Badge>
     );
@@ -125,23 +125,23 @@ export default function EcosystemMatrixOfficial() {
         {/* HERO */}
         <div className="mb-12 flex flex-col md:flex-row md:items-end justify-between gap-6">
           <div>
-            <h1 className="text-4xl font-black tracking-tight mb-2 bg-gradient-to-r from-violet-400 to-fuchsia-400 bg-clip-text text-transparent">
+            <h1 className="text-4xl font-black tracking-tight mb-2 text-de-magenta-ink">
               Digerati Experts — Service Matrix
             </h1>
             <p className="text-white/60 text-lg">Security-First IT bundles · Compare tiers · Explore add-ons</p>
             <div className="flex gap-4 mt-4 text-sm font-medium">
               <span className="flex items-center gap-1.5"><span className="w-2 h-2 rounded-full bg-emerald-400"></span> Included</span>
-              <span className="flex items-center gap-1.5"><span className="w-2 h-2 rounded-full bg-violet-400"></span> Premium</span>
+              <span className="flex items-center gap-1.5"><span className="w-2 h-2 rounded-full bg-de-magenta"></span> Premium</span>
               <span className="flex items-center gap-1.5"><span className="w-2 h-2 rounded-full bg-white/20"></span> N/A</span>
             </div>
           </div>
 
           <div className="flex flex-col gap-3">
             <div className="relative w-full md:w-80">
-              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-white/40" />
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-white/55" />
               <Input 
                 placeholder="Search features..." 
-                className="pl-10 bg-white/5 border-white/10 focus:border-violet-500/50"
+                className="pl-10 bg-white/5 border-white/10 focus:border-de-hairline"
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
               />
@@ -150,7 +150,7 @@ export default function EcosystemMatrixOfficial() {
               <Button 
                 variant={showUpgrades ? "default" : "outline"}
                 size="sm"
-                className={showUpgrades ? "bg-violet-600" : "border-white/10"}
+                className={showUpgrades ? "bg-de-magenta" : "border-white/10"}
                 onClick={() => setShowUpgrades(!showUpgrades)}
               >
                 <Zap className="w-4 h-4 mr-2" /> Highlight Upgrades
@@ -186,26 +186,26 @@ export default function EcosystemMatrixOfficial() {
 
         {/* TIERS HEADER */}
         <div className="grid grid-cols-5 gap-4 mb-6 sticky top-0 z-40 bg-[#0a0a0f]/80 backdrop-blur-md py-4 border-b border-white/10">
-          <div className="text-white/40 font-bold uppercase text-xs self-center">Capability</div>
+          <div className="text-white/55 font-bold uppercase text-xs self-center">Capability</div>
           <div className="p-4 rounded-xl bg-white/5 border border-white/10 text-center">
             <Badge variant="secondary" className="mb-2 bg-slate-500/20 text-slate-400">IT</Badge>
             <h3 className="font-bold text-lg">IT</h3>
             <p className="text-xs text-white/50">${pricing.it.user} /user·mo</p>
           </div>
           <div className="p-4 rounded-xl bg-white/5 border border-white/10 text-center">
-            <Badge variant="secondary" className="mb-2 bg-violet-500/20 text-violet-400">Office</Badge>
-            <h3 className="font-bold text-lg text-violet-300">Office</h3>
-            <p className="text-xs text-violet-400/60">${pricing.office.user} /user·mo</p>
+            <Badge variant="secondary" className="mb-2 bg-de-raised text-de-magenta-ink">Office</Badge>
+            <h3 className="font-bold text-lg text-de-magenta-ink">Office</h3>
+            <p className="text-xs text-de-magenta-ink/60">${pricing.office.user} /user·mo</p>
           </div>
           <div className="p-4 rounded-xl bg-white/5 border border-white/10 text-center">
             <Badge variant="secondary" className="mb-2 bg-fuchsia-500/20 text-fuchsia-400">Business</Badge>
             <h3 className="font-bold text-lg text-fuchsia-300">Business</h3>
             <p className="text-xs text-fuchsia-400/60">${pricing.business.user} /user·mo</p>
           </div>
-          <div className="p-4 rounded-xl bg-purple-500/10 border border-purple-500/20 text-center">
-            <Badge variant="secondary" className="mb-2 bg-purple-500/20 text-purple-400">Custom</Badge>
-            <h3 className="font-bold text-lg text-purple-300">Enterprise</h3>
-            <p className="text-xs text-purple-400/60">Multi-site + MDR</p>
+          <div className="p-4 rounded-xl bg-de-raised border border-de-hairline text-center">
+            <Badge variant="secondary" className="mb-2 bg-de-raised text-de-magenta-ink">Custom</Badge>
+            <h3 className="font-bold text-lg text-de-magenta-ink">Enterprise</h3>
+            <p className="text-xs text-de-magenta-ink/60">Multi-site + MDR</p>
           </div>
         </div>
 
@@ -218,10 +218,10 @@ export default function EcosystemMatrixOfficial() {
                 onClick={() => toggleSection(section.id)}
               >
                 <h2 className="text-xl font-bold flex items-center gap-2">
-                  <span className="w-1.5 h-6 bg-violet-500 rounded-full"></span>
+                  <span className="w-1.5 h-6 bg-de-magenta rounded-full"></span>
                   {section.title}
                 </h2>
-                <ChevronDown className={`w-5 h-5 text-white/40 transition-transform ${expandedSections.includes(section.id) ? "" : "-rotate-90"}`} />
+                <ChevronDown className={`w-5 h-5 text-white/55 transition-transform ${expandedSections.includes(section.id) ? "" : "-rotate-90"}`} />
               </button>
               
               {expandedSections.includes(section.id) && (
@@ -229,13 +229,13 @@ export default function EcosystemMatrixOfficial() {
                   {section.features.map((feature, idx) => (
                     <div 
                       key={idx} 
-                      className={`grid grid-cols-5 gap-4 items-center transition-all ${density === "compact" ? "py-2 px-4" : "py-4 px-4"} ${showUpgrades && feature.isUpgrade ? "bg-violet-500/5 ring-1 ring-inset ring-violet-500/20" : "hover:bg-white/[0.01]"}`}
+                      className={`grid grid-cols-5 gap-4 items-center transition-all ${density === "compact" ? "py-2 px-4" : "py-4 px-4"} ${showUpgrades && feature.isUpgrade ? "bg-de-raised ring-1 ring-inset ring-violet-500/20" : "hover:bg-white/[0.01]"}`}
                     >
                       <div className="flex items-center gap-2 group">
                         <span className="text-sm font-medium text-white/80 group-hover:text-white transition-colors">{feature.name}</span>
                         <TooltipProvider>
                           <Tooltip>
-                            <TooltipTrigger><Info className="w-3.5 h-3.5 text-white/20 hover:text-white/40" /></TooltipTrigger>
+                            <TooltipTrigger><Info className="w-3.5 h-3.5 text-white/20 hover:text-white/55" /></TooltipTrigger>
                             <TooltipContent><p className="max-w-xs text-xs">Standard industry definition for {feature.name}.</p></TooltipContent>
                           </Tooltip>
                         </TooltipProvider>
@@ -253,13 +253,13 @@ export default function EcosystemMatrixOfficial() {
         </div>
 
         {/* FOOTER NOTE */}
-        <div className="mt-12 p-6 rounded-2xl bg-gradient-to-br from-violet-500/10 to-transparent border border-white/10 text-center">
-          <p className="text-white/40 text-sm">
+        <div className="mt-12 p-6 rounded-2xl bg-de-raised to-transparent border border-white/10 text-center">
+          <p className="text-white/55 text-sm">
             {`Minimum billing: Office $${pricing.office.siteMin}/site/mo; Business $${pricing.business.siteMin.toLocaleString()}/site/mo; Enterprise $${pricing.enterprise.siteMin.toLocaleString()}/site/mo.`} 
             Billing rule: Minimums apply when per-user total &lt; minimum.
           </p>
           <div className="mt-6 flex justify-center gap-4">
-            <Button className="bg-violet-600 hover:bg-violet-700">Book Technical Assessment</Button>
+            <Button className="bg-de-magenta hover:bg-de-magenta">Book Technical Assessment</Button>
             <Button variant="outline" className="border-white/10">Download PDF Matrix</Button>
           </div>
         </div>

--- a/client/src/pages/EcosystemMatrixOfficial.tsx
+++ b/client/src/pages/EcosystemMatrixOfficial.tsx
@@ -229,7 +229,7 @@ export default function EcosystemMatrixOfficial() {
                   {section.features.map((feature, idx) => (
                     <div 
                       key={idx} 
-                      className={`grid grid-cols-5 gap-4 items-center transition-all ${density === "compact" ? "py-2 px-4" : "py-4 px-4"} ${showUpgrades && feature.isUpgrade ? "bg-de-raised ring-1 ring-inset ring-violet-500/20" : "hover:bg-white/[0.01]"}`}
+                      className={`grid grid-cols-5 gap-4 items-center transition-all ${density === "compact" ? "py-2 px-4" : "py-4 px-4"} ${showUpgrades && feature.isUpgrade ? "bg-de-raised ring-1 ring-inset ring-de-accent" : "hover:bg-white/[0.01]"}`}
                     >
                       <div className="flex items-center gap-2 group">
                         <span className="text-sm font-medium text-white/80 group-hover:text-white transition-colors">{feature.name}</span>

--- a/client/src/pages/EcosystemPricing.tsx
+++ b/client/src/pages/EcosystemPricing.tsx
@@ -130,7 +130,7 @@ const tiers = [
     subtitle: `Starting at $${pricing.office.user} /user·mo*`,
     ribbon: "Foundation",
     gradient: "from-violet-500 to-purple-500",
-    borderColor: "border-violet-500/30"
+    borderColor: "border-de-hairline"
   },
   { 
     id: "business", 
@@ -193,7 +193,7 @@ const EcosystemPricing = () => {
     }
     if (value === "Optional") {
       return (
-        <span className="px-2 py-1 rounded-full text-xs font-medium bg-violet-500/20 text-violet-300 border border-violet-500/30">
+        <span className="px-2 py-1 rounded-full text-xs font-medium bg-de-raised text-de-magenta-ink border border-de-hairline">
           Optional
         </span>
       );
@@ -204,7 +204,7 @@ const EcosystemPricing = () => {
       <span className={`px-2 py-1 rounded-full text-xs font-medium ${
         isPro 
           ? 'bg-emerald-500/20 text-emerald-300 border border-emerald-500/30' 
-          : 'bg-violet-500/20 text-violet-300 border border-violet-500/30'
+          : 'bg-de-raised text-de-magenta-ink border border-de-hairline'
       }`}>
         {value}
       </span>
@@ -237,7 +237,7 @@ const EcosystemPricing = () => {
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5 }}
           >
-            <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-violet-500/10 border border-violet-500/30 text-violet-300 text-sm font-medium mb-4">
+            <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-de-raised border border-de-hairline text-de-magenta-ink text-sm font-medium mb-4">
               <Shield className="w-4 h-4" />
               <span>Security-First IT Bundles</span>
             </div>
@@ -255,7 +255,7 @@ const EcosystemPricing = () => {
                 <span className="text-white/60">Included / ✓</span>
               </div>
               <div className="flex items-center gap-2">
-                <span className="w-3 h-3 rounded-full bg-violet-400"></span>
+                <span className="w-3 h-3 rounded-full bg-de-magenta"></span>
                 <span className="text-white/60">Premium / Pro</span>
               </div>
               <div className="flex items-center gap-2">
@@ -271,7 +271,7 @@ const EcosystemPricing = () => {
               size="sm"
               onClick={() => setHighlightUpgrades(!highlightUpgrades)}
               className={highlightUpgrades 
-                ? "bg-violet-600 hover:bg-violet-700 text-white" 
+                ? "bg-de-magenta hover:bg-de-magenta text-white" 
                 : "bg-white/10 border border-white/20 text-white hover:bg-white/20"}
               data-testid="btn-highlight-upgrades"
             >
@@ -300,7 +300,7 @@ const EcosystemPricing = () => {
           <div className="sticky top-16 z-20 bg-[#0a0a0f]/95 backdrop-blur-xl border-b border-white/10 mb-6 -mx-4 px-4 sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8">
             <div className="max-w-[1600px] mx-auto">
               <div className="grid grid-cols-5 gap-2 py-4">
-                <div className="text-white/40 text-sm font-medium flex items-center">
+                <div className="text-white/55 text-sm font-medium flex items-center">
                   Capability
                 </div>
                 {tiers.map((tier, index) => (
@@ -309,7 +309,7 @@ const EcosystemPricing = () => {
                     className={`text-center p-3 rounded-xl border ${tier.borderColor} bg-white/[0.02]`}
                     data-testid={`tier-header-${tier.id}`}
                   >
-                    <div className={`text-xs font-semibold text-transparent bg-clip-text bg-gradient-to-r ${tier.gradient} uppercase tracking-wide mb-1`}>
+                    <div className={`text-xs font-semibold text-de-magenta-ink uppercase tracking-wide mb-1`}>
                       {tier.ribbon}
                     </div>
                     <h3 className="text-white font-bold text-sm md:text-base">{tier.name}</h3>
@@ -347,17 +347,17 @@ const EcosystemPricing = () => {
                     data-testid={`btn-toggle-${category.id}`}
                   >
                     <div className="flex items-center gap-3">
-                      <div className="w-10 h-10 rounded-xl bg-violet-500/20 flex items-center justify-center text-violet-400">
+                      <div className="w-10 h-10 rounded-xl bg-de-raised flex items-center justify-center text-de-magenta-ink">
                         {category.icon}
                       </div>
                       <span className="text-white font-bold text-lg">{category.title}</span>
-                      <span className="text-white/40 text-sm">({category.rows.length})</span>
+                      <span className="text-white/55 text-sm">({category.rows.length})</span>
                     </div>
                     <div className="flex items-center gap-2">
                       {isExpanded ? (
-                        <ChevronUp className="w-5 h-5 text-white/40" />
+                        <ChevronUp className="w-5 h-5 text-white/55" />
                       ) : (
-                        <ChevronDown className="w-5 h-5 text-white/40" />
+                        <ChevronDown className="w-5 h-5 text-white/55" />
                       )}
                     </div>
                   </button>
@@ -415,7 +415,7 @@ const EcosystemPricing = () => {
             <div className="flex flex-wrap justify-center gap-4">
               <a href="/book">
                 <Button 
-                  className="bg-gradient-to-r from-violet-600 to-purple-600 hover:from-violet-700 hover:to-purple-700 text-white"
+                  className="bg-de-raised hover:from-violet-700 hover:to-purple-700 text-white"
                   data-testid="btn-book-call"
                 >
                   <Phone className="w-4 h-4 mr-2" />

--- a/client/src/pages/EcosystemPricing.tsx
+++ b/client/src/pages/EcosystemPricing.tsx
@@ -129,7 +129,7 @@ const tiers = [
     name: "ProActive Office", 
     subtitle: `Starting at $${pricing.office.user} /user·mo*`,
     ribbon: "Foundation",
-    gradient: "from-violet-500 to-purple-500",
+    gradient: " ",
     borderColor: "border-de-hairline"
   },
   { 
@@ -181,7 +181,7 @@ const EcosystemPricing = () => {
     }
     if (value === false) {
       return (
-        <span className="text-white/30">—</span>
+        <span className="text-white/55">—</span>
       );
     }
     if (value === "Add-on") {
@@ -415,7 +415,7 @@ const EcosystemPricing = () => {
             <div className="flex flex-wrap justify-center gap-4">
               <a href="/book">
                 <Button 
-                  className="bg-de-raised hover:from-violet-700 hover:to-purple-700 text-white"
+                  className="bg-de-raised hover: hover: text-white"
                   data-testid="btn-book-call"
                 >
                   <Phone className="w-4 h-4 mr-2" />

--- a/client/src/pages/GenericServicePage.tsx
+++ b/client/src/pages/GenericServicePage.tsx
@@ -83,7 +83,7 @@ export default function GenericServicePage({
   description,
   features,
   benefits,
-  gradientColors = "from-[#D3126A] via-fuchsia-700 to-violet-800",
+  gradientColors = "from-[#050312] via-[#0a0a0a] to-[#050312]",
   stat,
   canonical,
   recommendedTier,
@@ -200,7 +200,7 @@ export default function GenericServicePage({
         {narrative?.process && narrative.process.length > 0 && (
           <section data-testid="section-process">
             <div className="flex items-center gap-3 mb-8">
-              <div className="w-10 h-10 rounded-lg bg-violet-600 flex items-center justify-center">
+              <div className="w-10 h-10 rounded-lg bg-de-accent flex items-center justify-center">
                 <ArrowRight className="w-5 h-5 text-white" />
               </div>
               <div>
@@ -295,7 +295,7 @@ export default function GenericServicePage({
             transition={{ duration: 0.5 }}
           >
             <div className="flex items-center gap-3 mb-6">
-              <div className="w-10 h-10 rounded-lg bg-gradient-to-br from-violet-600 to-purple-500 flex items-center justify-center">
+              <div className="w-10 h-10 rounded-lg bg-de-raised flex items-center justify-center">
                 <Grid3X3 className="w-5 h-5 text-white" />
               </div>
               <div>

--- a/client/src/pages/GenericServicePage.tsx
+++ b/client/src/pages/GenericServicePage.tsx
@@ -179,7 +179,7 @@ export default function GenericServicePage({
               viewport={{ once: true }}
               transition={{ duration: 0.5 }}
             >
-              <div className="w-10 h-10 rounded-lg bg-gradient-to-br from-[#D3126A] to-fuchsia-500 flex items-center justify-center">
+              <div className="w-10 h-10 rounded-lg bg-[#D3126A] flex items-center justify-center">
                 <Zap className="w-5 h-5 text-white" />
               </div>
               <h2 className="text-3xl font-bold text-white">What you get</h2>
@@ -359,7 +359,7 @@ export default function GenericServicePage({
           viewport={{ once: true }}
           transition={{ duration: 0.5 }}
         >
-          <div className="absolute inset-0 bg-gradient-to-r from-[#D3126A] via-fuchsia-600 to-rose-500" />
+          <div className="absolute inset-0 bg-[#D3126A]" />
           <div className="absolute inset-0 opacity-30">
             <svg className="absolute w-full h-full" xmlns="http://www.w3.org/2000/svg">
               <defs>

--- a/client/src/pages/LeadQuoteWizard.tsx
+++ b/client/src/pages/LeadQuoteWizard.tsx
@@ -221,12 +221,12 @@ export default function LeadQuoteWizard() {
             <div
               key={step}
               className={`h-2 flex-1 rounded-full transition-colors ${
-                step <= currentStep ? 'bg-purple-600' : 'bg-gray-200'
+                step <= currentStep ? 'bg-de-accent' : 'bg-gray-200'
               }`}
             />
           ))}
         </div>
-        <span className="text-sm text-gray-600 ml-4">Step {currentStep} of 3</span>
+        <span className="text-sm text-white/70 ml-4">Step {currentStep} of 3</span>
       </div>
 
       <Form {...form}>
@@ -236,7 +236,7 @@ export default function LeadQuoteWizard() {
             <div className="space-y-6">
               <div>
                 <h2 className="text-2xl font-bold text-gray-900 mb-2">How many users?</h2>
-                <p className="text-gray-600">Includes employees and shared devices.</p>
+                <p className="text-white/70">Includes employees and shared devices.</p>
               </div>
 
               <FormField
@@ -253,7 +253,7 @@ export default function LeadQuoteWizard() {
                         {...field}
                         onChange={(e) => field.onChange(parseInt(e.target.value))}
                         disabled={form.watch('enterpriseToggle')}
-                        className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer accent-purple-600"
+                        className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer accent-[#D3126A]"
                       />
                     </FormControl>
                     <FormMessage />
@@ -295,7 +295,7 @@ export default function LeadQuoteWizard() {
             <div className="space-y-6">
               <div>
                 <h2 className="text-2xl font-bold text-gray-900 mb-2">What do you need?</h2>
-                <p className="text-gray-600">Help us understand your infrastructure needs.</p>
+                <p className="text-white/70">Help us understand your infrastructure needs.</p>
               </div>
 
               <FormField
@@ -360,7 +360,7 @@ export default function LeadQuoteWizard() {
             <div className="space-y-6">
               <div>
                 <h2 className="text-2xl font-bold text-gray-900 mb-2">Show Me The Best Plan!</h2>
-                <p className="text-gray-600">We'll need a few details to confirm your perfect fit.</p>
+                <p className="text-white/70">We'll need a few details to confirm your perfect fit.</p>
               </div>
 
               <FormField

--- a/client/src/pages/NetworkPlannerOfficial.tsx
+++ b/client/src/pages/NetworkPlannerOfficial.tsx
@@ -82,7 +82,7 @@ function InternalToolGate({ children }: { children: React.ReactNode }) {
           </p>
           <a
             href={loginUrl}
-            className="inline-flex items-center justify-center rounded-lg bg-violet-600 hover:bg-violet-500 px-5 py-2.5 font-semibold"
+            className="inline-flex items-center justify-center rounded-lg bg-de-accent hover:bg-de-accent px-5 py-2.5 font-semibold"
             data-testid="network-planner-login"
           >
             Sign in to continue
@@ -228,11 +228,11 @@ function NetworkPlannerOfficialApp() {
         {/* Header */}
         <header className="flex flex-col md:flex-row items-start justify-between gap-4 mb-6">
           <div className="flex items-start gap-4">
-            <div className="px-3 py-2 rounded-xl bg-gradient-to-br from-violet-500/25 to-cyan-500/18 border border-white/15 text-violet-200 font-bold text-sm">
+            <div className="px-3 py-2 rounded-xl bg-de-raised border border-white/15 text-de-accent-ink font-bold text-sm">
               Networking
             </div>
             <div>
-              <h1 className="text-2xl font-bold text-indigo-50 mb-1">Plan Your Networking Package</h1>
+              <h1 className="text-2xl font-bold text-white/80 mb-1">Plan Your Networking Package</h1>
               <p className="text-slate-400 text-sm">
                 Choose needs first. Pricing shows at the end. Compare <strong className="text-white">CloudShield</strong>, <strong className="text-white">CoreStack</strong>, or a <strong className="text-white">Merged</strong> package.
               </p>
@@ -250,15 +250,15 @@ function NetworkPlannerOfficialApp() {
 
         {/* Solutions */}
         <section className="bg-gradient-to-b from-[#141b2b] to-[#0f1525] border border-white/10 rounded-2xl p-5 mb-4 shadow-xl">
-          <h2 className="text-xl font-extrabold text-indigo-50 mb-4">Solutions</h2>
+          <h2 className="text-xl font-extrabold text-white/80 mb-4">Solutions</h2>
           <div className="grid md:grid-cols-2 gap-4">
             <label className="cursor-pointer group">
               <div className={`flex items-center gap-3 p-4 rounded-xl border transition-all ${cloudShield ? 'bg-[#182346] border-amber-500 shadow-[0_0_0_2px_rgba(255,155,22,0.18)]' : 'bg-gradient-to-b from-[#10182a] to-[#0b1220] border-white/10 hover:border-white/20'}`} onClick={() => setCloudShield(!cloudShield)} data-testid="toggle-cloudshield">
-                <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-violet-500/25 to-cyan-500/18 border border-white/15 flex items-center justify-center">
-                  <Shield className="w-5 h-5 text-violet-300" />
+                <div className="w-9 h-9 rounded-lg bg-de-raised border border-white/15 flex items-center justify-center">
+                  <Shield className="w-5 h-5 text-de-accent-ink" />
                 </div>
                 <div className="flex-1">
-                  <div className="font-extrabold text-indigo-50">CloudShield</div>
+                  <div className="font-extrabold text-white/80">CloudShield</div>
                   <div className="text-xs text-slate-400">(SASE)</div>
                 </div>
                 <div className={`w-6 h-6 rounded-lg bg-gradient-to-br from-amber-500 to-orange-500 border border-orange-400 flex items-center justify-center shadow-lg shadow-orange-500/25 transition-all ${cloudShield ? 'opacity-100 scale-100' : 'opacity-0 scale-75'}`}>
@@ -269,11 +269,11 @@ function NetworkPlannerOfficialApp() {
 
             <label className="cursor-pointer group">
               <div className={`flex items-center gap-3 p-4 rounded-xl border transition-all ${coreStack ? 'bg-[#182346] border-amber-500 shadow-[0_0_0_2px_rgba(255,155,22,0.18)]' : 'bg-gradient-to-b from-[#10182a] to-[#0b1220] border-white/10 hover:border-white/20'}`} onClick={() => setCoreStack(!coreStack)} data-testid="toggle-corestack">
-                <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-violet-500/25 to-cyan-500/18 border border-white/15 flex items-center justify-center">
+                <div className="w-9 h-9 rounded-lg bg-de-raised border border-white/15 flex items-center justify-center">
                   <Server className="w-5 h-5 text-cyan-300" />
                 </div>
                 <div className="flex-1">
-                  <div className="font-extrabold text-indigo-50">CoreStack</div>
+                  <div className="font-extrabold text-white/80">CoreStack</div>
                   <div className="text-xs text-slate-400">(Network)</div>
                 </div>
                 <div className={`w-6 h-6 rounded-lg bg-gradient-to-br from-amber-500 to-orange-500 border border-orange-400 flex items-center justify-center shadow-lg shadow-orange-500/25 transition-all ${coreStack ? 'opacity-100 scale-100' : 'opacity-0 scale-75'}`}>
@@ -287,7 +287,7 @@ function NetworkPlannerOfficialApp() {
 
         {/* Environment */}
         <section className="bg-gradient-to-b from-[#141b2b] to-[#0f1525] border border-white/10 rounded-2xl p-5 mb-4 shadow-xl">
-          <h2 className="text-xl font-extrabold text-indigo-50 mb-4">Your Environment</h2>
+          <h2 className="text-xl font-extrabold text-white/80 mb-4">Your Environment</h2>
           <div className="grid md:grid-cols-2 gap-4">
             <div className="space-y-2">
               <Label className="text-slate-400">Number of sites</Label>
@@ -296,7 +296,7 @@ function NetworkPlannerOfficialApp() {
                 min={1} 
                 value={sites} 
                 onChange={(e) => setSites(Math.max(1, parseInt(e.target.value) || 1))}
-                className="bg-[#0e1524] border-white/15 focus:border-violet-500"
+                className="bg-[#0e1524] border-white/15 focus:border-de-hairline"
                 data-testid="input-sites"
               />
             </div>
@@ -307,7 +307,7 @@ function NetworkPlannerOfficialApp() {
                 min={0} 
                 value={users} 
                 onChange={(e) => setUsers(Math.max(0, parseInt(e.target.value) || 0))}
-                className="bg-[#0e1524] border-white/15 focus:border-violet-500"
+                className="bg-[#0e1524] border-white/15 focus:border-de-hairline"
                 data-testid="input-users"
               />
             </div>
@@ -317,7 +317,7 @@ function NetworkPlannerOfficialApp() {
         {/* CloudShield Needs */}
         {cloudShield && (
           <section className="bg-gradient-to-b from-[#141b2b] to-[#0f1525] border border-white/10 rounded-2xl p-5 mb-4 shadow-xl">
-            <h2 className="text-xl font-extrabold text-indigo-50 mb-4">CloudShield (SASE) — Networking Needs</h2>
+            <h2 className="text-xl font-extrabold text-white/80 mb-4">CloudShield (SASE) — Networking Needs</h2>
             <div className="grid md:grid-cols-4 gap-4">
               <TooltipProvider>
                 <div className="space-y-2">
@@ -375,7 +375,7 @@ function NetworkPlannerOfficialApp() {
         {/* CoreStack Needs */}
         {coreStack && (
           <section className="bg-gradient-to-b from-[#141b2b] to-[#0f1525] border border-white/10 rounded-2xl p-5 mb-4 shadow-xl">
-            <h2 className="text-xl font-extrabold text-indigo-50 mb-4">CoreStack (Network) — Needs</h2>
+            <h2 className="text-xl font-extrabold text-white/80 mb-4">CoreStack (Network) — Needs</h2>
             <div className="grid md:grid-cols-3 gap-4 mb-4">
               <div className="space-y-2">
                 <Label className="text-slate-400">Gateway model (per site)</Label>
@@ -417,7 +417,7 @@ function NetworkPlannerOfficialApp() {
             </div>
 
             <fieldset className="border border-dashed border-white/10 rounded-xl p-4">
-              <legend className="px-2 text-indigo-100 font-semibold">Network hardware subscriptions (per site)</legend>
+              <legend className="px-2 text-white/80 font-semibold">Network hardware subscriptions (per site)</legend>
               <div className="grid md:grid-cols-4 gap-4">
                 <div className="space-y-2">
                   <Label className="text-slate-400">8-port PoE switches</Label>
@@ -442,14 +442,14 @@ function NetworkPlannerOfficialApp() {
 
         {/* Summary */}
         <section className="bg-gradient-to-b from-[#141b2b] to-[#0f1525] border border-white/10 rounded-2xl p-5 shadow-xl">
-          <h2 className="text-xl font-extrabold text-indigo-50 mb-4">Summary</h2>
+          <h2 className="text-xl font-extrabold text-white/80 mb-4">Summary</h2>
           <div className="grid md:grid-cols-4 gap-3 mb-6">
             <div className="bg-gradient-to-b from-[#10182a] to-[#0b1220] border border-white/10 rounded-xl p-4 shadow-inner">
-              <div className="text-xs text-violet-300 mb-1">Monthly Recurring</div>
+              <div className="text-xs text-de-accent-ink mb-1">Monthly Recurring</div>
               <div className="text-2xl font-black text-white" data-testid="text-total-mrc">${pricing.totalMRC.toLocaleString()}</div>
             </div>
             <div className="bg-gradient-to-b from-[#10182a] to-[#0b1220] border border-white/10 rounded-xl p-4 shadow-inner">
-              <div className="text-xs text-violet-300 mb-1">One-Time Setup</div>
+              <div className="text-xs text-de-accent-ink mb-1">One-Time Setup</div>
               <div className="text-2xl font-black text-white" data-testid="text-total-nrc">${pricing.totalNRC.toLocaleString()}</div>
             </div>
             <div className="bg-gradient-to-b from-[#182346] to-[#101a39] border border-white/15 rounded-xl p-4 shadow-inner">
@@ -468,7 +468,7 @@ function NetworkPlannerOfficialApp() {
           <div className="grid md:grid-cols-2 gap-4">
             {cloudShield && (
               <div className="bg-white/[0.02] border border-white/10 rounded-xl p-4">
-                <h3 className="font-bold text-violet-300 mb-3">CloudShield (SASE)</h3>
+                <h3 className="font-bold text-de-accent-ink mb-3">CloudShield (SASE)</h3>
                 <table className="w-full text-sm">
                   <tbody className="divide-y divide-white/5">
                     <tr><td className="py-2 text-slate-400">Base SASE ({users} users × $29)</td><td className="py-2 text-right font-semibold">${(users * 29).toLocaleString()}</td></tr>
@@ -520,7 +520,7 @@ function NetworkPlannerOfficialApp() {
           .bg-gradient-to-b { background: white !important; }
           .border-white\\/10 { border-color: #ddd !important; }
           .text-slate-400 { color: #666 !important; }
-          .text-white, .text-indigo-50 { color: black !important; }
+          .text-white, .text-white/80 { color: black !important; }
         }
       `}</style>
     </div>

--- a/client/src/pages/ProActiveEcosystemPricing.tsx
+++ b/client/src/pages/ProActiveEcosystemPricing.tsx
@@ -484,7 +484,7 @@ export default function ProActiveEcosystemPricing() {
               then confirm your exact ProActive Ecosystem investment.
             </p>
             <a href="https://meet.digerati-experts.com/" target="_blank" rel="noopener noreferrer">
-              <Button size="lg" className="bg-gradient-to-r from-violet-600 to-purple-600 hover:from-violet-500 hover:to-purple-500 text-white">
+              <Button size="lg" variant="brand">
                 {CTA.primary}
                 <ArrowRight className="w-4 h-4 ml-2" />
               </Button>

--- a/client/src/pages/ProActiveEcosystemPricing.tsx
+++ b/client/src/pages/ProActiveEcosystemPricing.tsx
@@ -147,7 +147,7 @@ const plans: PlanCard[] = [
       "Managed Workplace: limited / add-on",
       "No backup included by default",
     ],
-    gradient: "from-slate-500 to-violet-500",
+    gradient: "from-slate-500 ",
     borderColor: "border-slate-500/30",
     learnMoreUrl: pricing.it.learnMoreUrl,
   },
@@ -170,7 +170,7 @@ const plans: PlanCard[] = [
       "Threat Detection / SOC (add-on)",
       "BCDR, cloud backup, compliance reports (add-ons)",
     ],
-    gradient: "from-violet-500 to-purple-500",
+    gradient: " ",
     borderColor: "border-de-hairline",
     learnMoreUrl: pricing.office.learnMoreUrl,
   },
@@ -193,7 +193,7 @@ const plans: PlanCard[] = [
       "Budgeting / planning + 2× tech & security business reviews per year",
       "Spend-card controls included or available",
     ],
-    gradient: "from-purple-500 to-fuchsia-500",
+    gradient: " to-fuchsia-500",
     borderColor: "border-de-hairline",
     learnMoreUrl: pricing.business.learnMoreUrl,
   },
@@ -440,7 +440,7 @@ export default function ProActiveEcosystemPricing() {
                                 {service.name}
                                 {service.tooltip && (
                                   <span title={service.tooltip}>
-                                    <Info className="w-3.5 h-3.5 text-white/30" aria-label={service.tooltip} />
+                                    <Info className="w-3.5 h-3.5 text-white/55" aria-label={service.tooltip} />
                                   </span>
                                 )}
                               </span>

--- a/client/src/pages/ProActiveEcosystemPricing.tsx
+++ b/client/src/pages/ProActiveEcosystemPricing.tsx
@@ -171,7 +171,7 @@ const plans: PlanCard[] = [
       "BCDR, cloud backup, compliance reports (add-ons)",
     ],
     gradient: "from-violet-500 to-purple-500",
-    borderColor: "border-violet-500/40",
+    borderColor: "border-de-hairline",
     learnMoreUrl: pricing.office.learnMoreUrl,
   },
   {
@@ -194,7 +194,7 @@ const plans: PlanCard[] = [
       "Spend-card controls included or available",
     ],
     gradient: "from-purple-500 to-fuchsia-500",
-    borderColor: "border-purple-500/40",
+    borderColor: "border-de-hairline",
     learnMoreUrl: pricing.business.learnMoreUrl,
   },
   {
@@ -290,7 +290,7 @@ export default function ProActiveEcosystemPricing() {
           >
             <h1 className="text-4xl md:text-5xl font-bold text-white mb-4">
               ProActive Ecosystem{" "}
-              <span className="bg-gradient-to-r from-violet-400 to-fuchsia-400 bg-clip-text text-transparent">Pricing</span>
+              <span className="text-de-magenta-ink">Pricing</span>
             </h1>
             <p className="text-lg text-white/70 mb-3">
               Estimate your ProActive Ecosystem starting point. Final pricing is confirmed after assessment.
@@ -305,7 +305,7 @@ export default function ProActiveEcosystemPricing() {
           <section className="mb-14" aria-labelledby="estimator-heading">
             <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-6 md:p-8">
               <h2 id="estimator-heading" className="flex items-center gap-3 text-xl font-semibold text-white mb-2">
-                <Calculator className="w-5 h-5 text-violet-400" />
+                <Calculator className="w-5 h-5 text-de-magenta-ink" />
                 Estimate Your Starting Point
               </h2>
               <p className="text-sm text-white/50 mb-6">Estimates only — exact pricing confirmed after assessment.</p>
@@ -352,13 +352,13 @@ export default function ProActiveEcosystemPricing() {
                 variants={fadeIn}
                 data-testid={`plan-card-${plan.id}`}
               >
-                <div className={`inline-flex self-start px-3 py-1 rounded-full bg-gradient-to-r ${plan.gradient} text-white text-xs font-semibold mb-4`}>
+                <div className={`inline-flex self-start px-3 py-1 rounded-full bg-de-magenta text-white text-xs font-semibold mb-4`}>
                   {plan.shortName}
                 </div>
                 <h3 className="text-lg font-bold text-white mb-1">{plan.name}</h3>
                 <p className="text-sm text-white/50 mb-4">{plan.tagline}</p>
                 <div className="mb-4">
-                  <p className="text-violet-300 font-semibold">{plan.priceLabel}</p>
+                  <p className="text-de-magenta-ink font-semibold">{plan.priceLabel}</p>
                   {plan.siteMin ? (
                     <p className="text-xs text-white/50 mt-1">${plan.siteMin.toLocaleString()}/site/mo minimum</p>
                   ) : null}
@@ -383,7 +383,7 @@ export default function ProActiveEcosystemPricing() {
                 <Link href={plan.learnMoreUrl}>
                   <Button
                     variant="outline"
-                    className="w-full border-violet-400/40 bg-white/5 text-white hover:border-violet-300/70 hover:bg-violet-500/20 hover:text-white"
+                    className="w-full border-de-hairline bg-white/5 text-white hover:border-de-hairline hover:bg-de-raised hover:text-white"
                   >
                     Learn More
                     <ArrowRight className="w-4 h-4 ml-2" />
@@ -393,7 +393,7 @@ export default function ProActiveEcosystemPricing() {
             ))}
           </section>
 
-          <p className="text-center text-sm text-white/40 mb-16 max-w-2xl mx-auto">
+          <p className="text-center text-sm text-white/55 mb-16 max-w-2xl mx-auto">
             All numbers shown are estimated starting points, not exact totals. Final pricing is confirmed after a brief
             assessment of your environment, security needs, and selected add-ons.
           </p>
@@ -413,7 +413,7 @@ export default function ProActiveEcosystemPricing() {
               {matrixCategories.map((category) => (
                 <div key={category.id} className="rounded-2xl border border-white/10 bg-white/[0.02] overflow-hidden">
                   <div className="flex items-center gap-3 px-5 py-4 border-b border-white/10">
-                    <span className="text-violet-400">{category.icon}</span>
+                    <span className="text-de-magenta-ink">{category.icon}</span>
                     <h3 className="font-semibold text-white">{category.title}</h3>
                     {category.ribbon && (
                       <span className="ml-auto text-xs text-amber-400/90 border border-amber-400/30 rounded-full px-3 py-1">
@@ -424,7 +424,7 @@ export default function ProActiveEcosystemPricing() {
                   <div className="overflow-x-auto">
                     <table className="w-full text-left">
                       <thead>
-                        <tr className="text-xs uppercase tracking-wide text-white/40">
+                        <tr className="text-xs uppercase tracking-wide text-white/55">
                           <th className="px-5 py-3 font-medium min-w-[220px]">Service</th>
                           <th className="px-3 py-3 font-medium text-center">IT</th>
                           <th className="px-3 py-3 font-medium text-center">Office</th>
@@ -458,7 +458,7 @@ export default function ProActiveEcosystemPricing() {
               ))}
             </div>
 
-            <p className="text-center text-xs text-white/40 mt-6 max-w-3xl mx-auto">
+            <p className="text-center text-xs text-white/55 mt-6 max-w-3xl mx-auto">
               Digerati Experts provides audit readiness, evidence support, framework mapping, and risk reporting. We do
               not provide legal compliance signoff or certification.
             </p>
@@ -470,14 +470,14 @@ export default function ProActiveEcosystemPricing() {
               <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#FF477F]">Pricing tools</p>
               <h2 className="mt-2 text-3xl font-bold text-white">Calculate investment &amp; downtime risk</h2>
               <p className="mx-auto mt-2 max-w-2xl text-sm text-white/55">{PRICING_SCOPE_NOTE}</p>
-              <p className="mx-auto mt-2 max-w-2xl text-sm text-white/40">{NO_BLACK_BOX_TAGLINE}</p>
+              <p className="mx-auto mt-2 max-w-2xl text-sm text-white/55">{NO_BLACK_BOX_TAGLINE}</p>
             </div>
             <PricingToolsSection />
           </section>
 
           {/* CTA */}
-          <section className="text-center rounded-2xl border border-violet-500/30 bg-gradient-to-br from-violet-500/10 to-fuchsia-500/10 px-6 py-12">
-            <Layers className="w-10 h-10 text-violet-400 mx-auto mb-4" />
+          <section className="text-center rounded-2xl border border-de-hairline bg-de-raised px-6 py-12">
+            <Layers className="w-10 h-10 text-de-magenta-ink mx-auto mb-4" />
             <h2 className="text-3xl font-bold text-white mb-3">Ready to Confirm Your Pricing?</h2>
             <p className="text-white/70 max-w-2xl mx-auto mb-8">
               Schedule a brief assessment so we can scope users, devices, sites, backup, network, and compliance needs —

--- a/client/src/pages/QuoteConfirmation.tsx
+++ b/client/src/pages/QuoteConfirmation.tsx
@@ -33,7 +33,7 @@ export default function QuoteConfirmation() {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center">
-          <p className="text-gray-600 mb-4">Loading your quote...</p>
+          <p className="text-white/70 mb-4">Loading your quote...</p>
           <Button onClick={() => setLocation('/')}>Back to Home</Button>
         </div>
       </div>
@@ -41,7 +41,7 @@ export default function QuoteConfirmation() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-purple-50 to-blue-50 py-20 px-4">
+    <div className="min-h-screen bg-de-raised py-20 px-4">
       <div className="max-w-2xl mx-auto">
         {/* Success State */}
         <div className="text-center mb-12">
@@ -49,23 +49,23 @@ export default function QuoteConfirmation() {
             <CheckCircle className="h-16 w-16 text-green-500" />
           </div>
           <h1 className="text-4xl font-bold text-gray-900 mb-4">Perfect! We've Got Your Match</h1>
-          <p className="text-lg text-gray-600 mb-2">Hi {data.firstName},</p>
-          <p className="text-lg text-gray-600">We've analyzed your needs and found the ideal plan for {data.company}.</p>
+          <p className="text-lg text-white/70 mb-2">Hi {data.firstName},</p>
+          <p className="text-lg text-white/70">We've analyzed your needs and found the ideal plan for {data.company}.</p>
         </div>
 
         {/* Plan Card */}
-        <Card className="mb-12 p-8 border-2 border-purple-200 bg-white shadow-lg">
+        <Card className="mb-12 p-8 border-2 border-de-hairline bg-white shadow-lg">
           <div className="mb-6">
-            <h2 className="text-3xl font-bold text-purple-600 mb-2">{data.plan}</h2>
-            <p className="text-gray-600">Your personalized recommendation</p>
+            <h2 className="text-3xl font-bold text-de-accent mb-2">{data.plan}</h2>
+            <p className="text-white/70">Your personalized recommendation</p>
           </div>
 
           <div className="space-y-4 mb-8">
-            <p className="text-sm text-gray-600 font-semibold uppercase">Why this fits you:</p>
+            <p className="text-sm text-white/70 font-semibold uppercase">Why this fits you:</p>
             {data.reasons.map((reason, idx) => (
               <div key={idx} className="flex items-start gap-3">
-                <div className="w-6 h-6 rounded-full bg-purple-100 flex items-center justify-center flex-shrink-0 mt-0.5">
-                  <span className="text-purple-600 text-sm font-semibold">{idx + 1}</span>
+                <div className="w-6 h-6 rounded-full bg-de-paper-raised flex items-center justify-center flex-shrink-0 mt-0.5">
+                  <span className="text-de-accent text-sm font-semibold">{idx + 1}</span>
                 </div>
                 <p className="text-gray-700 leading-relaxed">{reason}</p>
               </div>
@@ -73,18 +73,18 @@ export default function QuoteConfirmation() {
           </div>
 
           <div className="border-t pt-6">
-            <p className="text-sm text-gray-600 mb-4">
+            <p className="text-sm text-white/70 mb-4">
               Next steps: Our team will review your profile and reach out within 24 hours with:
             </p>
             <ul className="space-y-2 text-gray-700">
               <li className="flex items-center gap-2">
-                <span className="text-purple-600">✓</span> Custom pricing for your company size
+                <span className="text-de-accent">✓</span> Custom pricing for your company size
               </li>
               <li className="flex items-center gap-2">
-                <span className="text-purple-600">✓</span> Implementation timeline and options
+                <span className="text-de-accent">✓</span> Implementation timeline and options
               </li>
               <li className="flex items-center gap-2">
-                <span className="text-purple-600">✓</span> Answers to any questions
+                <span className="text-de-accent">✓</span> Answers to any questions
               </li>
             </ul>
           </div>
@@ -92,11 +92,11 @@ export default function QuoteConfirmation() {
 
         {/* CTAs */}
         <div className="grid md:grid-cols-2 gap-4 mb-8">
-          <Button size="lg" className="bg-purple-600 hover:bg-purple-700 text-white h-12" data-testid="button-schedule-call">
+          <Button size="lg" className="bg-de-accent hover:bg-de-accent text-white h-12" data-testid="button-schedule-call">
             <Calendar className="mr-2 h-5 w-5" />
             Schedule 15-Minute Fit Call
           </Button>
-          <Button size="lg" variant="outline" className="h-12 border-purple-300 text-purple-700 hover:bg-purple-50 hover:text-purple-800" data-testid="button-email-details">
+          <Button size="lg" variant="outline" className="h-12 border-de-hairline text-de-accent hover:bg-de-paper-raised hover:text-de-accent" data-testid="button-email-details">
             <Mail className="mr-2 h-5 w-5" />
             Email Me These Details
           </Button>
@@ -104,16 +104,16 @@ export default function QuoteConfirmation() {
 
         {/* Footer CTA */}
         <div className="text-center">
-          <p className="text-gray-600 mb-4">Questions before we reach out?</p>
-          <Button variant="outline" className="border-purple-300 text-purple-700 hover:bg-purple-50 hover:text-purple-800" onClick={() => setLocation('/#contact')}>
+          <p className="text-white/70 mb-4">Questions before we reach out?</p>
+          <Button variant="outline" className="border-de-hairline text-de-accent hover:bg-de-paper-raised hover:text-de-accent" onClick={() => setLocation('/#contact')}>
             Contact Us Now <ArrowRight className="ml-2 h-4 w-4" />
           </Button>
         </div>
 
         {/* Trust Message */}
         <div className="mt-12 p-6 bg-white rounded-lg border border-gray-200">
-          <p className="text-center text-sm text-gray-600">
-            <span className="font-semibold">We respect your privacy:</span> Your information is secure and you'll only hear from our team about your specific plan match. <a href="/legal/privacy-policy" className="text-purple-600 hover:underline">View our privacy policy</a>.
+          <p className="text-center text-sm text-white/70">
+            <span className="font-semibold">We respect your privacy:</span> Your information is secure and you'll only hear from our team about your specific plan match. <a href="/legal/privacy-policy" className="text-de-accent hover:underline">View our privacy policy</a>.
           </p>
         </div>
       </div>

--- a/client/src/pages/ThankYouSuccess.tsx
+++ b/client/src/pages/ThankYouSuccess.tsx
@@ -68,7 +68,7 @@ export default function ThankYouSuccess() {
                 Identify how you can better protect your business from cyber threats.
               </p>
               <p className="text-slate-600 text-center mb-8">
-                If you qualify, you will receive a <strong className="text-purple-600">free security assessment</strong>.
+                If you qualify, you will receive a <strong className="text-de-accent">free security assessment</strong>.
               </p>
               
               {/* Divider */}
@@ -76,8 +76,8 @@ export default function ThankYouSuccess() {
               
               {/* Meeting Scheduled Card */}
               <div className="text-center mb-8">
-                <div className="inline-flex items-center justify-center w-16 h-16 bg-purple-100 rounded-full mb-4">
-                  <Calendar className="h-8 w-8 text-purple-600" />
+                <div className="inline-flex items-center justify-center w-16 h-16 bg-de-paper-raised rounded-full mb-4">
+                  <Calendar className="h-8 w-8 text-de-accent" />
                 </div>
                 
                 <h3 className="text-xl font-bold text-slate-900 mb-2">
@@ -85,7 +85,7 @@ export default function ThankYouSuccess() {
                 </h3>
                 <p className="text-slate-600 text-sm mb-6">
                   Thank you for your interest. Click below to book a time that works for you.<br />
-                  Call our office at <a href="tel:+13254809870" className="text-purple-600 hover:underline">325-480-9870</a> if you have any questions.
+                  Call our office at <a href="tel:+13254809870" className="text-de-accent hover:underline">325-480-9870</a> if you have any questions.
                 </p>
                 
                 {/* Meeting Details */}
@@ -110,7 +110,7 @@ export default function ThankYouSuccess() {
                 <Button 
                   asChild 
                   size="lg"
-                  className="bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white px-8 py-6 text-lg rounded-xl shadow-lg"
+                  className="bg-de-raised hover: hover:to-blue-700 text-white px-8 py-6 text-lg rounded-xl shadow-lg"
                   data-testid="button-book-consultation"
                 >
                   <a href="/book">

--- a/client/src/pages/about/ClientBillOfRights.tsx
+++ b/client/src/pages/about/ClientBillOfRights.tsx
@@ -114,7 +114,7 @@ export default function ClientBillOfRights() {
                   </div>
                 </div>
                 <div className="ml-0 md:ml-17 pl-0 md:pl-[68px]">
-                  <div className="pl-4 border-l-2 border-violet-500/50 bg-violet-500/5 py-3 pr-4 rounded-r-lg">
+                  <div className="pl-4 border-l-2 border-de-hairline bg-de-raised py-3 pr-4 rounded-r-lg">
                     <p className="text-white/80 text-sm leading-relaxed">
                       <span className="text-pink-300 font-semibold">We Pledge</span> {right.pledgeText.replace(/^We Pledge /i, '')}
                     </p>
@@ -146,7 +146,7 @@ export default function ClientBillOfRights() {
           <p className="text-white/50 mb-4">See also our money-back guarantee</p>
           <Link 
             href="/about/guarantee"
-            className="inline-flex items-center gap-2 px-6 py-3 rounded-lg bg-violet-600 hover:bg-violet-500 text-white font-medium transition-colors"
+            className="inline-flex items-center gap-2 px-6 py-3 rounded-lg bg-de-magenta hover:bg-de-magenta text-white font-medium transition-colors"
             data-testid="link-guarantee"
           >
             100% Money-Back Guarantee

--- a/client/src/pages/about/Compliance.tsx
+++ b/client/src/pages/about/Compliance.tsx
@@ -23,7 +23,7 @@ export default function Compliance() {
         "Proactive compliance posture, not reactive scrambling",
         "Clear roadmap to compliance certifications"
       ]}
-      gradientColors="from-purple-600 via-indigo-600 to-blue-600"
+      gradientColors="  to-blue-600"
     />
   );
 }

--- a/client/src/pages/about/ComplianceCertifications.tsx
+++ b/client/src/pages/about/ComplianceCertifications.tsx
@@ -12,7 +12,7 @@ const complianceFrameworks = [
     name: "HIPAA",
     fullName: "Health Insurance Portability and Accountability Act",
     icon: Heart,
-    color: "from-violet-500 to-purple-600",
+    color: " ",
     description: "Comprehensive protection for healthcare organizations handling Protected Health Information (PHI).",
     industries: ["Healthcare Providers", "Medical Practices", "Dental Offices", "Mental Health", "Home Health", "Pharmacies"],
     keyRequirements: [
@@ -37,7 +37,7 @@ const complianceFrameworks = [
     name: "CMMC",
     fullName: "Cybersecurity Maturity Model Certification",
     icon: Shield,
-    color: "from-purple-500 to-violet-600",
+    color: " ",
     description: "Required certification for Department of Defense contractors handling Controlled Unclassified Information (CUI).",
     industries: ["Defense Contractors", "DoD Suppliers", "Aerospace", "Manufacturing", "Engineering Firms", "Research Institutions"],
     keyRequirements: [
@@ -62,7 +62,7 @@ const complianceFrameworks = [
     name: "PCI DSS",
     fullName: "Payment Card Industry Data Security Standard",
     icon: CreditCard,
-    color: "from-fuchsia-500 to-purple-600",
+    color: "from-fuchsia-500 ",
     description: "Security standards for organizations that handle credit card transactions and cardholder data.",
     industries: ["Retail", "E-commerce", "Restaurants", "Hotels", "Financial Services", "Healthcare with Payment Processing"],
     keyRequirements: [
@@ -89,7 +89,7 @@ const complianceFrameworks = [
     name: "SOC 2",
     fullName: "Service Organization Control 2",
     icon: FileCheck,
-    color: "from-purple-500 to-violet-600",
+    color: " ",
     description: "Trust Services Criteria for service organizations demonstrating security, availability, and confidentiality controls.",
     industries: ["SaaS Companies", "Cloud Providers", "Data Centers", "Managed Service Providers", "Financial Tech", "Healthcare Tech"],
     keyRequirements: [
@@ -115,7 +115,7 @@ const complianceFrameworks = [
     name: "FTC Safeguards",
     fullName: "FTC Safeguards Rule (GLBA)",
     icon: Building2,
-    color: "from-violet-400 to-fuchsia-500",
+    color: " to-fuchsia-500",
     description: "Required security program for non-banking financial institutions under Gramm-Leach-Bliley Act.",
     industries: ["Tax Preparers", "Accountants", "Financial Advisors", "Mortgage Brokers", "Auto Dealers", "Collection Agencies"],
     keyRequirements: [
@@ -351,7 +351,7 @@ export default function ComplianceCertifications() {
             <div className="flex flex-wrap justify-center gap-6" data-testid="list-certifications">
               {teamCredentials.map((cert, i) => (
                 <div key={i} className="flex items-center gap-3 px-6 py-3 rounded-xl bg-white/[0.04] border border-white/10" data-testid={`badge-certification-${i}`}>
-                  <cert.icon className="h-5 w-5 text-[#A78BFA]" aria-hidden="true" />
+                  <cert.icon className="h-5 w-5 text-de-accent-ink" aria-hidden="true" />
                   <span className="text-white/80 font-medium">{cert.name}</span>
                 </div>
               ))}

--- a/client/src/pages/about/ComplianceCertifications.tsx
+++ b/client/src/pages/about/ComplianceCertifications.tsx
@@ -155,9 +155,9 @@ export default function ComplianceCertifications() {
 
         {/* Hero Section */}
         <section className="relative de-nav-clear pb-20 overflow-hidden">
-          <div className="absolute inset-0 bg-gradient-to-br from-violet-900/20 via-slate-950 to-purple-900/20" />
-          <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-violet-600/10 rounded-full blur-3xl" />
-          <div className="absolute bottom-1/4 right-1/4 w-96 h-96 bg-purple-600/10 rounded-full blur-3xl" />
+          <div className="absolute inset-0 bg-de-raised" />
+          <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-de-magenta/10 rounded-full blur-3xl" />
+          <div className="absolute bottom-1/4 right-1/4 w-96 h-96 bg-de-magenta/10 rounded-full blur-3xl" />
           
           <div className="relative container mx-auto px-6">
             <motion.div
@@ -167,14 +167,14 @@ export default function ComplianceCertifications() {
               className="max-w-4xl mx-auto text-center"
               data-testid="section-hero-compliance"
             >
-              <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-violet-500/10 border border-violet-500/20 mb-6" data-testid="badge-compliance-header">
-                <ClipboardCheck className="w-4 h-4 text-violet-400" />
-                <span className="text-violet-300 text-sm font-medium">Compliance & risk reporting</span>
+              <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-de-raised border border-de-hairline mb-6" data-testid="badge-compliance-header">
+                <ClipboardCheck className="w-4 h-4 text-de-magenta-ink" />
+                <span className="text-de-magenta-ink text-sm font-medium">Compliance & risk reporting</span>
               </div>
               
               <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6" data-testid="heading-compliance-hero">
                 Navigate Compliance with{" "}
-                <span className="bg-gradient-to-r from-violet-300 via-purple-300 to-fuchsia-300 bg-clip-text text-transparent">
+                <span className="text-de-magenta-ink">
                   Confidence
                 </span>
               </h1>
@@ -202,7 +202,7 @@ export default function ComplianceCertifications() {
                   asChild
                   size="lg"
                   variant="outline"
-                  className="border-violet-500/30 text-violet-300 hover:bg-violet-500/10"
+                  className="border-de-hairline text-de-magenta hover:bg-de-paper-raised"
                   data-testid="button-download-guide"
                 >
                   <Link href="/resources/security-checklist">
@@ -233,8 +233,8 @@ export default function ComplianceCertifications() {
                   className="p-6 rounded-xl bg-white/[0.02] border border-white/10 text-center"
                   data-testid={`card-why-compliance-${item.id}`}
                 >
-                  <div className="w-12 h-12 rounded-lg bg-violet-500/10 flex items-center justify-center mx-auto mb-4">
-                    <item.icon className="w-6 h-6 text-violet-400" />
+                  <div className="w-12 h-12 rounded-lg bg-de-raised flex items-center justify-center mx-auto mb-4">
+                    <item.icon className="w-6 h-6 text-de-magenta-ink" />
                   </div>
                   <h3 className="text-white font-semibold mb-2" data-testid={`heading-${item.id}`}>{item.title}</h3>
                   <p className="text-white/60 text-sm">{item.desc}</p>
@@ -269,10 +269,10 @@ export default function ComplianceCertifications() {
                   data-testid={`section-compliance-${framework.id}`}
                 >
                   {/* Header */}
-                  <div className={`p-6 bg-gradient-to-r ${framework.color} bg-opacity-10`} data-testid={`header-${framework.id}`}>
+                  <div className={`p-6 bg-de-raised`} data-testid={`header-${framework.id}`}>
                     <div className="flex items-start gap-4">
-                      <div className={`w-14 h-14 rounded-xl bg-gradient-to-br ${framework.color} flex items-center justify-center flex-shrink-0`}>
-                        <framework.icon className="w-7 h-7 text-white" />
+                      <div className={`w-14 h-14 rounded-xl border border-de-hairline bg-de-bg flex items-center justify-center flex-shrink-0`}>
+                        <framework.icon className="w-7 h-7 text-de-magenta" />
                       </div>
                       <div className="flex-1">
                         <div className="flex items-center gap-3 mb-1">
@@ -292,7 +292,7 @@ export default function ComplianceCertifications() {
                     {/* Key Requirements */}
                     <div data-testid={`list-requirements-${framework.id}`}>
                       <h4 className="text-white font-semibold mb-4 flex items-center gap-2">
-                        <FileText className="w-5 h-5 text-violet-400" />
+                        <FileText className="w-5 h-5 text-de-magenta-ink" />
                         Key Requirements
                       </h4>
                       <ul className="space-y-3">
@@ -308,13 +308,13 @@ export default function ComplianceCertifications() {
                     {/* Our Capabilities */}
                     <div data-testid={`list-capabilities-${framework.id}`}>
                       <h4 className="text-white font-semibold mb-4 flex items-center gap-2">
-                        <Shield className="w-5 h-5 text-violet-400" />
+                        <Shield className="w-5 h-5 text-de-magenta-ink" />
                         Our Capabilities
                       </h4>
                       <ul className="space-y-2">
                         {framework.ourCapabilities.map((cap, i) => (
                           <li key={i} className="flex items-center gap-2" data-testid={`item-capability-${framework.id}-${i}`}>
-                            <div className="w-1.5 h-1.5 rounded-full bg-violet-400" />
+                            <div className="w-1.5 h-1.5 rounded-full bg-de-magenta" />
                             <span className="text-white/70 text-sm">{cap}</span>
                           </li>
                         ))}
@@ -328,7 +328,7 @@ export default function ComplianceCertifications() {
                       <span className="text-white/50 text-xs uppercase tracking-wider">Industries We Serve:</span>
                       <div className="flex flex-wrap gap-2 mt-2">
                         {framework.industries.map((industry, i) => (
-                          <span key={i} className="px-3 py-1 rounded-full bg-violet-500/10 text-violet-300 text-xs" data-testid={`badge-industry-${framework.id}-${i}`}>
+                          <span key={i} className="px-3 py-1 rounded-full bg-de-raised text-de-magenta-ink text-xs" data-testid={`badge-industry-${framework.id}-${i}`}>
                             {industry}
                           </span>
                         ))}
@@ -360,7 +360,7 @@ export default function ComplianceCertifications() {
         </section>
 
         {/* CTA Section */}
-        <section className="py-20 bg-gradient-to-br from-violet-900/30 via-slate-950 to-purple-900/30">
+        <section className="py-20 bg-de-raised">
           <div className="container mx-auto px-6">
             <div className="max-w-3xl mx-auto text-center">
               <h2 className="text-3xl md:text-4xl font-bold text-white mb-6">
@@ -387,7 +387,7 @@ export default function ComplianceCertifications() {
                   asChild
                   size="lg"
                   variant="outline"
-                  className="border-violet-500/30 text-violet-300 hover:bg-violet-500/10"
+                  className="border-de-hairline text-de-magenta hover:bg-de-paper-raised"
                   data-testid="button-contact-us"
                 >
                   <Link href="/#contact">

--- a/client/src/pages/about/Guarantee.tsx
+++ b/client/src/pages/about/Guarantee.tsx
@@ -69,8 +69,8 @@ export default function Guarantee() {
 
             <div className="order-1 lg:order-2 flex-shrink-0">
               <div className="w-56 h-56 md:w-64 md:h-64 relative" data-testid="guarantee-badge">
-                <div className="absolute inset-0 rounded-full bg-gradient-to-br from-violet-600 to-purple-700 animate-pulse opacity-30" />
-                <div className="absolute inset-2 rounded-full bg-gradient-to-br from-violet-500 to-purple-600 flex items-center justify-center">
+                <div className="absolute inset-0 rounded-full bg-de-raised animate-pulse opacity-30" />
+                <div className="absolute inset-2 rounded-full bg-de-raised border border-de-hairline flex items-center justify-center">
                   <div className="w-[85%] h-[85%] rounded-full bg-white flex flex-col items-center justify-center text-center p-4">
                     <div className="text-5xl md:text-6xl font-bold text-[#030228] leading-none">100%</div>
                     <div className="mt-2 px-4 py-1.5 rounded-full bg-gradient-to-r from-amber-500 to-orange-500 text-white text-sm md:text-base font-bold uppercase tracking-wide shadow-lg">
@@ -94,7 +94,7 @@ export default function Guarantee() {
           </p>
           <a 
             href="tel:+13254809870" 
-            className="inline-flex items-center gap-3 text-2xl md:text-3xl font-bold text-violet-400 hover:text-violet-300 transition-colors"
+            className="inline-flex items-center gap-3 text-2xl md:text-3xl font-bold text-de-magenta-ink hover:text-de-magenta-ink transition-colors"
             data-testid="link-phone"
           >
             <Phone className="w-6 h-6" />
@@ -108,7 +108,7 @@ export default function Guarantee() {
           <p className="text-white/50 mb-4">See also our commitments to you</p>
           <Link 
             href="/about/client-bill-of-rights"
-            className="inline-flex items-center gap-2 px-6 py-3 rounded-lg bg-violet-600 hover:bg-violet-500 text-white font-medium transition-colors"
+            className="inline-flex items-center gap-2 px-6 py-3 rounded-lg bg-de-magenta hover:bg-de-magenta text-white font-medium transition-colors"
             data-testid="link-bill-of-rights"
           >
             Client Bill of Rights

--- a/client/src/pages/about/MissionValues.tsx
+++ b/client/src/pages/about/MissionValues.tsx
@@ -63,7 +63,7 @@ export default function MissionValues() {
           viewport={{ once: true }}
           transition={{ duration: 0.5 }}
         >
-          <div className="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-gradient-to-br from-purple-600 to-indigo-600 mb-6">
+          <div className="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-de-raised border border-de-hairline mb-6">
             <Zap className="w-8 h-8 text-white" />
           </div>
           <h2 className="text-3xl font-bold mb-6 text-white">Our Mission</h2>
@@ -95,10 +95,10 @@ export default function MissionValues() {
                   viewport={{ once: true }}
                   transition={{ delay: index * 0.1, duration: 0.5 }}
                 >
-                  <Card className="group h-full bg-white/5 backdrop-blur-sm border border-white/10 hover:border-purple-500/50 hover:bg-white/10 transition-all duration-300 overflow-hidden">
-                    <div className={`absolute top-0 right-0 w-32 h-32 bg-gradient-to-bl ${value.gradient} opacity-10 rounded-bl-full`} />
+                  <Card className="group h-full bg-white/5 backdrop-blur-sm border border-white/10 hover:border-de-hairline hover:bg-white/10 transition-all duration-300 overflow-hidden">
+                    <div className={`absolute top-0 right-0 w-32 h-32 bg-de-magenta opacity-[0.06] rounded-bl-full`} />
                     <CardHeader>
-                      <div className={`w-14 h-14 rounded-xl bg-gradient-to-br ${value.gradient} flex items-center justify-center mb-4 group-hover:scale-110 transition-transform`}>
+                      <div className={`w-14 h-14 rounded-xl border border-de-hairline bg-de-bg flex items-center justify-center mb-4 group-hover:scale-110 transition-transform`}>
                         <Icon className="h-7 w-7 text-white" />
                       </div>
                       <CardTitle className="text-2xl text-white">{value.title}</CardTitle>
@@ -121,8 +121,8 @@ export default function MissionValues() {
           viewport={{ once: true }}
           transition={{ duration: 0.5 }}
         >
-          <div className="absolute top-0 right-0 w-64 h-64 bg-gradient-to-bl from-purple-500/20 to-transparent rounded-full blur-3xl" />
-          <div className="absolute bottom-0 left-0 w-48 h-48 bg-gradient-to-tr from-indigo-500/20 to-transparent rounded-full blur-3xl" />
+          <div className="absolute top-0 right-0 w-64 h-64 bg-de-raised to-transparent rounded-full blur-3xl" />
+          <div className="absolute bottom-0 left-0 w-48 h-48 bg-de-raised to-transparent rounded-full blur-3xl" />
           
           <div className="relative">
             <h2 className="text-3xl font-bold mb-8 text-white">What Sets Us Apart</h2>
@@ -132,13 +132,13 @@ export default function MissionValues() {
                 return (
                   <motion.div 
                     key={index}
-                    className="flex gap-4 p-4 bg-white/5 backdrop-blur-sm rounded-xl border border-white/10 hover:border-purple-500/50 hover:bg-white/10 transition-all duration-300"
+                    className="flex gap-4 p-4 bg-white/5 backdrop-blur-sm rounded-xl border border-white/10 hover:border-de-hairline hover:bg-white/10 transition-all duration-300"
                     initial={prefersReducedMotion ? {} : { opacity: 0, x: -10 }}
                     whileInView={{ opacity: 1, x: 0 }}
                     viewport={{ once: true }}
                     transition={{ delay: index * 0.1, duration: 0.3 }}
                   >
-                    <div className="flex-shrink-0 w-12 h-12 rounded-lg bg-gradient-to-br from-purple-600 to-indigo-600 flex items-center justify-center">
+                    <div className="flex-shrink-0 w-12 h-12 rounded-lg bg-de-raised border border-de-hairline flex items-center justify-center">
                       <Icon className="w-6 h-6 text-white" />
                     </div>
                     <div>
@@ -154,7 +154,7 @@ export default function MissionValues() {
 
         {/* Stats Section */}
         <motion.div 
-          className="grid md:grid-cols-4 gap-6 bg-gradient-to-r from-purple-600 via-indigo-600 to-blue-600 rounded-2xl p-8 text-white"
+          className="grid md:grid-cols-4 gap-6 bg-de-surface rounded-2xl p-8 text-white"
           initial={prefersReducedMotion ? {} : { opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
@@ -168,7 +168,7 @@ export default function MissionValues() {
           ].map((stat, idx) => (
             <div key={idx} className="text-center p-4 bg-white/10 rounded-xl backdrop-blur-sm">
               <p className="text-3xl font-bold mb-1">{stat.value}</p>
-              <p className="text-purple-100 text-sm">{stat.label}</p>
+              <p className="text-white/80 text-sm">{stat.label}</p>
             </div>
           ))}
         </motion.div>
@@ -181,7 +181,7 @@ export default function MissionValues() {
           viewport={{ once: true }}
           transition={{ duration: 0.5 }}
         >
-          <div className="absolute inset-0 bg-gradient-to-r from-purple-600 to-indigo-600" />
+          <div className="absolute inset-0 bg-de-surface" />
           <div className="absolute inset-0 opacity-20">
             <svg className="w-full h-full" xmlns="http://www.w3.org/2000/svg">
               <defs>
@@ -202,7 +202,7 @@ export default function MissionValues() {
               href="/book"
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center justify-center bg-white text-purple-700 hover:bg-purple-50 px-8 py-4 rounded-xl font-semibold transition-all shadow-lg hover:shadow-xl hover:scale-105"
+              className="inline-flex items-center justify-center bg-white text-de-magenta hover:bg-de-paper-raised px-8 py-4 rounded-xl font-semibold transition-all shadow-lg hover:shadow-xl hover:scale-105"
               data-testid="button-schedule"
             >
               Schedule Free Consultation

--- a/client/src/pages/about/MissionValues.tsx
+++ b/client/src/pages/about/MissionValues.tsx
@@ -18,19 +18,19 @@ export default function MissionValues() {
       icon: Shield,
       title: "Security First",
       description: "We believe every business deserves enterprise-level security, regardless of size. We stay ahead of threats so you don't have to.",
-      gradient: "from-purple-500 to-indigo-600"
+      gradient: " "
     },
     {
       icon: Users,
       title: "Partnership",
       description: "We're not just your IT provider – we're your technology partner. Your success is our success, and we're invested in your long-term growth.",
-      gradient: "from-purple-500 to-violet-600"
+      gradient: " "
     },
     {
       icon: Target,
       title: "Proactive Approach",
       description: "We prevent problems before they happen. Our proactive monitoring and maintenance keep your systems running smoothly 24/7.",
-      gradient: "from-violet-500 to-fuchsia-600"
+      gradient: " to-fuchsia-600"
     },
     {
       icon: Heart,

--- a/client/src/pages/about/Press.tsx
+++ b/client/src/pages/about/Press.tsx
@@ -50,7 +50,7 @@ export default function Press() {
         }}
       />
       <main className="mx-auto max-w-3xl px-6 py-20">
-        <p className="text-sm uppercase tracking-[0.2em] text-violet-300/80">Media</p>
+        <p className="text-sm uppercase tracking-[0.2em] text-de-magenta-ink/80">Media</p>
         <h1 className="mt-3 text-4xl font-semibold tracking-tight md:text-5xl">Press & media</h1>
         <p className="mt-4 text-lg text-white/70">
           Use this page for accurate company facts, citations, and interview requests. Please do not
@@ -78,17 +78,17 @@ export default function Press() {
             {NAP.city}, {NAP.region} {NAP.postal}
             <br />
             Phone:{" "}
-            <a className="text-violet-300 underline-offset-2 hover:underline" href="tel:+13254809870">
+            <a className="text-de-magenta-ink underline-offset-2 hover:underline" href="tel:+13254809870">
               {NAP.phone}
             </a>
             <br />
             Email:{" "}
-            <a className="text-violet-300 underline-offset-2 hover:underline" href={`mailto:${NAP.email}`}>
+            <a className="text-de-magenta-ink underline-offset-2 hover:underline" href={`mailto:${NAP.email}`}>
               {NAP.email}
             </a>
             <br />
             Web:{" "}
-            <a className="text-violet-300 underline-offset-2 hover:underline" href="https://digeratiexperts.com">
+            <a className="text-de-magenta-ink underline-offset-2 hover:underline" href="https://digeratiexperts.com">
               https://digeratiexperts.com
             </a>
           </address>
@@ -98,22 +98,22 @@ export default function Press() {
           <h2 className="text-2xl font-semibold">Linkable resources</h2>
           <ul className="list-disc space-y-2 pl-5 text-white/80">
             <li>
-              <Link href="/resources/case-studies" className="text-violet-300 hover:underline">
+              <Link href="/resources/case-studies" className="text-de-magenta-ink hover:underline">
                 Case studies
               </Link>
             </li>
             <li>
-              <Link href="/resources/blog" className="text-violet-300 hover:underline">
+              <Link href="/resources/blog" className="text-de-magenta-ink hover:underline">
                 Security & IT blog
               </Link>
             </li>
             <li>
-              <Link href="/trust/trust-center" className="text-violet-300 hover:underline">
+              <Link href="/trust/trust-center" className="text-de-magenta-ink hover:underline">
                 Trust center
               </Link>
             </li>
             <li>
-              <Link href="/book" className="text-violet-300 hover:underline">
+              <Link href="/book" className="text-de-magenta-ink hover:underline">
                 Free risk assessment
               </Link>
             </li>
@@ -124,7 +124,7 @@ export default function Press() {
           <h2 className="text-2xl font-semibold">Media contact</h2>
           <p className="text-white/75">
             Interview and citation requests:{" "}
-            <a className="text-violet-300 hover:underline" href={`mailto:${NAP.email}?subject=Media%20inquiry`}>
+            <a className="text-de-magenta-ink hover:underline" href={`mailto:${NAP.email}?subject=Media%20inquiry`}>
               {NAP.email}
             </a>{" "}
             · {NAP.phone}

--- a/client/src/pages/about/Team.tsx
+++ b/client/src/pages/about/Team.tsx
@@ -21,21 +21,21 @@ export default function Team() {
       description: "Industry veterans with decades of combined experience in IT and cybersecurity",
       certifications: ["CISSP", "CISM", "Microsoft Certified", "CompTIA Security+"],
       icon: Trophy,
-      gradient: "from-purple-500 to-indigo-600"
+      gradient: " "
     },
     {
       name: "Security Engineers",
       description: "Specialized cybersecurity experts protecting your business 24/7",
       certifications: ["CEH", "GIAC", "OSCP", "Security+"],
       icon: Shield,
-      gradient: "from-purple-500 to-violet-600"
+      gradient: " "
     },
     {
       name: "System Engineers",
       description: "Infrastructure experts ensuring your systems run smoothly",
       certifications: ["MCSE", "VMware VCP", "AWS Certified", "Azure Administrator"],
       icon: Briefcase,
-      gradient: "from-violet-500 to-fuchsia-600"
+      gradient: " to-fuchsia-600"
     },
     {
       name: "Support Team",
@@ -117,7 +117,7 @@ export default function Team() {
                   height={160}
                   loading="lazy"
                   decoding="async"
-                  className="h-36 w-36 sm:h-40 sm:w-40 rounded-2xl object-cover border border-de-hairline shadow-lg shadow-violet-500/20"
+                  className="h-36 w-36 sm:h-40 sm:w-40 rounded-2xl object-cover border border-de-hairline shadow-lg shadow-none"
                 />
               </picture>
               <div className="text-center sm:text-left">

--- a/client/src/pages/about/Team.tsx
+++ b/client/src/pages/about/Team.tsx
@@ -117,7 +117,7 @@ export default function Team() {
                   height={160}
                   loading="lazy"
                   decoding="async"
-                  className="h-36 w-36 sm:h-40 sm:w-40 rounded-2xl object-cover border border-violet-500/30 shadow-lg shadow-violet-500/20"
+                  className="h-36 w-36 sm:h-40 sm:w-40 rounded-2xl object-cover border border-de-hairline shadow-lg shadow-violet-500/20"
                 />
               </picture>
               <div className="text-center sm:text-left">
@@ -146,11 +146,11 @@ export default function Team() {
                 viewport={{ once: true }}
                 transition={{ delay: index * 0.1, duration: 0.5 }}
               >
-                <Card className="group h-full bg-white/5 backdrop-blur-sm border border-white/10 hover:border-purple-500/50 hover:bg-white/10 transition-all duration-300 overflow-hidden">
-                  <div className={`absolute top-0 right-0 w-32 h-32 bg-gradient-to-bl ${group.gradient} opacity-10 rounded-bl-full`} />
+                <Card className="group h-full bg-white/5 backdrop-blur-sm border border-white/10 hover:border-de-hairline hover:bg-white/10 transition-all duration-300 overflow-hidden">
+                  <div className={`absolute top-0 right-0 w-32 h-32 bg-de-magenta opacity-[0.06] rounded-bl-full`} />
                   <CardHeader>
-                    <div className={`w-14 h-14 rounded-xl bg-gradient-to-br ${group.gradient} flex items-center justify-center mb-4 group-hover:scale-110 transition-transform`}>
-                      <Icon className="h-7 w-7 text-white" />
+                    <div className={`w-14 h-14 rounded-xl border border-de-hairline bg-de-bg flex items-center justify-center mb-4 group-hover:scale-110 transition-transform`}>
+                      <Icon className="h-7 w-7 text-de-magenta" />
                     </div>
                     <CardTitle className="text-2xl flex items-center gap-2 text-white">
                       {group.name}
@@ -162,7 +162,7 @@ export default function Team() {
                       {group.certifications.map((cert, idx) => (
                         <Badge 
                           key={idx} 
-                          className={`bg-gradient-to-r ${group.gradient} text-white border-0`}
+                          className={`bg-de-magenta text-white border-0`}
                         >
                           {cert}
                         </Badge>
@@ -177,7 +177,7 @@ export default function Team() {
 
         {/* Team Stats */}
         <motion.div 
-          className="grid md:grid-cols-4 gap-6 bg-gradient-to-r from-purple-600 via-indigo-600 to-blue-600 rounded-2xl p-8 text-white"
+          className="grid md:grid-cols-4 gap-6 bg-de-surface rounded-2xl p-8 text-white"
           initial={prefersReducedMotion ? {} : { opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
@@ -191,7 +191,7 @@ export default function Team() {
           ].map((stat, idx) => (
             <div key={idx} className="text-center p-4 bg-white/10 rounded-xl backdrop-blur-sm">
               <p className="text-3xl font-bold mb-1">{stat.value}</p>
-              <p className="text-purple-100 text-sm">{stat.label}</p>
+              <p className="text-white/80 text-sm">{stat.label}</p>
             </div>
           ))}
         </motion.div>
@@ -204,11 +204,11 @@ export default function Team() {
           viewport={{ once: true }}
           transition={{ duration: 0.5 }}
         >
-          <div className="absolute top-0 right-0 w-64 h-64 bg-gradient-to-bl from-purple-500/20 to-transparent rounded-full blur-3xl" />
+          <div className="absolute top-0 right-0 w-64 h-64 bg-de-raised to-transparent rounded-full blur-3xl" />
           
           <div className="relative">
             <div className="flex items-center gap-3 mb-8">
-              <div className="w-12 h-12 rounded-lg bg-gradient-to-br from-purple-600 to-indigo-600 flex items-center justify-center">
+              <div className="w-12 h-12 rounded-lg bg-de-raised border border-de-hairline flex items-center justify-center">
                 <Award className="w-6 h-6 text-white" />
               </div>
               <h2 className="text-3xl font-bold text-white">Our Certifications & Partnerships</h2>
@@ -218,14 +218,14 @@ export default function Team() {
               {certCategories.map((category, catIdx) => (
                 <motion.div 
                   key={catIdx}
-                  className="bg-white/5 backdrop-blur-sm rounded-xl p-6 border border-white/10 hover:border-purple-500/50 hover:bg-white/10 transition-all duration-300"
+                  className="bg-white/5 backdrop-blur-sm rounded-xl p-6 border border-white/10 hover:border-de-hairline hover:bg-white/10 transition-all duration-300"
                   initial={prefersReducedMotion ? {} : { opacity: 0, y: 10 }}
                   whileInView={{ opacity: 1, y: 0 }}
                   viewport={{ once: true }}
                   transition={{ delay: catIdx * 0.1, duration: 0.3 }}
                 >
                   <h3 className="font-bold text-lg mb-4 text-white flex items-center gap-2">
-                    <Star className="w-5 h-5 text-purple-400" />
+                    <Star className="w-5 h-5 text-de-magenta-ink" />
                     {category.title}
                   </h3>
                   <ul className="space-y-3">
@@ -250,7 +250,7 @@ export default function Team() {
           viewport={{ once: true }}
           transition={{ duration: 0.5 }}
         >
-          <div className="absolute inset-0 bg-gradient-to-r from-purple-600 to-indigo-600" />
+          <div className="absolute inset-0 bg-de-surface" />
           <div className="absolute inset-0 opacity-20">
             <svg className="w-full h-full" xmlns="http://www.w3.org/2000/svg">
               <defs>
@@ -271,7 +271,7 @@ export default function Team() {
               href="/book" 
               target="_blank" 
               rel="noopener noreferrer" 
-              className="inline-flex items-center justify-center bg-white text-purple-700 hover:bg-purple-50 px-8 py-4 rounded-xl font-semibold transition-all shadow-lg hover:shadow-xl hover:scale-105" 
+              className="inline-flex items-center justify-center bg-white text-de-magenta hover:bg-de-paper-raised px-8 py-4 rounded-xl font-semibold transition-all shadow-lg hover:shadow-xl hover:scale-105" 
               data-testid="button-schedule"
             >
               Schedule Consultation

--- a/client/src/pages/about/TwentyOneQuestions.tsx
+++ b/client/src/pages/about/TwentyOneQuestions.tsx
@@ -56,15 +56,15 @@ export default function TwentyOneQuestions() {
                     Critical Question
                   </th>
                   <th className="bg-[#1a1a2e] text-white text-center p-4 font-bold text-sm border border-white/10 w-[13.75%]">
-                    Company A<br /><span className="text-white/40">_______</span>
+                    Company A<br /><span className="text-white/55">_______</span>
                   </th>
                   <th className="bg-[#1a1a2e] text-white text-center p-4 font-bold text-sm border border-white/10 w-[13.75%]">
-                    Company B<br /><span className="text-white/40">_______</span>
+                    Company B<br /><span className="text-white/55">_______</span>
                   </th>
                   <th className="bg-[#1a1a2e] text-white text-center p-4 font-bold text-sm border border-white/10 w-[13.75%]">
-                    Company C<br /><span className="text-white/40">_______</span>
+                    Company C<br /><span className="text-white/55">_______</span>
                   </th>
-                  <th className="bg-gradient-to-br from-violet-500/30 to-violet-600/20 text-white text-center p-4 font-bold text-sm border border-violet-400/30 w-[13.75%]">
+                  <th className="bg-de-raised text-white text-center p-4 font-bold text-sm border border-de-hairline w-[13.75%]">
                     DIGERATI<br />EXPERTS
                   </th>
                 </tr>
@@ -78,13 +78,13 @@ export default function TwentyOneQuestions() {
                     <td className="bg-[#2a2a3e] text-center p-4 border border-white/10"></td>
                     <td className="bg-[#2a2a3e] text-center p-4 border border-white/10"></td>
                     <td className="bg-[#2a2a3e] text-center p-4 border border-white/10"></td>
-                    <td className="bg-gradient-to-br from-violet-500/25 to-violet-600/15 text-center p-4 border border-violet-400/20">
+                    <td className="bg-de-raised text-center p-4 border border-de-hairline">
                       {index === 17 ? (
-                        <span className="text-violet-300 font-bold text-xs leading-tight block" data-testid="special-note">
+                        <span className="text-de-magenta-ink font-bold text-xs leading-tight block" data-testid="special-note">
                           Phoenix-based<br />& US Only!
                         </span>
                       ) : (
-                        <Check className="w-7 h-7 text-violet-400 mx-auto" strokeWidth={3} data-testid={`check-${index}`} />
+                        <Check className="w-7 h-7 text-de-magenta-ink mx-auto" strokeWidth={3} data-testid={`check-${index}`} />
                       )}
                     </td>
                   </tr>
@@ -93,13 +93,13 @@ export default function TwentyOneQuestions() {
             </table>
           </div>
 
-          <div className="bg-gradient-to-br from-[#1a1a2e] to-[#2a2a3e] border-4 border-violet-400 rounded-xl p-8 md:p-12 text-center mb-12">
+          <div className="bg-gradient-to-br from-[#1a1a2e] to-[#2a2a3e] border-4 border-de-hairline rounded-xl p-8 md:p-12 text-center mb-12">
             <h2 className="text-2xl md:text-3xl font-bold text-white mb-6" data-testid="heading-cta">
               Ready to experience the Digerati Experts difference?
             </h2>
             <a 
               href="tel:+13254809870" 
-              className="text-3xl md:text-4xl font-bold text-violet-400 hover:text-violet-300 transition-colors block mb-6"
+              className="text-3xl md:text-4xl font-bold text-de-magenta-ink hover:text-de-magenta-ink transition-colors block mb-6"
               data-testid="link-phone"
             >
               <Phone className="w-8 h-8 inline-block mr-3 -mt-1" />
@@ -114,7 +114,7 @@ export default function TwentyOneQuestions() {
                 href="/book"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 bg-violet-500 hover:bg-violet-400 text-white font-semibold px-8 py-4 rounded-lg transition-colors"
+                className="inline-flex items-center gap-2 bg-de-magenta hover:bg-de-magenta text-white font-semibold px-8 py-4 rounded-lg transition-colors"
                 data-testid="button-schedule"
               >
                 {CTA.primary}

--- a/client/src/pages/industries/Accounting.tsx
+++ b/client/src/pages/industries/Accounting.tsx
@@ -173,7 +173,7 @@ export default function Accounting() {
               href="/book" 
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center justify-center bg-gradient-to-r from-fuchsia-600 via-pink-600 to-rose-500 hover:from-fuchsia-500 hover:via-pink-500 hover:to-rose-400 text-white px-8 py-3 rounded-lg font-semibold transition-all border border-pink-300/25"
+              className="inline-flex items-center justify-center bg-[#D3126A] hover:bg-[#B80E5C] text-white px-8 py-3 rounded-lg font-semibold transition-all border border-pink-300/25"
               data-testid="button-schedule-accounting"
             >
               {CTA.primary}

--- a/client/src/pages/industries/Accounting.tsx
+++ b/client/src/pages/industries/Accounting.tsx
@@ -22,7 +22,7 @@ export default function Accounting() {
     <PageTemplate
       title="IT Solutions for Accounting & Finance"
       subtitle="PCI DSS-aligned security and financial data protection for Arizona CPAs and accounting firms"
-      gradientColors="from-violet-600 via-purple-600 to-fuchsia-600"
+      gradientColors="from-[#050312] via-[#0a0a0a] to-[#050312]"
     >
       <div className="space-y-16">
         {/* Key Metrics - Modern Dashboard Style */}
@@ -33,7 +33,7 @@ export default function Accounting() {
               <div key={idx} className="relative group">
                 <Card className="relative bg-white/5 backdrop-blur-sm border border-white/10 hover:border-white/20 hover:shadow-lg transition-all">
                   <CardContent className="pt-6">
-                    <Icon className="h-6 w-6 text-[#A78BFA] mb-3" />
+                    <Icon className="h-6 w-6 text-de-accent-ink mb-3" />
                     <p className="text-white font-semibold">{item.label}</p>
                     <p className="text-sm text-gray-400 mt-2 leading-relaxed">{item.value}</p>
                   </CardContent>
@@ -105,10 +105,10 @@ export default function Accounting() {
             const Icon = service.icon;
             return (
               <div key={idx} className="group relative">
-                <div className="absolute inset-0 bg-gradient-to-r from-violet-400 via-purple-400 to-fuchsia-400 rounded-xl blur opacity-0 group-hover:opacity-10 transition-all duration-300" />
+                <div className="absolute inset-0 bg-de-raised rounded-xl blur opacity-0 group-hover:opacity-10 transition-all duration-300" />
                 <Card className="relative h-full bg-white/5 backdrop-blur-sm border border-white/10 hover:border-white/20 hover:shadow-xl transition-all duration-300">
                   <CardHeader>
-                    <Icon className="h-10 w-10 text-violet-400 mb-2 group-hover:scale-110 transition-transform" />
+                    <Icon className="h-10 w-10 text-de-accent-ink mb-2 group-hover:scale-110 transition-transform" />
                     <CardTitle className="text-xl text-white">{service.title}</CardTitle>
                     <p className="text-sm text-gray-400 mt-2">{service.desc}</p>
                   </CardHeader>

--- a/client/src/pages/industries/AnimalHospitals.tsx
+++ b/client/src/pages/industries/AnimalHospitals.tsx
@@ -15,10 +15,10 @@ export default function AnimalHospitals() {
   const prefersReducedMotion = useReducedMotion() ?? false;
   
   const metrics = [
-    { label: "Data Protection", value: "100%", icon: Shield, color: "from-violet-500 to-purple-500" },
-    { label: "System Uptime", value: "99.95%", icon: Activity, color: "from-purple-500 to-fuchsia-500" },
-    { label: "Response Time", value: "<15min", icon: Clock, color: "from-violet-500 to-purple-500" },
-    { label: "Veterinary Clients", value: "20+", icon: Heart, color: "from-purple-500 to-fuchsia-500" }
+    { label: "Data Protection", value: "100%", icon: Shield, color: " " },
+    { label: "System Uptime", value: "99.95%", icon: Activity, color: " to-fuchsia-500" },
+    { label: "Response Time", value: "<15min", icon: Clock, color: " " },
+    { label: "Veterinary Clients", value: "20+", icon: Heart, color: " to-fuchsia-500" }
   ];
 
   const challenges = [
@@ -26,19 +26,19 @@ export default function AnimalHospitals() {
       icon: Database, 
       title: "Patient Records Security", 
       description: "Protect sensitive pet medical records and client payment information with enterprise-grade encryption.",
-      color: "text-violet-400"
+      color: "text-de-accent-ink"
     },
     { 
       icon: Lock, 
       title: "Payment Card Compliance", 
       description: "Maintain PCI DSS compliance for credit card transactions and client billing systems.",
-      color: "text-violet-400"
+      color: "text-de-accent-ink"
     },
     { 
       icon: Users, 
       title: "Multi-Location Management", 
       description: "Seamlessly manage IT across multiple clinic locations with centralized security and monitoring.",
-      color: "text-violet-400"
+      color: "text-de-accent-ink"
     }
   ];
 
@@ -59,7 +59,7 @@ export default function AnimalHospitals() {
     <PageTemplate
       title="IT Solutions for Veterinary Practices"
       subtitle="Secure, reliable IT solutions designed specifically for animal hospitals and veterinary clinics across Arizona."
-      gradientColors="from-violet-600 via-purple-600 to-fuchsia-600"
+      gradientColors="from-[#050312] via-[#0a0a0a] to-[#050312]"
       icon={<PawPrint className="w-10 h-10 text-white" />}
       breadcrumbs={[{ label: "Industries", href: "/" }, { label: "Animal Hospitals" }]}
     >
@@ -78,7 +78,7 @@ export default function AnimalHospitals() {
                 className="group relative"
               >
                 <div className={`absolute inset-0 bg-gradient-to-r ${metric.color} rounded-xl blur opacity-0 group-hover:opacity-30 transition-all duration-300`} />
-                <Card className="relative bg-white/5 backdrop-blur-sm border border-white/10 hover:border-violet-500/30 hover:shadow-lg transition-all">
+                <Card className="relative bg-white/5 backdrop-blur-sm border border-white/10 hover:border-de-hairline hover:shadow-lg transition-all">
                   <CardContent className="pt-6">
                     <div className="flex items-start justify-between mb-3">
                       <div className={`w-10 h-10 rounded-lg bg-gradient-to-r ${metric.color} flex items-center justify-center`}>
@@ -138,7 +138,7 @@ export default function AnimalHospitals() {
                   viewport={{ once: true }}
                   transition={{ delay: idx * 0.1, duration: 0.5 }}
                 >
-                  <Card className="bg-white/5 backdrop-blur-sm border border-white/10 hover:border-violet-500/30 transition-all h-full">
+                  <Card className="bg-white/5 backdrop-blur-sm border border-white/10 hover:border-de-hairline transition-all h-full">
                     <CardHeader>
                       <div className={`w-12 h-12 rounded-lg bg-white/10 flex items-center justify-center mb-4`}>
                         <Icon className={`h-6 w-6 ${challenge.color}`} />
@@ -162,10 +162,10 @@ export default function AnimalHospitals() {
           viewport={{ once: true }}
           transition={{ duration: 0.5 }}
         >
-          <Card className="bg-gradient-to-br from-violet-600/20 to-purple-600/20 border border-violet-500/30">
+          <Card className="bg-de-raised border border-de-hairline">
             <CardHeader>
               <CardTitle className="text-2xl text-white flex items-center gap-3">
-                <Shield className="h-7 w-7 text-violet-400" />
+                <Shield className="h-7 w-7 text-de-accent-ink" />
                 Complete Security for Your Practice
               </CardTitle>
             </CardHeader>
@@ -200,7 +200,7 @@ export default function AnimalHospitals() {
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <a 
               href="/book"
-              className="inline-flex items-center justify-center gap-2 px-8 py-4 bg-violet-600 hover:bg-violet-700 text-white font-semibold rounded-lg transition-colors"
+              className="inline-flex items-center justify-center gap-2 px-8 py-4 bg-de-accent hover:bg-de-accent text-white font-semibold rounded-lg transition-colors"
               data-testid="button-schedule-call"
             >
               <Phone className="h-5 w-5" />

--- a/client/src/pages/industries/Healthcare.tsx
+++ b/client/src/pages/industries/Healthcare.tsx
@@ -186,10 +186,10 @@ export default function Healthcare() {
         {/* Supporting focus labels (elevated from prior metrics — not fake KPIs) */}
         <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-4">
           {[
-            { label: "Focus", value: "HIPAA", icon: Shield, color: "from-[#D3126A] to-[#D3126A]" },
-            { label: "Encryption", value: "AES-256", icon: Lock, color: "from-fuchsia-600 " },
-            { label: "Priority", value: "PHI", icon: Activity, color: " to-[#D3126A]" },
-            { label: "Outcome", value: "Audit-ready evidence", icon: Heart, color: "from-[#D3126A] to-rose-500" },
+            { label: "Focus", value: "HIPAA", icon: Shield },
+            { label: "Encryption", value: "AES-256", icon: Lock },
+            { label: "Priority", value: "PHI", icon: Activity },
+            { label: "Outcome", value: "Audit-ready evidence", icon: Heart },
           ].map((metric, idx) => {
             const Icon = metric.icon;
             return (
@@ -202,13 +202,13 @@ export default function Healthcare() {
                 className="group relative"
               >
                 <div
-                  className={`absolute inset-0 bg-gradient-to-r ${metric.color} rounded-xl blur opacity-0 group-hover:opacity-30 transition-all duration-300`}
+                  className="absolute inset-0 bg-[#D3126A] rounded-xl blur opacity-0 group-hover:opacity-30 transition-all duration-300"
                 />
                 <Card className="relative bg-white/5 backdrop-blur-sm border border-white/10 hover:border-de-hairline transition-all">
                   <CardContent className="pt-6">
                     <div className="flex items-start justify-between mb-3">
                       <div
-                        className={`w-10 h-10 rounded-lg bg-gradient-to-r ${metric.color} flex items-center justify-center`}
+                        className="w-10 h-10 rounded-lg bg-[#D3126A] flex items-center justify-center"
                       >
                         <Icon className="h-5 w-5 text-white" />
                       </div>

--- a/client/src/pages/industries/Healthcare.tsx
+++ b/client/src/pages/industries/Healthcare.tsx
@@ -174,7 +174,7 @@ export default function Healthcare() {
                 transition={{ delay: idx * 0.06, duration: 0.4 }}
                 className="flex items-center gap-3 p-4 rounded-xl bg-white/[0.04] border border-white/10"
               >
-                <div className="w-9 h-9 rounded-lg bg-gradient-to-r from-[#D3126A] to-fuchsia-600 flex items-center justify-center shrink-0">
+                <div className="w-9 h-9 rounded-lg bg-[#D3126A] flex items-center justify-center shrink-0">
                   <Icon className="h-4 w-4 text-white" />
                 </div>
                 <p className="text-sm font-medium text-white/90 leading-snug">{item.label}</p>
@@ -186,7 +186,7 @@ export default function Healthcare() {
         {/* Supporting focus labels (elevated from prior metrics — not fake KPIs) */}
         <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-4">
           {[
-            { label: "Focus", value: "HIPAA", icon: Shield, color: "from-[#D3126A] to-fuchsia-600" },
+            { label: "Focus", value: "HIPAA", icon: Shield, color: "from-[#D3126A] to-[#D3126A]" },
             { label: "Encryption", value: "AES-256", icon: Lock, color: "from-fuchsia-600 " },
             { label: "Priority", value: "PHI", icon: Activity, color: " to-[#D3126A]" },
             { label: "Outcome", value: "Audit-ready evidence", icon: Heart, color: "from-[#D3126A] to-rose-500" },
@@ -584,7 +584,7 @@ export default function Healthcare() {
           transition={{ duration: 0.5 }}
           data-testid="section-final-cta"
         >
-          <div className="absolute inset-0 bg-gradient-to-r from-[#D3126A] via-fuchsia-600 to-rose-500" />
+          <div className="absolute inset-0 bg-[#D3126A]" />
           <div className="relative p-8 md:p-12 text-center">
             <h2 className="text-3xl md:text-4xl font-bold mb-4 text-white">
               {narrative?.ctaHeadline ?? "Protect patient data with a clear plan"}

--- a/client/src/pages/industries/Healthcare.tsx
+++ b/client/src/pages/industries/Healthcare.tsx
@@ -137,7 +137,7 @@ export default function Healthcare() {
     <PageTemplate
       title="Keep Patient Data Protected Without Becoming a HIPAA Expert"
       subtitle="Digerati manages security, backups, access controls, documentation, and ongoing IT behind Arizona practices so owners can focus on patients."
-      gradientColors="from-violet-600 via-purple-600 to-fuchsia-600"
+      gradientColors="from-[#050312] via-[#0a0a0a] to-[#050312]"
       icon={<Stethoscope className="w-10 h-10 text-white" />}
       breadcrumbs={[{ label: "Industries", href: "/" }, { label: "Healthcare" }]}
       actions={
@@ -187,8 +187,8 @@ export default function Healthcare() {
         <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-4">
           {[
             { label: "Focus", value: "HIPAA", icon: Shield, color: "from-[#D3126A] to-fuchsia-600" },
-            { label: "Encryption", value: "AES-256", icon: Lock, color: "from-fuchsia-600 to-violet-600" },
-            { label: "Priority", value: "PHI", icon: Activity, color: "from-violet-600 to-[#D3126A]" },
+            { label: "Encryption", value: "AES-256", icon: Lock, color: "from-fuchsia-600 " },
+            { label: "Priority", value: "PHI", icon: Activity, color: " to-[#D3126A]" },
             { label: "Outcome", value: "Audit-ready evidence", icon: Heart, color: "from-[#D3126A] to-rose-500" },
           ].map((metric, idx) => {
             const Icon = metric.icon;
@@ -204,7 +204,7 @@ export default function Healthcare() {
                 <div
                   className={`absolute inset-0 bg-gradient-to-r ${metric.color} rounded-xl blur opacity-0 group-hover:opacity-30 transition-all duration-300`}
                 />
-                <Card className="relative bg-white/5 backdrop-blur-sm border border-white/10 hover:border-violet-500/30 transition-all">
+                <Card className="relative bg-white/5 backdrop-blur-sm border border-white/10 hover:border-de-hairline transition-all">
                   <CardContent className="pt-6">
                     <div className="flex items-start justify-between mb-3">
                       <div
@@ -269,7 +269,7 @@ export default function Healthcare() {
             viewport={{ once: true }}
             transition={{ duration: 0.5 }}
           >
-            <div className="w-10 h-10 rounded-lg bg-gradient-to-r from-violet-600 to-purple-600 flex items-center justify-center">
+            <div className="w-10 h-10 rounded-lg bg-de-raised flex items-center justify-center">
               <Shield className="w-5 h-5 text-white" />
             </div>
             Common healthcare IT &amp; security problems
@@ -285,10 +285,10 @@ export default function Healthcare() {
                   viewport={{ once: true }}
                   transition={{ delay: idx * 0.1, duration: 0.5 }}
                 >
-                  <Card className="group h-full bg-white/5 backdrop-blur-sm border border-white/10 hover:border-violet-500/30 transition-all duration-300">
+                  <Card className="group h-full bg-white/5 backdrop-blur-sm border border-white/10 hover:border-de-hairline transition-all duration-300">
                     <CardHeader>
-                      <div className="w-14 h-14 rounded-xl bg-gradient-to-br from-violet-500/20 to-purple-500/20 flex items-center justify-center mb-4 group-hover:scale-110 transition-transform">
-                        <Icon className="h-7 w-7 text-violet-400" />
+                      <div className="w-14 h-14 rounded-xl bg-de-raised flex items-center justify-center mb-4 group-hover:scale-110 transition-transform">
+                        <Icon className="h-7 w-7 text-de-accent-ink" />
                       </div>
                       <CardTitle className="text-xl text-white">{item.title}</CardTitle>
                     </CardHeader>
@@ -393,12 +393,12 @@ export default function Healthcare() {
           transition={{ duration: 0.5 }}
           data-testid="section-security-stack"
         >
-          <div className="absolute top-0 right-0 w-64 h-64 bg-gradient-to-bl from-violet-500/20 to-transparent rounded-full blur-3xl" />
-          <div className="absolute bottom-0 left-0 w-48 h-48 bg-gradient-to-tr from-purple-500/20 to-transparent rounded-full blur-3xl" />
+          <div className="absolute top-0 right-0 w-64 h-64 bg-de-raised to-transparent rounded-full blur-3xl" />
+          <div className="absolute bottom-0 left-0 w-48 h-48 bg-de-raised to-transparent rounded-full blur-3xl" />
 
           <div className="relative">
             <div className="flex items-center gap-3 mb-3">
-              <div className="w-10 h-10 rounded-lg bg-gradient-to-r from-violet-600 to-purple-600 flex items-center justify-center">
+              <div className="w-10 h-10 rounded-lg bg-de-raised flex items-center justify-center">
                 <FileCheck className="w-5 h-5 text-white" />
               </div>
               <h2 className="text-3xl font-bold text-white">Healthcare security stack &amp; outcomes</h2>
@@ -412,7 +412,7 @@ export default function Healthcare() {
               {securityStack.map((item, index) => (
                 <motion.div
                   key={item}
-                  className="flex items-center gap-3 p-4 bg-white/5 backdrop-blur-sm rounded-xl border border-white/10 hover:border-violet-500/30 transition-all duration-300"
+                  className="flex items-center gap-3 p-4 bg-white/5 backdrop-blur-sm rounded-xl border border-white/10 hover:border-de-hairline transition-all duration-300"
                   initial={prefersReducedMotion ? {} : { opacity: 0, x: -10 }}
                   whileInView={{ opacity: 1, x: 0 }}
                   viewport={{ once: true }}
@@ -472,7 +472,7 @@ export default function Healthcare() {
         {/* 10. Free assessment module — major conversion block */}
         <motion.section
           id="assessment"
-          className="relative scroll-mt-28 rounded-2xl border border-[#D3126A]/35 bg-gradient-to-br from-[#D3126A]/15 via-white/[0.03] to-violet-900/20 p-8 md:p-12 overflow-hidden"
+          className="relative scroll-mt-28 rounded-2xl border border-[#D3126A]/35 bg-gradient-to-br from-[#D3126A]/15 via-white/[0.03] p-8 md:p-12 overflow-hidden"
           initial={prefersReducedMotion ? {} : { opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
@@ -518,7 +518,7 @@ export default function Healthcare() {
         {/* 11. Simple 3-step engagement */}
         <section data-testid="section-process">
           <div className="flex items-center gap-3 mb-8">
-            <div className="w-10 h-10 rounded-lg bg-violet-600 flex items-center justify-center">
+            <div className="w-10 h-10 rounded-lg bg-de-accent flex items-center justify-center">
               <ArrowRight className="w-5 h-5 text-white" />
             </div>
             <div>

--- a/client/src/pages/industries/LawFirms.tsx
+++ b/client/src/pages/industries/LawFirms.tsx
@@ -23,7 +23,7 @@ export default function LawFirms() {
     <PageTemplate
       title="IT Solutions for Law Firms"
       subtitle="Protect client privilege, prevent data breaches, stay compliant—secure IT for Arizona attorneys"
-      gradientColors="from-violet-600 via-purple-600 to-fuchsia-600"
+      gradientColors="from-[#050312] via-[#0a0a0a] to-[#050312]"
     >
       <div className="space-y-16">
         {/* Risk Assessment Cards */}
@@ -36,7 +36,7 @@ export default function LawFirms() {
               return (
                 <Card key={idx} className="bg-white/5 backdrop-blur-sm border-white/10 hover:shadow-lg transition-all">
                   <CardContent className="pt-6">
-                    <Icon className="h-8 w-8 text-violet-400 mb-3" />
+                    <Icon className="h-8 w-8 text-de-accent-ink mb-3" />
                     <h3 className="font-semibold text-white mb-2">{item.factor}</h3>
                     <Badge className={`${severity} border`}>{item.severity}</Badge>
                   </CardContent>
@@ -102,10 +102,10 @@ export default function LawFirms() {
               const Icon = service.icon;
               return (
                 <div key={idx} className="group relative">
-                  <div className="absolute inset-0 bg-gradient-to-r from-violet-500 to-purple-500 rounded-xl blur opacity-0 group-hover:opacity-15 transition-all" />
-                  <Card className="relative bg-white/5 backdrop-blur-sm hover:shadow-lg transition-all border border-white/10 group-hover:border-violet-500/30">
+                  <div className="absolute inset-0 bg-de-raised rounded-xl blur opacity-0 group-hover:opacity-15 transition-all" />
+                  <Card className="relative bg-white/5 backdrop-blur-sm hover:shadow-lg transition-all border border-white/10 group-hover:border-de-hairline">
                     <CardHeader>
-                      <Icon className="h-10 w-10 text-violet-400 mb-2 group-hover:scale-110 transition-transform" />
+                      <Icon className="h-10 w-10 text-de-accent-ink mb-2 group-hover:scale-110 transition-transform" />
                       <CardTitle className="text-white">{service.title}</CardTitle>
                       <p className="text-sm text-gray-400 mt-1">{service.desc}</p>
                     </CardHeader>
@@ -127,7 +127,7 @@ export default function LawFirms() {
         </div>
 
         {/* Compliance Dashboard */}
-        <div className="bg-violet-500/10 border border-violet-500/30 rounded-xl p-8">
+        <div className="bg-de-raised border border-de-hairline rounded-xl p-8">
           <h3 className="text-2xl font-bold mb-8 text-center text-white">ABA Compliance Checklist</h3>
           <div className="grid md:grid-cols-2 gap-6">
             {[

--- a/client/src/pages/industries/LawFirms.tsx
+++ b/client/src/pages/industries/LawFirms.tsx
@@ -185,7 +185,7 @@ export default function LawFirms() {
         </div>
 
         {/* CTA */}
-        <div className="bg-gradient-to-r from-[#D3126A] via-fuchsia-600 to-rose-500 rounded-xl p-8 text-center text-white">
+        <div className="bg-[#D3126A] rounded-xl p-8 text-center text-white">
           <h2 className="text-3xl font-bold mb-4">Protect privilege with a clear security plan</h2>
           <p className="text-lg mb-6 text-white/90">Schedule a cyber risk assessment focused on law-firm email, access, and client data.</p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">

--- a/client/src/pages/industries/Nonprofits.tsx
+++ b/client/src/pages/industries/Nonprofits.tsx
@@ -12,9 +12,9 @@ export default function Nonprofits() {
     canonical: "/industries/nonprofits",
   });
   const savings = [
-    { metric: "IT Cost Savings", value: "40%", icon: DollarSign, color: "text-violet-400" },
-    { metric: "Staff Time Saved", value: "6 hrs/wk", icon: Zap, color: "text-violet-400" },
-    { metric: "Donor Confidence", value: "+85%", icon: Heart, color: "text-violet-400" },
+    { metric: "IT Cost Savings", value: "40%", icon: DollarSign, color: "text-de-accent-ink" },
+    { metric: "Staff Time Saved", value: "6 hrs/wk", icon: Zap, color: "text-de-accent-ink" },
+    { metric: "Donor Confidence", value: "+85%", icon: Heart, color: "text-de-accent-ink" },
     { metric: "Audit Pass Rate", value: "100%", icon: CheckCircle, color: "text-emerald-500" }
   ];
 
@@ -22,7 +22,7 @@ export default function Nonprofits() {
     <PageTemplate
       title="IT Solutions for Nonprofits"
       subtitle="Cost-effective, compliant IT for mission-driven organizations in Arizona"
-      gradientColors="from-violet-600 via-purple-600 to-fuchsia-600"
+      gradientColors="from-[#050312] via-[#0a0a0a] to-[#050312]"
     >
       <div className="space-y-16">
         {/* Impact Metrics */}
@@ -31,7 +31,7 @@ export default function Nonprofits() {
             const Icon = item.icon;
             return (
               <div key={idx} className="relative group">
-                <div className="absolute inset-0 bg-gradient-to-r from-violet-500 to-purple-500 rounded-xl blur opacity-0 group-hover:opacity-20 transition-all" />
+                <div className="absolute inset-0 bg-de-raised rounded-xl blur opacity-0 group-hover:opacity-20 transition-all" />
                 <Card className="relative bg-white/5 backdrop-blur-sm border border-white/10 hover:bg-white/10 hover:shadow-lg transition-all">
                   <CardContent className="pt-6">
                     <Icon className={`h-6 w-6 ${item.color} mb-3`} />
@@ -45,9 +45,9 @@ export default function Nonprofits() {
         </div>
 
         {/* Why Nonprofits Struggle */}
-        <div className="bg-violet-500/10 backdrop-blur-sm border border-violet-500/30 rounded-xl p-8">
+        <div className="bg-de-raised backdrop-blur-sm border border-de-hairline rounded-xl p-8">
           <div className="flex gap-4">
-            <Target className="h-8 w-8 text-violet-400 flex-shrink-0 mt-1" />
+            <Target className="h-8 w-8 text-de-accent-ink flex-shrink-0 mt-1" />
             <div>
               <h3 className="text-2xl font-bold text-white mb-3">Nonprofit IT Challenges</h3>
               <div className="space-y-2 text-white/50">
@@ -59,7 +59,7 @@ export default function Nonprofits() {
                   "Rapid growth strains IT infrastructure"
                 ].map((item, idx) => (
                   <div key={idx} className="flex gap-2">
-                    <span className="text-violet-400 font-bold">•</span>
+                    <span className="text-de-accent-ink font-bold">•</span>
                     <span>{item}</span>
                   </div>
                 ))}
@@ -101,10 +101,10 @@ export default function Nonprofits() {
               const Icon = service.icon;
               return (
                 <div key={idx} className="group relative">
-                  <div className="absolute inset-0 bg-gradient-to-r from-violet-500 to-purple-500 rounded-xl blur opacity-0 group-hover:opacity-15 transition-all" />
-                  <Card className="relative bg-white/5 backdrop-blur-sm border border-white/10 hover:bg-white/10 hover:shadow-lg transition-all group-hover:border-violet-500/30">
+                  <div className="absolute inset-0 bg-de-raised rounded-xl blur opacity-0 group-hover:opacity-15 transition-all" />
+                  <Card className="relative bg-white/5 backdrop-blur-sm border border-white/10 hover:bg-white/10 hover:shadow-lg transition-all group-hover:border-de-hairline">
                     <CardHeader>
-                      <Icon className="h-10 w-10 text-violet-400 mb-2 group-hover:scale-110 transition-transform" />
+                      <Icon className="h-10 w-10 text-de-accent-ink mb-2 group-hover:scale-110 transition-transform" />
                       <CardTitle className="text-white">{service.title}</CardTitle>
                       <p className="text-sm text-gray-400 mt-1">{service.desc}</p>
                     </CardHeader>
@@ -126,7 +126,7 @@ export default function Nonprofits() {
         </div>
 
         {/* Supported Programs */}
-        <div className="bg-violet-500/10 backdrop-blur-sm rounded-xl p-8 border border-violet-500/20">
+        <div className="bg-de-raised backdrop-blur-sm rounded-xl p-8 border border-de-hairline">
           <h3 className="text-2xl font-bold mb-8 text-center text-white">Nonprofit Programs We Support</h3>
           <div className="grid md:grid-cols-3 gap-4">
             {[
@@ -146,13 +146,13 @@ export default function Nonprofits() {
         </div>
 
         {/* Success Story */}
-        <div className="grid md:grid-cols-3 gap-6 bg-gradient-to-r from-violet-600 to-purple-600 rounded-xl p-8 text-white">
+        <div className="grid md:grid-cols-3 gap-6 bg-de-raised rounded-xl p-8 text-white">
           <div className="text-center p-4 bg-white/10 rounded-lg backdrop-blur-sm">
             <p className="text-3xl font-bold mb-1">40%</p>
             <p className="text-white/70">IT Cost Reduction</p>
             <p className="text-xs text-white/50 mt-2">20% nonprofit discount + efficient management</p>
           </div>
-          <div className="text-center p-4 bg-white/10 rounded-lg backdrop-blur-sm border-l border-r border-violet-400">
+          <div className="text-center p-4 bg-white/10 rounded-lg backdrop-blur-sm border-l border-r border-de-hairline">
             <p className="text-3xl font-bold mb-1">100%</p>
             <p className="text-white/70">Audit Pass Rate</p>
             <p className="text-xs text-white/50 mt-2">Grant compliance documentation</p>
@@ -165,7 +165,7 @@ export default function Nonprofits() {
         </div>
 
         {/* CTA */}
-        <div className="bg-gradient-to-r from-violet-600 to-purple-600 rounded-xl p-8 text-center text-white">
+        <div className="bg-de-raised rounded-xl p-8 text-center text-white">
           <h2 className="text-3xl font-bold mb-4">Focus on Your Mission</h2>
           <p className="text-lg mb-6 text-white/70">Let us handle technology. Get nonprofit pricing + free consultation.</p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
@@ -173,7 +173,7 @@ export default function Nonprofits() {
               href="/book" 
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center justify-center bg-white text-violet-700 hover:bg-violet-50 px-8 py-3 rounded-lg font-semibold transition-all hover:shadow-lg"
+              className="inline-flex items-center justify-center bg-white text-de-accent hover:bg-de-paper-raised px-8 py-3 rounded-lg font-semibold transition-all hover:shadow-lg"
               data-testid="button-schedule-nonprofit"
             >
               Schedule Free Consultation

--- a/client/src/pages/industries/RealEstate.tsx
+++ b/client/src/pages/industries/RealEstate.tsx
@@ -165,7 +165,7 @@ export default function RealEstate() {
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <a 
               href="/book" 
-              className="inline-flex items-center justify-center bg-gradient-to-r from-fuchsia-600 via-pink-600 to-rose-500 hover:from-fuchsia-500 hover:via-pink-500 hover:to-rose-400 text-white px-8 py-3 rounded-lg font-semibold transition-all border border-pink-300/25"
+              className="inline-flex items-center justify-center bg-[#D3126A] hover:bg-[#B80E5C] text-white px-8 py-3 rounded-lg font-semibold transition-all border border-pink-300/25"
               data-testid="button-schedule-real-estate"
             >
               {CTA.primary}

--- a/client/src/pages/industries/RealEstate.tsx
+++ b/client/src/pages/industries/RealEstate.tsx
@@ -22,7 +22,7 @@ export default function RealEstate() {
     <PageTemplate
       title="IT Solutions for Real Estate Professionals"
       subtitle="Prevent wire fraud, protect transaction data, stay compliant—secure IT for Arizona real estate"
-      gradientColors="from-violet-600 via-purple-600 to-fuchsia-600"
+      gradientColors="from-[#050312] via-[#0a0a0a] to-[#050312]"
     >
       <div className="space-y-16">
         {/* Wire Fraud Statistics - Modern Dashboard */}
@@ -32,7 +32,7 @@ export default function RealEstate() {
             return (
               <Card key={item.title} className="relative bg-white/5 backdrop-blur-sm border border-white/10 hover:bg-white/10 hover:shadow-lg transition-all">
                 <CardContent className="pt-6">
-                  <Icon className="h-6 w-6 text-[#A78BFA] mb-3" />
+                  <Icon className="h-6 w-6 text-de-accent-ink mb-3" />
                   <p className="font-semibold text-white">{item.title}</p>
                   <p className="text-sm text-gray-400 mt-2 leading-relaxed">{item.body}</p>
                 </CardContent>
@@ -98,10 +98,10 @@ export default function RealEstate() {
               const Icon = service.icon;
               return (
                 <div key={idx} className="group relative">
-                  <div className="absolute inset-0 bg-gradient-to-r from-violet-500 to-purple-500 rounded-xl blur opacity-0 group-hover:opacity-15 transition-all" />
-                  <Card className="relative bg-white/5 backdrop-blur-sm border border-white/10 hover:bg-white/10 hover:shadow-lg transition-all group-hover:border-violet-500/30">
+                  <div className="absolute inset-0 bg-de-raised rounded-xl blur opacity-0 group-hover:opacity-15 transition-all" />
+                  <Card className="relative bg-white/5 backdrop-blur-sm border border-white/10 hover:bg-white/10 hover:shadow-lg transition-all group-hover:border-de-hairline">
                     <CardHeader>
-                      <Icon className="h-10 w-10 text-violet-400 mb-2 group-hover:scale-110 transition-transform" />
+                      <Icon className="h-10 w-10 text-de-accent-ink mb-2 group-hover:scale-110 transition-transform" />
                       <CardTitle className="text-white">{service.title}</CardTitle>
                       <p className="text-sm text-gray-400 mt-1">{service.desc}</p>
                     </CardHeader>
@@ -123,7 +123,7 @@ export default function RealEstate() {
         </div>
 
         {/* Protection Checklist */}
-        <div className="bg-violet-500/10 backdrop-blur-sm rounded-xl p-8 border border-violet-500/20">
+        <div className="bg-de-raised backdrop-blur-sm rounded-xl p-8 border border-de-hairline">
           <h3 className="text-2xl font-bold mb-6 text-white">Wire Fraud Prevention Checklist</h3>
           <div className="grid md:grid-cols-2 gap-4">
             {[

--- a/client/src/pages/legal/AUP.tsx
+++ b/client/src/pages/legal/AUP.tsx
@@ -12,7 +12,7 @@ export default function AUP() {
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">
           <div className="max-w-4xl">
             <div className="flex items-center gap-3 mb-6">
-              <ShieldAlert className="h-12 w-12 text-purple-400" />
+              <ShieldAlert className="h-12 w-12 text-de-accent-ink" />
               <h1 className="text-4xl md:text-5xl font-bold">Acceptable Use Policy</h1>
             </div>
             <p className="text-xl text-gray-300">
@@ -65,7 +65,7 @@ export default function AUP() {
             <h2 className="text-2xl font-bold text-white mb-4 mt-8">Request Full AUP</h2>
             <div className="flex flex-col sm:flex-row gap-4 mt-8">
               <Button 
-                className="bg-gradient-to-r from-purple-600 to-blue-600 text-white hover:from-purple-700 hover:to-blue-700"
+                className="bg-de-raised text-white hover: hover:to-blue-700"
                 onClick={() => window.location.href = 'mailto:legal@digeratiexperts.com?subject=AUP Request'}
                 data-testid="button-request-aup"
               >

--- a/client/src/pages/legal/DPA.tsx
+++ b/client/src/pages/legal/DPA.tsx
@@ -12,7 +12,7 @@ export default function DPA() {
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">
           <div className="max-w-4xl">
             <div className="flex items-center gap-3 mb-6">
-              <Database className="h-12 w-12 text-purple-400" />
+              <Database className="h-12 w-12 text-de-accent-ink" />
               <h1 className="text-4xl md:text-5xl font-bold">Data Processing Agreement</h1>
             </div>
             <p className="text-xl text-gray-300">
@@ -46,7 +46,7 @@ export default function DPA() {
               </ul>
             </div>
 
-            <div className="bg-purple-500/10 backdrop-blur-sm border border-purple-500/30 border-l-4 border-l-purple-500 p-6 rounded mb-8">
+            <div className="bg-de-raised backdrop-blur-sm border border-de-hairline border-l-4 border-l-de-accent p-6 rounded mb-8">
               <h3 className="text-xl font-semibold text-white mb-3">Compliance Frameworks:</h3>
               <ul className="list-disc pl-6 text-gray-300 space-y-2">
                 <li><strong className="text-white">HIPAA:</strong> Business Associate Agreement provisions for Protected Health Information</li>
@@ -64,7 +64,7 @@ export default function DPA() {
 
             <div className="flex flex-col sm:flex-row gap-4 mt-8">
               <Button 
-                className="bg-gradient-to-r from-purple-600 to-blue-600 text-white hover:from-purple-700 hover:to-blue-700"
+                className="bg-de-raised text-white hover: hover:to-blue-700"
                 onClick={() => window.location.href = 'mailto:legal@digeratiexperts.com?subject=DPA Request'}
                 data-testid="button-request-dpa"
               >

--- a/client/src/pages/legal/MSA.tsx
+++ b/client/src/pages/legal/MSA.tsx
@@ -12,7 +12,7 @@ export default function MSA() {
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">
           <div className="max-w-4xl">
             <div className="flex items-center gap-3 mb-6">
-              <FileText className="h-12 w-12 text-purple-400" />
+              <FileText className="h-12 w-12 text-de-accent-ink" />
               <h1 className="text-4xl md:text-5xl font-bold">Master Service Agreement</h1>
             </div>
             <p className="text-xl text-gray-300">
@@ -30,7 +30,7 @@ export default function MSA() {
               the provision of managed IT and security services by Digerati Experts to our clients.
             </p>
 
-            <div className="bg-purple-500/10 backdrop-blur-sm border border-purple-500/30 border-l-4 border-l-purple-500 p-6 rounded mb-8">
+            <div className="bg-de-raised backdrop-blur-sm border border-de-hairline border-l-4 border-l-de-accent p-6 rounded mb-8">
               <h3 className="text-xl font-semibold text-white mb-3">What's Included in Our MSA:</h3>
               <ul className="list-disc pl-6 text-gray-300 space-y-2">
                 <li>Scope of managed IT and security services</li>
@@ -55,7 +55,7 @@ export default function MSA() {
 
             <div className="flex flex-col sm:flex-row gap-4 mt-8">
               <Button 
-                className="bg-gradient-to-r from-purple-600 to-blue-600 text-white hover:from-purple-700 hover:to-blue-700"
+                className="bg-de-raised text-white hover: hover:to-blue-700"
                 onClick={() => window.location.href = 'mailto:legal@digeratiexperts.com?subject=MSA Request'}
                 data-testid="button-request-msa"
               >

--- a/client/src/pages/legal/PrivacyPolicy.tsx
+++ b/client/src/pages/legal/PrivacyPolicy.tsx
@@ -21,7 +21,7 @@ export default function PrivacyPolicy() {
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">
           <div className="max-w-4xl">
             <div className="flex items-center gap-3 mb-6">
-              <Shield className="h-12 w-12 text-purple-400" />
+              <Shield className="h-12 w-12 text-de-accent-ink" />
               <h1 className="text-4xl md:text-5xl font-bold">Privacy Policy</h1>
             </div>
             <p className="text-xl text-gray-300">
@@ -58,7 +58,7 @@ export default function PrivacyPolicy() {
             {/* Information We Collect */}
             <div className="mb-12">
               <h2 className="text-3xl font-bold text-white mb-4 flex items-center gap-3">
-                <Database className="h-8 w-8 text-purple-400" />
+                <Database className="h-8 w-8 text-de-accent-ink" />
                 2. Information We Collect
               </h2>
               
@@ -139,7 +139,7 @@ export default function PrivacyPolicy() {
             {/* Data Security */}
             <div className="mb-12">
               <h2 className="text-3xl font-bold text-white mb-4 flex items-center gap-3">
-                <Lock className="h-8 w-8 text-purple-400" />
+                <Lock className="h-8 w-8 text-de-accent-ink" />
                 4. Data Security Measures
               </h2>
               <p className="text-gray-300 mb-4">
@@ -364,9 +364,9 @@ export default function PrivacyPolicy() {
             </div>
 
             {/* Contact Information */}
-            <div className="mb-12 bg-purple-500/10 backdrop-blur-sm border border-purple-500/30 border-l-4 border-l-purple-500 p-6 rounded">
+            <div className="mb-12 bg-de-raised backdrop-blur-sm border border-de-hairline border-l-4 border-l-de-accent p-6 rounded">
               <h2 className="text-3xl font-bold text-white mb-4 flex items-center gap-3">
-                <FileText className="h-8 w-8 text-purple-400" />
+                <FileText className="h-8 w-8 text-de-accent-ink" />
                 15. Contact Us
               </h2>
               <p className="text-gray-300 mb-4">

--- a/client/src/pages/legal/SLA.tsx
+++ b/client/src/pages/legal/SLA.tsx
@@ -12,7 +12,7 @@ export default function SLA() {
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">
           <div className="max-w-4xl">
             <div className="flex items-center gap-3 mb-6">
-              <Clock className="h-12 w-12 text-purple-400" />
+              <Clock className="h-12 w-12 text-de-accent-ink" />
               <h1 className="text-4xl md:text-5xl font-bold">Service Level Agreement</h1>
             </div>
             <p className="text-xl text-gray-300">
@@ -35,24 +35,24 @@ export default function SLA() {
               <div className="space-y-3">
                 <div className="flex justify-between items-center border-b border-white/10 pb-2">
                   <span className="font-semibold text-white">Critical (Active Breach/System Down)</span>
-                  <span className="text-purple-400 font-bold">15 minutes</span>
+                  <span className="text-de-accent-ink font-bold">15 minutes</span>
                 </div>
                 <div className="flex justify-between items-center border-b border-white/10 pb-2">
                   <span className="font-semibold text-white">High (Major Functionality Impaired)</span>
-                  <span className="text-purple-400 font-bold">1 hour</span>
+                  <span className="text-de-accent-ink font-bold">1 hour</span>
                 </div>
                 <div className="flex justify-between items-center border-b border-white/10 pb-2">
                   <span className="font-semibold text-white">Medium (Partial Loss)</span>
-                  <span className="text-purple-400 font-bold">4 hours</span>
+                  <span className="text-de-accent-ink font-bold">4 hours</span>
                 </div>
                 <div className="flex justify-between items-center">
                   <span className="font-semibold text-white">Low (Questions/Minor Issues)</span>
-                  <span className="text-purple-400 font-bold">Next business day</span>
+                  <span className="text-de-accent-ink font-bold">Next business day</span>
                 </div>
               </div>
             </div>
 
-            <div className="bg-purple-500/10 backdrop-blur-sm border border-purple-500/30 border-l-4 border-l-purple-500 p-6 rounded mb-8">
+            <div className="bg-de-raised backdrop-blur-sm border border-de-hairline border-l-4 border-l-de-accent p-6 rounded mb-8">
               <h3 className="text-xl font-semibold text-white mb-3">SLA Commitments Include:</h3>
               <ul className="list-disc pl-6 text-gray-300 space-y-2">
                 <li>99.9% uptime for SOC monitoring and security services</li>
@@ -72,7 +72,7 @@ export default function SLA() {
 
             <div className="flex flex-col sm:flex-row gap-4 mt-8">
               <Button 
-                className="bg-gradient-to-r from-purple-600 to-blue-600 text-white hover:from-purple-700 hover:to-blue-700"
+                className="bg-de-raised text-white hover: hover:to-blue-700"
                 onClick={() => window.location.href = 'mailto:legal@digeratiexperts.com?subject=SLA Request'}
                 data-testid="button-request-sla"
               >

--- a/client/src/pages/legal/SampleSOW.tsx
+++ b/client/src/pages/legal/SampleSOW.tsx
@@ -12,7 +12,7 @@ export default function SampleSOW() {
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">
           <div className="max-w-4xl">
             <div className="flex items-center gap-3 mb-6">
-              <FileText className="h-12 w-12 text-purple-400" />
+              <FileText className="h-12 w-12 text-de-accent-ink" />
               <h1 className="text-4xl md:text-5xl font-bold">Sample Statement of Work</h1>
             </div>
             <p className="text-xl text-gray-300">
@@ -30,7 +30,7 @@ export default function SampleSOW() {
               pricing for each client engagement. Each SOW is customized to your unique requirements.
             </p>
 
-            <div className="bg-purple-500/10 backdrop-blur-sm border border-purple-500/30 border-l-4 border-l-purple-500 p-6 rounded mb-8">
+            <div className="bg-de-raised backdrop-blur-sm border border-de-hairline border-l-4 border-l-de-accent p-6 rounded mb-8">
               <h3 className="text-xl font-semibold text-white mb-3">Typical SOW Components:</h3>
               <ul className="list-disc pl-6 text-gray-300 space-y-2">
                 <li><strong className="text-white">Project Overview:</strong> Description of services and objectives</li>
@@ -78,7 +78,7 @@ export default function SampleSOW() {
 
             <div className="flex flex-col sm:flex-row gap-4 mt-8">
               <Button 
-                className="bg-gradient-to-r from-purple-600 to-blue-600 text-white hover:from-purple-700 hover:to-blue-700"
+                className="bg-de-raised text-white hover: hover:to-blue-700"
                 onClick={() => window.location.href = 'mailto:legal@digeratiexperts.com?subject=SOW Request'}
                 data-testid="button-request-sow"
               >

--- a/client/src/pages/legal/TermsOfUse.tsx
+++ b/client/src/pages/legal/TermsOfUse.tsx
@@ -21,7 +21,7 @@ export default function TermsOfUse() {
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">
           <div className="max-w-4xl">
             <div className="flex items-center gap-3 mb-6">
-              <FileText className="h-12 w-12 text-purple-400" />
+              <FileText className="h-12 w-12 text-de-accent-ink" />
               <h1 className="text-4xl md:text-5xl font-bold">Terms of Service</h1>
             </div>
             <p className="text-xl text-gray-300">
@@ -79,7 +79,7 @@ export default function TermsOfUse() {
             {/* Services Description */}
             <div className="mb-12">
               <h2 className="text-3xl font-bold text-white mb-4 flex items-center gap-3">
-                <Shield className="h-8 w-8 text-purple-400" />
+                <Shield className="h-8 w-8 text-de-accent-ink" />
                 3. Service Description
               </h2>
               
@@ -119,7 +119,7 @@ export default function TermsOfUse() {
             {/* Service Levels */}
             <div className="mb-12">
               <h2 className="text-3xl font-bold text-white mb-4 flex items-center gap-3">
-                <Clock className="h-8 w-8 text-purple-400" />
+                <Clock className="h-8 w-8 text-de-accent-ink" />
                 4. Service Level Commitments
               </h2>
               
@@ -237,7 +237,7 @@ export default function TermsOfUse() {
             {/* Payment Terms */}
             <div className="mb-12">
               <h2 className="text-3xl font-bold text-white mb-4 flex items-center gap-3">
-                <DollarSign className="h-8 w-8 text-purple-400" />
+                <DollarSign className="h-8 w-8 text-de-accent-ink" />
                 7. Payment Terms
               </h2>
               
@@ -330,7 +330,7 @@ export default function TermsOfUse() {
             {/* Limitation of Liability */}
             <div className="mb-12">
               <h2 className="text-3xl font-bold text-white mb-4 flex items-center gap-3">
-                <Scale className="h-8 w-8 text-purple-400" />
+                <Scale className="h-8 w-8 text-de-accent-ink" />
                 10. Limitation of Liability
               </h2>
               
@@ -445,7 +445,7 @@ export default function TermsOfUse() {
             </div>
 
             {/* Contact Information */}
-            <div className="mb-12 bg-purple-500/10 backdrop-blur-sm border border-purple-500/30 border-l-4 border-l-purple-500 p-6 rounded">
+            <div className="mb-12 bg-de-raised backdrop-blur-sm border border-de-hairline border-l-4 border-l-de-accent p-6 rounded">
               <h2 className="text-3xl font-bold text-white mb-4">15. Contact Information</h2>
               <p className="text-gray-300 mb-4">
                 For questions about these Terms of Service, please contact:

--- a/client/src/pages/locations/LocationServicePage.tsx
+++ b/client/src/pages/locations/LocationServicePage.tsx
@@ -183,10 +183,10 @@ export function LocationServicePage(props: LocationPageProps) {
   ];
 
   const features = [
-    { icon: FileCheck, text: "Insurance & Compliance-Ready", color: "text-violet-400" },
-    { icon: Shield, text: "24/7 Human-Led Monitoring", color: "text-violet-400" },
-    { icon: Building, text: `Built for ${props.city} Businesses`, color: "text-violet-400" },
-    { icon: CheckCircle, text: "Easy-to-Read Risk Reports", color: "text-violet-400" },
+    { icon: FileCheck, text: "Insurance & Compliance-Ready", color: "text-de-accent-ink" },
+    { icon: Shield, text: "24/7 Human-Led Monitoring", color: "text-de-accent-ink" },
+    { icon: Building, text: `Built for ${props.city} Businesses`, color: "text-de-accent-ink" },
+    { icon: CheckCircle, text: "Easy-to-Read Risk Reports", color: "text-de-accent-ink" },
   ];
 
   return (
@@ -233,20 +233,20 @@ export function LocationServicePage(props: LocationPageProps) {
                 transition={{ duration: 0.6 }}
               >
                 {/* Location Badge */}
-                <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-purple-500/30 bg-purple-500/10 backdrop-blur-sm w-fit">
-                  <MapPin className="w-4 h-4 text-purple-400" />
-                  <span className="text-sm text-purple-300">{props.localArea}</span>
+                <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-de-hairline bg-de-raised backdrop-blur-sm w-fit">
+                  <MapPin className="w-4 h-4 text-de-accent-ink" />
+                  <span className="text-sm text-de-accent-ink">{props.localArea}</span>
                 </div>
 
                 {/* Headline */}
                 <h1 className="text-4xl sm:text-5xl lg:text-5xl xl:text-6xl font-bold leading-[1.1] tracking-tight">
-                  <span className="text-transparent bg-clip-text bg-gradient-to-r from-violet-400 via-purple-400 to-fuchsia-400">
+                  <span className="text-de-accent-ink">
                     {props.city} Businesses
                   </span>
                   <br />
                   <span className="text-white">
                     Deserve{" "}
-                    <span className="text-transparent bg-clip-text bg-gradient-to-r from-purple-400 to-fuchsia-400">Better IT.</span>
+                    <span className="text-de-accent-ink">Better IT.</span>
                   </span>
                 </h1>
 
@@ -266,7 +266,7 @@ export function LocationServicePage(props: LocationPageProps) {
 
                 {/* Form Card */}
                 <motion.div className="relative" initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.6, delay: 0.2 }}>
-                  <div className="absolute -inset-1 bg-gradient-to-r from-purple-600/20 via-transparent to-fuchsia-600/20 blur-2xl" />
+                  <div className="absolute -inset-1 bg-de-raised via-transparent to-fuchsia-600/20 blur-2xl" />
                   
                   <div className="relative backdrop-blur-xl bg-white/5 border border-white/10 rounded-2xl p-6">
                     <Form {...form}>
@@ -276,7 +276,7 @@ export function LocationServicePage(props: LocationPageProps) {
                             <FormItem>
                               <FormLabel className="text-sm text-gray-300">Full Name</FormLabel>
                               <FormControl>
-                                <Input placeholder="John Smith" data-testid={`input-${props.city.toLowerCase()}-name`} className="h-11 bg-white/10 border-white/20 text-white placeholder:text-gray-500 focus-visible:ring-purple-500" disabled={isSubmitting} {...field} />
+                                <Input placeholder="John Smith" data-testid={`input-${props.city.toLowerCase()}-name`} className="h-11 bg-white/10 border-white/20 text-white placeholder:text-white/70 focus-visible:ring-de-accent" disabled={isSubmitting} {...field} />
                               </FormControl>
                               <FormMessage />
                             </FormItem>
@@ -285,7 +285,7 @@ export function LocationServicePage(props: LocationPageProps) {
                             <FormItem>
                               <FormLabel className="text-sm text-gray-300">Email Address</FormLabel>
                               <FormControl>
-                                <Input type="email" placeholder="john@company.com" data-testid={`input-${props.city.toLowerCase()}-email`} className="h-11 bg-white/10 border-white/20 text-white placeholder:text-gray-500 focus-visible:ring-purple-500" disabled={isSubmitting} {...field} />
+                                <Input type="email" placeholder="john@company.com" data-testid={`input-${props.city.toLowerCase()}-email`} className="h-11 bg-white/10 border-white/20 text-white placeholder:text-white/70 focus-visible:ring-de-accent" disabled={isSubmitting} {...field} />
                               </FormControl>
                               <FormMessage />
                             </FormItem>
@@ -294,7 +294,7 @@ export function LocationServicePage(props: LocationPageProps) {
                             <FormItem>
                               <FormLabel className="text-sm text-gray-300">Phone Number</FormLabel>
                               <FormControl>
-                                <Input type="tel" placeholder="(480) 000-0000" data-testid={`input-${props.city.toLowerCase()}-phone`} className="h-11 bg-white/10 border-white/20 text-white placeholder:text-gray-500 focus-visible:ring-purple-500" disabled={isSubmitting} {...field} />
+                                <Input type="tel" placeholder="(480) 000-0000" data-testid={`input-${props.city.toLowerCase()}-phone`} className="h-11 bg-white/10 border-white/20 text-white placeholder:text-white/70 focus-visible:ring-de-accent" disabled={isSubmitting} {...field} />
                               </FormControl>
                               <FormMessage />
                             </FormItem>
@@ -303,7 +303,7 @@ export function LocationServicePage(props: LocationPageProps) {
                             <FormItem>
                               <FormLabel className="text-sm text-gray-300">Company Name</FormLabel>
                               <FormControl>
-                                <Input placeholder="Your Company Inc." data-testid={`input-${props.city.toLowerCase()}-company`} className="h-11 bg-white/10 border-white/20 text-white placeholder:text-gray-500 focus-visible:ring-purple-500" disabled={isSubmitting} {...field} />
+                                <Input placeholder="Your Company Inc." data-testid={`input-${props.city.toLowerCase()}-company`} className="h-11 bg-white/10 border-white/20 text-white placeholder:text-white/70 focus-visible:ring-de-accent" disabled={isSubmitting} {...field} />
                               </FormControl>
                               <FormMessage />
                             </FormItem>
@@ -311,7 +311,7 @@ export function LocationServicePage(props: LocationPageProps) {
                         </div>
 
                         <div className="flex flex-col sm:flex-row gap-3 pt-2">
-                          <Button type="submit" size="lg" data-testid={`button-${props.city.toLowerCase()}-submit`} disabled={isSubmitting} className="flex-1 h-12 text-base font-semibold bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-500 hover:to-indigo-500 border-0 shadow-lg shadow-purple-500/25">
+                          <Button type="submit" size="lg" data-testid={`button-${props.city.toLowerCase()}-submit`} disabled={isSubmitting} className="flex-1 h-12 text-base font-semibold bg-de-raised hover: hover: border-0 shadow-lg shadow-none">
                             {isSubmitting ? <><Loader2 className="mr-2 h-5 w-5 animate-spin" />Submitting...</> : <>Get Free {props.city} Assessment<ArrowRight className="w-5 h-5 ml-2" /></>}
                           </Button>
                           <a href="tel:+13254809870" className="sm:flex-shrink-0">
@@ -329,8 +329,8 @@ export function LocationServicePage(props: LocationPageProps) {
                 <div className="flex flex-wrap gap-3">
                   {stats.map((stat, index) => (
                     <motion.div key={stat.label} className="flex items-center gap-3 px-4 py-3 rounded-xl bg-white/5 backdrop-blur-sm border border-white/10" initial={{ opacity: 0, scale: 0.9 }} animate={{ opacity: 1, scale: 1 }} transition={{ delay: 0.4 + index * 0.1 }}>
-                      <div className="w-10 h-10 rounded-lg bg-gradient-to-br from-purple-500/20 to-indigo-500/20 flex items-center justify-center">
-                        <stat.icon className="w-5 h-5 text-purple-400" />
+                      <div className="w-10 h-10 rounded-lg bg-de-raised flex items-center justify-center">
+                        <stat.icon className="w-5 h-5 text-de-accent-ink" />
                       </div>
                       <div>
                         <div className="text-xl font-bold text-white">{stat.value}</div>
@@ -342,7 +342,7 @@ export function LocationServicePage(props: LocationPageProps) {
 
                 {/* Trust badges */}
                 <div className="flex flex-wrap items-center gap-3">
-                  <span className="text-sm text-gray-500">Built for regulated environments</span>
+                  <span className="text-sm text-white/70">Built for regulated environments</span>
                   {["HIPAA-aligned support", "SOC 2 readiness", "Cyber insurance readiness", "Framework mapping"].map((badge) => (
                     <div key={badge} className="px-3 py-1.5 rounded-md bg-white/5 border border-white/10 text-xs text-gray-400">{badge}</div>
                   ))}
@@ -357,7 +357,7 @@ export function LocationServicePage(props: LocationPageProps) {
               {/* Right column - Dashboard Visual */}
               <div className="relative flex justify-center lg:justify-end w-full mt-8 lg:mt-0">
                 <motion.div className="relative w-full max-w-[500px] lg:max-w-[550px] xl:max-w-[600px]" initial={{ opacity: 0, x: 60, scale: 0.95 }} animate={{ opacity: 1, x: 0, scale: 1 }} transition={{ duration: 0.9, delay: 0.5 }}>
-                  <div className="absolute inset-0 bg-gradient-to-br from-purple-600/30 via-indigo-600/15 to-cyan-600/30 blur-3xl scale-110" />
+                  <div className="absolute inset-0 bg-de-raised blur-3xl scale-110" />
                   <motion.div className="relative" style={{ transform: "perspective(1200px) rotateY(-8deg) rotateX(3deg)", transformStyle: "preserve-3d" }} animate={{ rotateY: [-8, -5, -8], rotateX: [3, 4, 3] }} transition={{ duration: 12, repeat: Infinity, ease: "easeInOut" }}>
                     <DashboardMockup className="w-full drop-shadow-2xl" />
                   </motion.div>
@@ -381,14 +381,14 @@ export function LocationServicePage(props: LocationPageProps) {
             const azFact = getCyberFact("az-ic3-losses-2024");
             return (
               <motion.div
-                className="rounded-2xl border border-violet-500/20 bg-violet-500/5 px-6 py-5 text-center"
+                className="rounded-2xl border border-de-hairline bg-de-raised px-6 py-5 text-center"
                 initial={{ opacity: 0, y: 12 }}
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
               >
-                <p className="text-xs uppercase tracking-wider text-violet-300/80 mb-2">Arizona context</p>
+                <p className="text-xs uppercase tracking-wider text-de-accent-ink/80 mb-2">Arizona context</p>
                 <p className="text-white/90 text-sm md:text-base leading-relaxed">
-                  <span className="font-bold text-violet-300">{azFact.metric}</span>{" "}
+                  <span className="font-bold text-de-accent-ink">{azFact.metric}</span>{" "}
                   {azFact.statement} — relevant for {props.city} and Greater Phoenix SMBs planning
                   insurance-ready IT and breach readiness.
                 </p>
@@ -397,12 +397,12 @@ export function LocationServicePage(props: LocationPageProps) {
                     href={azFact.sourceUrl}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="inline-block mt-2 text-xs text-white/40 hover:text-violet-300 underline-offset-2 hover:underline"
+                    className="inline-block mt-2 text-xs text-white/55 hover:text-de-accent-ink underline-offset-2 hover:underline"
                   >
                     — {formatFactSource(azFact)}
                   </a>
                 ) : (
-                  <p className="mt-2 text-xs text-white/40">— {formatFactSource(azFact)}</p>
+                  <p className="mt-2 text-xs text-white/55">— {formatFactSource(azFact)}</p>
                 )}
               </motion.div>
             );
@@ -415,7 +415,7 @@ export function LocationServicePage(props: LocationPageProps) {
         <div className="mx-auto w-[min(94vw,1400px)] px-4">
           <motion.div className="text-center mb-16" initial={{ opacity: 0, y: 20 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true }}>
             <h2 className="text-3xl md:text-4xl font-bold text-white mb-4">
-              IT Services for <span className="text-transparent bg-clip-text bg-gradient-to-r from-purple-400 to-fuchsia-400">{props.city}</span> Businesses
+              IT Services for <span className="text-de-accent-ink">{props.city}</span> Businesses
             </h2>
             <p className="text-gray-400 text-lg max-w-2xl mx-auto">{props.serviceRadius}</p>
           </motion.div>
@@ -424,9 +424,9 @@ export function LocationServicePage(props: LocationPageProps) {
             {props.serviceFocus.map((service, index) => {
               const IconComponent = serviceIcons[index % serviceIcons.length];
               return (
-                <motion.div key={service} className="group p-6 rounded-2xl bg-white/5 backdrop-blur-sm border border-white/10 hover:border-purple-500/50 transition-all duration-300" initial={{ opacity: 0, y: 20 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true }} transition={{ delay: index * 0.1 }}>
-                  <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-purple-500/20 to-indigo-500/20 flex items-center justify-center mb-4 group-hover:scale-110 transition-transform">
-                    <IconComponent className="w-6 h-6 text-purple-400" />
+                <motion.div key={service} className="group p-6 rounded-2xl bg-white/5 backdrop-blur-sm border border-white/10 hover:border-de-hairline transition-all duration-300" initial={{ opacity: 0, y: 20 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true }} transition={{ delay: index * 0.1 }}>
+                  <div className="w-12 h-12 rounded-xl bg-de-raised flex items-center justify-center mb-4 group-hover:scale-110 transition-transform">
+                    <IconComponent className="w-6 h-6 text-de-accent-ink" />
                   </div>
                   <h3 className="text-xl font-semibold text-white">{service}</h3>
                 </motion.div>
@@ -441,7 +441,7 @@ export function LocationServicePage(props: LocationPageProps) {
         <div className="mx-auto w-[min(94vw,1400px)] px-4">
           <motion.div className="text-center mb-16" initial={{ opacity: 0, y: 20 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true }}>
             <h2 className="text-3xl md:text-4xl font-bold text-white mb-4">
-              Why {props.city} Chooses <span className="text-transparent bg-clip-text bg-gradient-to-r from-purple-400 to-fuchsia-400">Digerati Experts</span>
+              Why {props.city} Chooses <span className="text-de-accent-ink">Digerati Experts</span>
             </h2>
           </motion.div>
 
@@ -465,7 +465,7 @@ export function LocationServicePage(props: LocationPageProps) {
 
           <div className="flex flex-wrap justify-center gap-4">
             {props.localProof.industries.map((industry, index) => (
-              <motion.div key={industry} className="px-6 py-3 rounded-full bg-gradient-to-r from-purple-500/10 to-fuchsia-500/10 border border-purple-500/30 text-gray-300" initial={{ opacity: 0, scale: 0.9 }} whileInView={{ opacity: 1, scale: 1 }} viewport={{ once: true }} transition={{ delay: index * 0.1 }}>
+              <motion.div key={industry} className="px-6 py-3 rounded-full bg-de-raised border border-de-hairline text-gray-300" initial={{ opacity: 0, scale: 0.9 }} whileInView={{ opacity: 1, scale: 1 }} viewport={{ once: true }} transition={{ delay: index * 0.1 }}>
                 {industry}
               </motion.div>
             ))}
@@ -489,14 +489,14 @@ export function LocationServicePage(props: LocationPageProps) {
       </section>
 
       {/* CTA Section */}
-      <section className="py-20 bg-gradient-to-r from-purple-900/50 via-[#0a0118] to-indigo-900/50">
+      <section className="py-20 bg-de-raised via-[#0a0118]">
         <div className="mx-auto w-[min(94vw,1200px)] px-4 text-center">
           <motion.div initial={{ opacity: 0, y: 20 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true }}>
             <h2 className="text-3xl md:text-4xl font-bold text-white mb-6">{props.cta}</h2>
             <p className="text-xl text-gray-300 mb-8">Contact our {props.city} team today for your free consultation</p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <a href="/book">
-                <Button size="lg" className="px-8 py-6 text-lg font-semibold bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-500 hover:to-indigo-500 shadow-lg shadow-purple-500/25">
+                <Button size="lg" className="px-8 py-6 text-lg font-semibold bg-de-raised hover: hover: shadow-lg shadow-none">
                   {CTA.primary} <ArrowRight className="ml-2 w-5 h-5" />
                 </Button>
               </a>

--- a/client/src/pages/locations/LocationServicePage.tsx
+++ b/client/src/pages/locations/LocationServicePage.tsx
@@ -197,23 +197,23 @@ export function LocationServicePage(props: LocationPageProps) {
       <section className="relative min-h-screen overflow-hidden">
         {/* Animated gradient mesh background */}
         <div className="absolute inset-0">
-          <div className="absolute inset-0 bg-gradient-to-br from-[#0a0118] via-[#1a0a2e] to-[#0f0720]" />
+          <div className="absolute inset-0 bg-gradient-to-br from-[#050312] via-[#0a0a0a] to-[#151217]" />
           
           <motion.div
-            className="absolute top-[-20%] right-[-10%] w-[1000px] h-[1000px] rounded-full"
-            style={{ background: "radial-gradient(circle, rgba(139, 92, 246, 0.3) 0%, transparent 60%)" }}
+            className="de-hero-glow absolute top-[-20%] right-[-10%] w-[1000px] h-[1000px] rounded-full"
+            style={{ background: "radial-gradient(circle, rgba(211, 18, 106, 0.22) 0%, transparent 60%)" }}
             animate={{ scale: [1, 1.15, 1], x: [0, 60, 0], y: [0, 30, 0] }}
             transition={{ duration: 18, repeat: Infinity, ease: "easeInOut" }}
           />
           <motion.div
-            className="absolute bottom-[-20%] left-[-15%] w-[900px] h-[900px] rounded-full"
-            style={{ background: "radial-gradient(circle, rgba(99, 102, 241, 0.25) 0%, transparent 60%)" }}
+            className="de-hero-glow absolute bottom-[-20%] left-[-15%] w-[900px] h-[900px] rounded-full"
+            style={{ background: "radial-gradient(circle, rgba(91, 69, 224, 0.12) 0%, transparent 60%)" }}
             animate={{ scale: [1.1, 1, 1.1], x: [0, -40, 0], y: [0, -60, 0] }}
             transition={{ duration: 15, repeat: Infinity, ease: "easeInOut" }}
           />
           
           <div className="absolute inset-0 opacity-10" style={{
-            backgroundImage: "linear-gradient(rgba(139, 92, 246, 0.15) 1px, transparent 1px), linear-gradient(90deg, rgba(139, 92, 246, 0.15) 1px, transparent 1px)",
+            backgroundImage: "linear-gradient(rgba(255, 255, 255, 0.08) 1px, transparent 1px), linear-gradient(90deg, rgba(255, 255, 255, 0.08) 1px, transparent 1px)",
             backgroundSize: "80px 80px"
           }} />
           
@@ -386,7 +386,7 @@ export function LocationServicePage(props: LocationPageProps) {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
               >
-                <p className="text-xs uppercase tracking-wider text-de-accent-ink/80 mb-2">Arizona context</p>
+                <p className="text-xs uppercase tracking-wider text-de-accent-ink mb-2">Arizona context</p>
                 <p className="text-white/90 text-sm md:text-base leading-relaxed">
                   <span className="font-bold text-de-accent-ink">{azFact.metric}</span>{" "}
                   {azFact.statement} — relevant for {props.city} and Greater Phoenix SMBs planning

--- a/client/src/pages/not-found.tsx
+++ b/client/src/pages/not-found.tsx
@@ -18,7 +18,7 @@ export default function NotFound() {
             <h1 className="text-2xl font-bold text-gray-900">404 Page Not Found</h1>
           </div>
 
-          <p className="mt-4 text-sm text-gray-600">
+          <p className="mt-4 text-sm text-white/70">
             Did you forget to add the page to the router?
           </p>
         </CardContent>

--- a/client/src/pages/resources/Blog.tsx
+++ b/client/src/pages/resources/Blog.tsx
@@ -168,7 +168,7 @@ export default function Blog() {
               </button>
               <Link href="/#contact">
                 <button
-                  className="group relative inline-flex items-center gap-2 h-12 px-6 rounded-full font-semibold text-white border border-de-hairline backdrop-blur-md transition-all duration-200 bg-de-raised hover: hover:via-fuchsia-400/40 hover: shadow-[inset_0_1px_0_rgba(255,255,255,0.4),inset_0_-1px_0_rgba(0,0,0,0.2),0_10px_28px_-8px_rgba(179,0,255,0.65)] hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.5),inset_0_-1px_0_rgba(0,0,0,0.2),0_14px_36px_-8px_rgba(217,70,239,0.7)] active:translate-y-px"
+                  className="group relative inline-flex items-center gap-2 h-12 px-6 rounded-full font-semibold text-white border border-de-hairline backdrop-blur-md transition-all duration-200 bg-de-raised hover:bg-de-raised shadow-[inset_0_1px_0_rgba(255,255,255,0.4),inset_0_-1px_0_rgba(0,0,0,0.2),0_10px_28px_-8px_rgb(var(--de-accent-rgb) / 0.35)] hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.5),inset_0_-1px_0_rgba(0,0,0,0.2),0_14px_36px_-8px_rgb(var(--de-accent-rgb) / 0.4)] active:translate-y-px"
                   data-testid="button-subscribe"
                 >
                   <span className="pointer-events-none absolute inset-x-3 top-1 h-1/2 rounded-full bg-gradient-to-b from-white/35 to-transparent opacity-70" aria-hidden />
@@ -216,7 +216,7 @@ export default function Blog() {
                     {isActive && (
                       <span
                         aria-hidden
-                        className="absolute left-3 right-3 -bottom-px h-0.5 bg-gradient-to-r from-fuchsia-300 to-pink-300 rounded-full"
+                        className="absolute left-3 right-3 -bottom-px h-0.5 bg-gradient-to-r from-de-accent-ink to-de-accent-ink rounded-full"
                       />
                     )}
                   </button>
@@ -237,7 +237,7 @@ export default function Blog() {
                   value={query}
                   onChange={(e) => setQuery(e.target.value)}
                   placeholder="Search articles, topics, frameworks…"
-                  className="pl-11 pr-11 h-12 bg-white/[0.06] border-white/15 text-white placeholder:text-white/55 focus-visible:ring-fuchsia-500/40 focus-visible:border-fuchsia-500/40 rounded-full"
+                  className="pl-11 pr-11 h-12 bg-white/[0.06] border-white/15 text-white placeholder:text-white/55 focus-visible:ring-de-accent/40 focus-visible:border-de-accent/40 rounded-full"
                   data-testid="input-blog-search"
                 />
                 {query && (
@@ -325,7 +325,7 @@ export default function Blog() {
               {filtered.map((post) => (
                 <Link href={post.href} key={post.slug}>
                   <Card
-                    className="group h-full overflow-hidden border-white/10 bg-white/[0.02] hover:border-fuchsia-500/40 transition-all cursor-pointer flex flex-col"
+                    className="group h-full overflow-hidden border-white/10 bg-white/[0.02] hover:border-de-accent/40 transition-all cursor-pointer flex flex-col"
                     data-testid={`card-post-${post.slug}`}
                   >
                     <div className="relative aspect-[16/9] overflow-hidden">
@@ -346,7 +346,7 @@ export default function Blog() {
                       </div>
                     </div>
                     <CardContent className="p-6 flex flex-col flex-1">
-                      <h3 className="text-lg md:text-xl font-bold text-white mb-3 leading-snug group-hover:text-fuchsia-300 transition-colors line-clamp-3">
+                      <h3 className="text-lg md:text-xl font-bold text-white mb-3 leading-snug group-hover:text-de-accent-ink transition-colors line-clamp-3">
                         {post.title}
                       </h3>
                       <p className="text-white/55 text-sm mb-5 line-clamp-3 flex-1 leading-relaxed">
@@ -376,7 +376,7 @@ export default function Blog() {
 
           {/* Ebook spotlight — editorial bottom feature */}
           <section className="mt-20" aria-label="Featured ebook">
-            <div className="rounded-3xl border border-white/10 bg-de-raised via-[#0a0a0a] to-fuchsia-950/40 overflow-hidden">
+            <div className="rounded-3xl border border-white/10 bg-de-raised overflow-hidden">
               <Link href={ebookFeature.href}>
                 <div
                   className="grid md:grid-cols-2 gap-0 group cursor-pointer"
@@ -393,11 +393,11 @@ export default function Blog() {
                     <div className="absolute inset-0 bg-gradient-to-r from-transparent to-[#0a0a0a]/40 md:to-[#0a0a0a]/0" />
                   </div>
                   <div className="p-8 md:p-10 flex flex-col justify-center">
-                    <Badge className="self-start mb-4 bg-fuchsia-500/15 text-fuchsia-300 border-fuchsia-500/30">
+                    <Badge className="self-start mb-4 bg-de-raised text-de-accent-ink border-de-hairline">
                       <BookOpen className="h-3 w-3 mr-1.5" />
                       Free Ebook
                     </Badge>
-                    <h3 className="text-2xl md:text-3xl font-bold text-white mb-3 group-hover:text-fuchsia-200 transition-colors">
+                    <h3 className="text-2xl md:text-3xl font-bold text-white mb-3 group-hover:text-de-accent-ink transition-colors">
                       {ebookFeature.title}
                     </h3>
                     <p className="text-white/65 text-base mb-6 leading-relaxed">
@@ -411,7 +411,7 @@ export default function Blog() {
                       <span>•</span>
                       <span>{ebookFeature.author}</span>
                     </div>
-                    <span className="inline-flex items-center text-fuchsia-300 group-hover:text-fuchsia-200 font-medium">
+                    <span className="inline-flex items-center text-de-accent-ink font-medium">
                       Read the ebook
                       <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
                     </span>
@@ -423,7 +423,7 @@ export default function Blog() {
 
           {/* Bottom CTA */}
           <section className="mt-16">
-            <Card className="overflow-hidden border-de-hairline bg-de-raised via-[#0a0a0a] to-fuchsia-600/15">
+            <Card className="overflow-hidden border-de-hairline bg-de-raised ">
               <CardContent className="p-8 md:p-12 flex flex-col md:flex-row items-center justify-between gap-6">
                 <div className="text-center md:text-left">
                   <h3 className="text-2xl md:text-3xl font-bold text-white mb-3">
@@ -436,7 +436,7 @@ export default function Blog() {
                 </div>
                 <Link href="/book">
                   <button
-                    className="group relative inline-flex items-center gap-3 h-14 px-8 rounded-2xl font-semibold text-white whitespace-nowrap border border-de-hairline backdrop-blur-md transition-all duration-200 bg-de-raised hover: hover:via-fuchsia-400/45 hover: shadow-[inset_0_1px_0_rgba(255,255,255,0.45),inset_0_-1px_0_rgba(0,0,0,0.25),0_14px_36px_-10px_rgba(179,0,255,0.7)] hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.55),inset_0_-1px_0_rgba(0,0,0,0.25),0_18px_44px_-10px_rgba(217,70,239,0.75)] active:translate-y-px"
+                    className="group relative inline-flex items-center gap-3 h-14 px-8 rounded-2xl font-semibold text-white whitespace-nowrap border border-de-hairline backdrop-blur-md transition-all duration-200 bg-de-raised hover:bg-de-raised shadow-[inset_0_1px_0_rgba(255,255,255,0.45),inset_0_-1px_0_rgba(0,0,0,0.25),0_14px_36px_-10px_rgb(var(--de-accent-rgb) / 0.4)] hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.55),inset_0_-1px_0_rgba(0,0,0,0.25),0_18px_44px_-10px_rgb(var(--de-accent-rgb) / 0.45)] active:translate-y-px"
                     data-testid="button-blog-assessment"
                   >
                     <span className="pointer-events-none absolute inset-x-4 top-1 h-1/2 rounded-2xl bg-gradient-to-b from-white/35 to-transparent opacity-70" aria-hidden />

--- a/client/src/pages/resources/Blog.tsx
+++ b/client/src/pages/resources/Blog.tsx
@@ -141,7 +141,7 @@ export default function Blog() {
                 </span>
                 <span className="block text-5xl md:text-7xl lg:text-8xl">
                   Digerati{" "}
-                  <span className="bg-gradient-to-r from-fuchsia-300 via-pink-300 to-violet-200 bg-clip-text text-transparent">
+                  <span className="text-de-accent-ink">
                     Journal
                   </span>
                 </span>
@@ -155,7 +155,7 @@ export default function Blog() {
             <div className="flex items-center gap-3">
               <button
                 onClick={() => setSearchOpen((o) => !o)}
-                className="group relative w-12 h-12 rounded-full text-white border border-violet-300/30 backdrop-blur-md transition-all duration-200 flex items-center justify-center bg-gradient-to-b from-white/15 to-white/5 hover:from-white/25 hover:to-white/10 shadow-[inset_0_1px_0_rgba(255,255,255,0.35),inset_0_-1px_0_rgba(0,0,0,0.2),0_8px_24px_-8px_rgba(139,92,246,0.55)] hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.45),inset_0_-1px_0_rgba(0,0,0,0.2),0_10px_28px_-6px_rgba(217,70,239,0.6)] active:translate-y-px"
+                className="group relative w-12 h-12 rounded-full text-white border border-de-hairline backdrop-blur-md transition-all duration-200 flex items-center justify-center bg-gradient-to-b from-white/15 to-white/5 hover:from-white/25 hover:to-white/10 shadow-[inset_0_1px_0_rgba(255,255,255,0.35),inset_0_-1px_0_rgba(0,0,0,0.2),0_8px_24px_-8px_rgba(139,92,246,0.55)] hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.45),inset_0_-1px_0_rgba(0,0,0,0.2),0_10px_28px_-6px_rgba(217,70,239,0.6)] active:translate-y-px"
                 aria-label={searchOpen ? "Close search" : "Open search"}
                 data-testid="button-search-toggle"
               >
@@ -168,7 +168,7 @@ export default function Blog() {
               </button>
               <Link href="/#contact">
                 <button
-                  className="group relative inline-flex items-center gap-2 h-12 px-6 rounded-full font-semibold text-white border border-violet-200/40 backdrop-blur-md transition-all duration-200 bg-gradient-to-b from-violet-400/40 via-violet-500/35 to-violet-700/45 hover:from-violet-300/50 hover:via-fuchsia-400/40 hover:to-violet-700/55 shadow-[inset_0_1px_0_rgba(255,255,255,0.4),inset_0_-1px_0_rgba(0,0,0,0.2),0_10px_28px_-8px_rgba(179,0,255,0.65)] hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.5),inset_0_-1px_0_rgba(0,0,0,0.2),0_14px_36px_-8px_rgba(217,70,239,0.7)] active:translate-y-px"
+                  className="group relative inline-flex items-center gap-2 h-12 px-6 rounded-full font-semibold text-white border border-de-hairline backdrop-blur-md transition-all duration-200 bg-de-raised hover: hover:via-fuchsia-400/40 hover: shadow-[inset_0_1px_0_rgba(255,255,255,0.4),inset_0_-1px_0_rgba(0,0,0,0.2),0_10px_28px_-8px_rgba(179,0,255,0.65)] hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.5),inset_0_-1px_0_rgba(0,0,0,0.2),0_14px_36px_-8px_rgba(217,70,239,0.7)] active:translate-y-px"
                   data-testid="button-subscribe"
                 >
                   <span className="pointer-events-none absolute inset-x-3 top-1 h-1/2 rounded-full bg-gradient-to-b from-white/35 to-transparent opacity-70" aria-hidden />
@@ -207,7 +207,7 @@ export default function Blog() {
                     <span
                       className={`ml-2 inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 rounded-full text-[10px] font-semibold ${
                         isActive
-                          ? "bg-white text-violet-800"
+                          ? "bg-white text-de-accent"
                           : "bg-white/10 text-white/60"
                       }`}
                     >
@@ -237,7 +237,7 @@ export default function Blog() {
                   value={query}
                   onChange={(e) => setQuery(e.target.value)}
                   placeholder="Search articles, topics, frameworks…"
-                  className="pl-11 pr-11 h-12 bg-white/[0.06] border-white/15 text-white placeholder:text-white/40 focus-visible:ring-fuchsia-500/40 focus-visible:border-fuchsia-500/40 rounded-full"
+                  className="pl-11 pr-11 h-12 bg-white/[0.06] border-white/15 text-white placeholder:text-white/55 focus-visible:ring-fuchsia-500/40 focus-visible:border-fuchsia-500/40 rounded-full"
                   data-testid="input-blog-search"
                 />
                 {query && (
@@ -258,14 +258,14 @@ export default function Blog() {
       <main className="py-12 md:py-16">
         <div className="container mx-auto px-4 max-w-7xl">
           {/* Breadcrumb + page title */}
-          <div className="flex items-center gap-2 text-sm text-white/40 mb-3">
-            <Link href="/" className="hover:text-violet-300 transition-colors">
+          <div className="flex items-center gap-2 text-sm text-white/55 mb-3">
+            <Link href="/" className="hover:text-de-accent-ink transition-colors">
               Home
             </Link>
             <ChevronRight className="h-3.5 w-3.5" />
             <Link
               href="/resources/blog"
-              className="hover:text-violet-300 transition-colors"
+              className="hover:text-de-accent-ink transition-colors"
             >
               Journal
             </Link>
@@ -280,7 +280,7 @@ export default function Blog() {
             <h2 className="text-4xl md:text-5xl font-bold text-white tracking-tight">
               {pageTitle}
             </h2>
-            <span className="text-sm text-white/40">
+            <span className="text-sm text-white/55">
               {filtered.length} {filtered.length === 1 ? "article" : "articles"}
               {query && (
                 <>
@@ -297,16 +297,16 @@ export default function Blog() {
               className="text-center py-20 rounded-3xl border border-white/10 bg-white/[0.02]"
               data-testid="text-no-posts"
             >
-              <Search className="h-10 w-10 mx-auto text-white/30 mb-4" />
+              <Search className="h-10 w-10 mx-auto text-white/55 mb-4" />
               <p className="text-white/70 text-lg mb-2">No matches found</p>
-              <p className="text-white/40 text-sm">
+              <p className="text-white/55 text-sm">
                 Try a different search or category.
               </p>
               {(query || activeCategory !== "All") && (
                 <Button
                   variant="outline"
                   size="sm"
-                  className="mt-4 border-white/15 text-white/70 hover:text-white hover:border-violet-500/50"
+                  className="mt-4 border-white/15 text-white/70 hover:text-white hover:border-de-hairline"
                   onClick={() => {
                     setQuery("");
                     setActiveCategory("All");
@@ -352,7 +352,7 @@ export default function Blog() {
                       <p className="text-white/55 text-sm mb-5 line-clamp-3 flex-1 leading-relaxed">
                         {post.excerpt}
                       </p>
-                      <div className="flex items-center gap-3 text-xs text-white/45 pt-4 border-t border-white/5">
+                      <div className="flex items-center gap-3 text-xs text-white/55 pt-4 border-t border-white/5">
                         <span className="inline-flex items-center gap-1">
                           <Calendar className="h-3 w-3" />
                           {new Date(post.date).toLocaleDateString("en-US", {
@@ -376,7 +376,7 @@ export default function Blog() {
 
           {/* Ebook spotlight — editorial bottom feature */}
           <section className="mt-20" aria-label="Featured ebook">
-            <div className="rounded-3xl border border-white/10 bg-gradient-to-br from-violet-950/40 via-[#0a0a0a] to-fuchsia-950/40 overflow-hidden">
+            <div className="rounded-3xl border border-white/10 bg-de-raised via-[#0a0a0a] to-fuchsia-950/40 overflow-hidden">
               <Link href={ebookFeature.href}>
                 <div
                   className="grid md:grid-cols-2 gap-0 group cursor-pointer"
@@ -423,7 +423,7 @@ export default function Blog() {
 
           {/* Bottom CTA */}
           <section className="mt-16">
-            <Card className="overflow-hidden border-violet-500/30 bg-gradient-to-br from-violet-600/15 via-[#0a0a0a] to-fuchsia-600/15">
+            <Card className="overflow-hidden border-de-hairline bg-de-raised via-[#0a0a0a] to-fuchsia-600/15">
               <CardContent className="p-8 md:p-12 flex flex-col md:flex-row items-center justify-between gap-6">
                 <div className="text-center md:text-left">
                   <h3 className="text-2xl md:text-3xl font-bold text-white mb-3">
@@ -436,7 +436,7 @@ export default function Blog() {
                 </div>
                 <Link href="/book">
                   <button
-                    className="group relative inline-flex items-center gap-3 h-14 px-8 rounded-2xl font-semibold text-white whitespace-nowrap border border-violet-200/40 backdrop-blur-md transition-all duration-200 bg-gradient-to-b from-violet-400/45 via-violet-500/40 to-violet-800/55 hover:from-violet-300/55 hover:via-fuchsia-400/45 hover:to-violet-800/60 shadow-[inset_0_1px_0_rgba(255,255,255,0.45),inset_0_-1px_0_rgba(0,0,0,0.25),0_14px_36px_-10px_rgba(179,0,255,0.7)] hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.55),inset_0_-1px_0_rgba(0,0,0,0.25),0_18px_44px_-10px_rgba(217,70,239,0.75)] active:translate-y-px"
+                    className="group relative inline-flex items-center gap-3 h-14 px-8 rounded-2xl font-semibold text-white whitespace-nowrap border border-de-hairline backdrop-blur-md transition-all duration-200 bg-de-raised hover: hover:via-fuchsia-400/45 hover: shadow-[inset_0_1px_0_rgba(255,255,255,0.45),inset_0_-1px_0_rgba(0,0,0,0.25),0_14px_36px_-10px_rgba(179,0,255,0.7)] hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.55),inset_0_-1px_0_rgba(0,0,0,0.25),0_18px_44px_-10px_rgba(217,70,239,0.75)] active:translate-y-px"
                     data-testid="button-blog-assessment"
                   >
                     <span className="pointer-events-none absolute inset-x-4 top-1 h-1/2 rounded-2xl bg-gradient-to-b from-white/35 to-transparent opacity-70" aria-hidden />

--- a/client/src/pages/resources/Blog.tsx
+++ b/client/src/pages/resources/Blog.tsx
@@ -107,7 +107,7 @@ export default function Blog() {
           className="absolute inset-0"
           style={{
             background:
-              "linear-gradient(135deg, #1a0030 0%, #2d0052 35%, #4a0072 65%, #b300ff 100%)",
+              "linear-gradient(135deg, #050312 0%, #0a0a0a 55%, #151217 100%)",
           }}
         />
         <div

--- a/client/src/pages/resources/BlogPost.tsx
+++ b/client/src/pages/resources/BlogPost.tsx
@@ -593,7 +593,7 @@ export default function BlogPost() {
                                     aria-hidden
                                     className={`absolute left-[3px] top-[11px] w-3.5 h-3.5 rounded-full border-2 transition-all duration-300 flex items-center justify-center text-[8px] font-bold ${
                                       isActive
-                                        ? "bg-gradient-to-br  to-fuchsia-400 border-white/80 shadow-[0_0_12px_rgba(217,70,239,0.7)] scale-110"
+                                        ? "bg-de-accent border-white/80 scale-110"
                                         : isPast
                                           ? "bg-de-raised border-de-hairline"
                                           : "bg-[#0a0a0a] border-white/25"
@@ -900,7 +900,7 @@ export default function BlogPost() {
                       key={idx}
                       className={`text-white/85 text-[18px] leading-[1.85] mb-7 ${
                         isFirst
-                          ? "first-letter:float-left first-letter:mr-3 first-letter:mt-1 first-letter:text-7xl first-letter:font-bold first-letter:leading-[0.85] first-letter:bg-gradient-to-br first-letter: first-letter:to-fuchsia-400 first-letter:bg-clip-text first-letter:text-transparent"
+                          ? "first-letter:float-left first-letter:mr-3 first-letter:mt-1 first-letter:text-7xl first-letter:font-bold first-letter:leading-[0.85] first-letter:text-de-accent-ink"
                           : ""
                       }`}
                     >

--- a/client/src/pages/resources/BlogPost.tsx
+++ b/client/src/pages/resources/BlogPost.tsx
@@ -307,7 +307,7 @@ export default function BlogPost() {
               The article you’re looking for doesn’t exist.
             </p>
             <Link href="/resources/blog">
-              <Button className="bg-white text-violet-700 hover:bg-white/90">
+              <Button className="bg-white text-de-accent hover:bg-white/90">
                 <ArrowLeft className="mr-2 h-4 w-4" />
                 Back to Blog
               </Button>
@@ -381,14 +381,14 @@ export default function BlogPost() {
           >
             <Link
               href="/"
-              className="hover:text-violet-400 transition-colors"
+              className="hover:text-de-accent-ink transition-colors"
             >
               Home
             </Link>
             <ChevronRight className="h-4 w-4" />
             <Link
               href="/resources/blog"
-              className="hover:text-violet-400 transition-colors"
+              className="hover:text-de-accent-ink transition-colors"
             >
               Blog
             </Link>
@@ -400,7 +400,7 @@ export default function BlogPost() {
 
           <Link
             href="/resources/blog"
-            className="inline-flex items-center text-violet-300 hover:text-violet-200 mb-8 transition-colors text-sm"
+            className="inline-flex items-center text-de-accent-ink hover:text-de-accent-ink mb-8 transition-colors text-sm"
             data-testid="link-back-blog"
           >
             <ArrowLeft className="mr-2 h-4 w-4" />
@@ -408,7 +408,7 @@ export default function BlogPost() {
           </Link>
 
           <header className="mb-10">
-            <Badge className="mb-5 bg-violet-500/15 text-violet-300 border-violet-500/30 backdrop-blur">
+            <Badge className="mb-5 bg-de-raised text-de-accent-ink border-de-hairline backdrop-blur">
               {post.category}
             </Badge>
             <h1 className="text-3xl md:text-5xl lg:text-6xl font-bold text-white mb-6 leading-[1.1] tracking-tight">
@@ -420,7 +420,7 @@ export default function BlogPost() {
 
             <div className="flex flex-wrap items-center gap-x-6 gap-y-4 pt-6 border-t border-white/10">
               <div className="flex items-center gap-3">
-                <div className="w-11 h-11 rounded-full bg-gradient-to-br from-violet-500 to-fuchsia-500 flex items-center justify-center shadow-[0_0_18px_rgba(179,0,255,0.4)]">
+                <div className="w-11 h-11 rounded-full bg-de-raised flex items-center justify-center shadow-[0_0_18px_rgba(179,0,255,0.4)]">
                   <User className="h-5 w-5 text-white" />
                 </div>
                 <div>
@@ -456,7 +456,7 @@ export default function BlogPost() {
                 />
                 <button
                   onClick={() => handleShare("twitter")}
-                  className="w-9 h-9 rounded-full border border-white/10 bg-white/[0.03] text-white/60 hover:text-white hover:border-violet-500/50 hover:bg-violet-500/10 transition-all flex items-center justify-center"
+                  className="w-9 h-9 rounded-full border border-white/10 bg-white/[0.03] text-white/60 hover:text-white hover:border-de-hairline hover:bg-de-raised transition-all flex items-center justify-center"
                   aria-label="Share on Twitter"
                   data-testid="button-share-twitter"
                 >
@@ -464,7 +464,7 @@ export default function BlogPost() {
                 </button>
                 <button
                   onClick={() => handleShare("linkedin")}
-                  className="w-9 h-9 rounded-full border border-white/10 bg-white/[0.03] text-white/60 hover:text-white hover:border-violet-500/50 hover:bg-violet-500/10 transition-all flex items-center justify-center"
+                  className="w-9 h-9 rounded-full border border-white/10 bg-white/[0.03] text-white/60 hover:text-white hover:border-de-hairline hover:bg-de-raised transition-all flex items-center justify-center"
                   aria-label="Share on LinkedIn"
                   data-testid="button-share-linkedin"
                 >
@@ -472,7 +472,7 @@ export default function BlogPost() {
                 </button>
                 <button
                   onClick={handleCopyLink}
-                  className="w-9 h-9 rounded-full border border-white/10 bg-white/[0.03] text-white/60 hover:text-white hover:border-violet-500/50 hover:bg-violet-500/10 transition-all flex items-center justify-center"
+                  className="w-9 h-9 rounded-full border border-white/10 bg-white/[0.03] text-white/60 hover:text-white hover:border-de-hairline hover:bg-de-raised transition-all flex items-center justify-center"
                   aria-label="Copy link"
                   data-testid="button-share-copy"
                 >
@@ -499,7 +499,7 @@ export default function BlogPost() {
                   onClick={() => setView("overview")}
                   className={`w-full sm:w-auto px-4 sm:px-5 py-2.5 sm:py-2 rounded-xl sm:rounded-full text-sm font-medium transition-all text-center ${
                     view === "overview"
-                      ? "bg-gradient-to-r from-violet-500 to-fuchsia-500 text-white shadow-[0_0_18px_rgba(179,0,255,0.35)]"
+                      ? "bg-gradient-to-r  to-fuchsia-500 text-white shadow-[0_0_18px_rgba(179,0,255,0.35)]"
                       : "text-white/60 hover:text-white"
                   }`}
                   data-testid="tab-overview"
@@ -516,7 +516,7 @@ export default function BlogPost() {
                   onClick={() => setView("extended")}
                   className={`w-full sm:w-auto px-4 sm:px-5 py-2.5 sm:py-2 rounded-xl sm:rounded-full text-sm font-medium transition-all text-center ${
                     view === "extended"
-                      ? "bg-gradient-to-r from-violet-500 to-fuchsia-500 text-white shadow-[0_0_18px_rgba(179,0,255,0.35)]"
+                      ? "bg-gradient-to-r  to-fuchsia-500 text-white shadow-[0_0_18px_rgba(179,0,255,0.35)]"
                       : "text-white/60 hover:text-white"
                   }`}
                   data-testid="tab-extended"
@@ -555,8 +555,8 @@ export default function BlogPost() {
                 <div className="sticky top-28">
                   <div className="rounded-2xl border border-white/10 bg-gradient-to-b from-white/[0.04] to-white/[0.01] p-5 backdrop-blur-sm shadow-[0_10px_40px_-20px_rgba(179,0,255,0.4)]">
                     <div className="flex items-center gap-2 text-[11px] font-bold text-white/80 mb-5 uppercase tracking-[0.18em]">
-                      <span className="inline-flex items-center justify-center w-6 h-6 rounded-md bg-violet-500/15 border border-violet-400/30">
-                        <List className="h-3.5 w-3.5 text-violet-300" />
+                      <span className="inline-flex items-center justify-center w-6 h-6 rounded-md bg-de-raised border border-de-hairline">
+                        <List className="h-3.5 w-3.5 text-de-accent-ink" />
                       </span>
                       In this article
                     </div>
@@ -577,7 +577,7 @@ export default function BlogPost() {
                           />
                           <span
                             aria-hidden
-                            className="absolute left-[10px] top-1 w-px bg-gradient-to-b from-violet-400 via-fuchsia-400 to-violet-400 transition-all duration-500"
+                            className="absolute left-[10px] top-1 w-px bg-de-raised transition-all duration-500"
                             style={{
                               height: `max(0px, calc(${progressPct}% - 4px))`,
                             }}
@@ -593,9 +593,9 @@ export default function BlogPost() {
                                     aria-hidden
                                     className={`absolute left-[3px] top-[11px] w-3.5 h-3.5 rounded-full border-2 transition-all duration-300 flex items-center justify-center text-[8px] font-bold ${
                                       isActive
-                                        ? "bg-gradient-to-br from-violet-400 to-fuchsia-400 border-white/80 shadow-[0_0_12px_rgba(217,70,239,0.7)] scale-110"
+                                        ? "bg-gradient-to-br  to-fuchsia-400 border-white/80 shadow-[0_0_12px_rgba(217,70,239,0.7)] scale-110"
                                         : isPast
-                                          ? "bg-violet-500/70 border-violet-300/60"
+                                          ? "bg-de-raised border-de-hairline"
                                           : "bg-[#0a0a0a] border-white/25"
                                     }`}
                                   >
@@ -614,9 +614,9 @@ export default function BlogPost() {
                                     }}
                                     className={`block text-sm leading-snug transition-all rounded-lg px-3 py-2 ${
                                       isActive
-                                        ? "bg-violet-500/10 text-white font-medium"
+                                        ? "bg-de-raised text-white font-medium"
                                         : isPast
-                                          ? "text-white/45 hover:text-white"
+                                          ? "text-white/55 hover:text-white"
                                           : "text-white/60 hover:text-white hover:bg-white/[0.04]"
                                     }`}
                                     data-testid={`toc-${h.id}`}
@@ -634,13 +634,13 @@ export default function BlogPost() {
                           <div className="mt-5 pt-4 border-t border-white/10">
                             <div className="flex items-center justify-between text-[10px] font-semibold uppercase tracking-wider text-white/50 mb-2">
                               <span>Progress</span>
-                              <span className="text-violet-300 tabular-nums">
+                              <span className="text-de-accent-ink tabular-nums">
                                 {activeIdx < 0 ? 0 : activeIdx + 1}/{headings.length}
                               </span>
                             </div>
                             <div className="h-1 rounded-full bg-white/10 overflow-hidden">
                               <div
-                                className="h-full bg-gradient-to-r from-violet-400 via-fuchsia-400 to-violet-400 transition-all duration-500 rounded-full"
+                                className="h-full bg-de-raised transition-all duration-500 rounded-full"
                                 style={{ width: `${progressPct}%` }}
                               />
                             </div>
@@ -674,12 +674,12 @@ export default function BlogPost() {
                         id={id}
                         className="group scroll-mt-28 text-2xl md:text-[34px] font-bold text-white mt-16 mb-6 leading-[1.15] tracking-tight"
                       >
-                        <span className="bg-gradient-to-r from-white to-violet-100 bg-clip-text text-transparent">
+                        <span className="bg-gradient-to-r from-white bg-clip-text text-transparent">
                           {renderTokens(block.text, wordCounter)}
                         </span>
                         <span
                           aria-hidden
-                          className="block mt-3 h-px w-12 bg-gradient-to-r from-violet-400/70 to-fuchsia-400/0"
+                          className="block mt-3 h-px w-12 bg-de-raised"
                         />
                       </h2>
                     );
@@ -695,7 +695,7 @@ export default function BlogPost() {
                             key={i}
                             className="flex items-start gap-3 leading-[1.75] text-[17px]"
                           >
-                            <span className="mt-[10px] inline-block w-1.5 h-1.5 rounded-full bg-gradient-to-r from-violet-400 to-fuchsia-400 flex-shrink-0" />
+                            <span className="mt-[10px] inline-block w-1.5 h-1.5 rounded-full bg-de-raised flex-shrink-0" />
                             <span>{renderTokens(it, wordCounter)}</span>
                           </li>
                         ))}
@@ -707,17 +707,17 @@ export default function BlogPost() {
                     const toneCfg = {
                       insight: {
                         Icon: Sparkles,
-                        ring: "border-violet-400/40",
-                        bg: "from-violet-600/15 to-fuchsia-600/10",
-                        glow: "bg-violet-500/20",
-                        accent: "text-violet-200",
-                        chip: "bg-violet-500/20 text-violet-100 border-violet-400/40",
+                        ring: "border-de-hairline",
+                        bg: " to-fuchsia-600/10",
+                        glow: "bg-de-raised",
+                        accent: "text-de-accent-ink",
+                        chip: "bg-de-raised text-white/80 border-de-hairline",
                         defaultTitle: "Key insight",
                       },
                       warning: {
                         Icon: AlertTriangle,
                         ring: "border-fuchsia-400/50",
-                        bg: "from-fuchsia-600/20 to-violet-700/15",
+                        bg: "from-fuchsia-600/20 ",
                         glow: "bg-fuchsia-500/25",
                         accent: "text-fuchsia-200",
                         chip: "bg-fuchsia-500/20 text-fuchsia-100 border-fuchsia-400/40",
@@ -725,20 +725,20 @@ export default function BlogPost() {
                       },
                       note: {
                         Icon: Info,
-                        ring: "border-violet-400/35",
-                        bg: "from-violet-700/15 to-violet-900/10",
-                        glow: "bg-violet-500/20",
-                        accent: "text-violet-200",
-                        chip: "bg-violet-500/15 text-violet-100 border-violet-400/35",
+                        ring: "border-de-hairline",
+                        bg: " ",
+                        glow: "bg-de-raised",
+                        accent: "text-de-accent-ink",
+                        chip: "bg-de-raised text-white/80 border-de-hairline",
                         defaultTitle: "Note",
                       },
                       tip: {
                         Icon: Lightbulb,
-                        ring: "border-violet-300/40",
-                        bg: "from-violet-500/15 to-violet-700/10",
-                        glow: "bg-violet-400/20",
-                        accent: "text-violet-200",
-                        chip: "bg-violet-400/20 text-violet-100 border-violet-300/40",
+                        ring: "border-de-hairline",
+                        bg: " ",
+                        glow: "bg-de-raised",
+                        accent: "text-de-accent-ink",
+                        chip: "bg-de-raised text-white/80 border-de-hairline",
                         defaultTitle: "Pro tip",
                       },
                     }[tone];
@@ -773,12 +773,12 @@ export default function BlogPost() {
                     return (
                       <figure
                         key={idx}
-                        className="relative my-10 pl-6 sm:pl-8 border-l-[3px] border-violet-400/70"
+                        className="relative my-10 pl-6 sm:pl-8 border-l-[3px] border-de-hairline"
                         data-testid="pullquote"
                       >
                         <Quote
                           aria-hidden
-                          className="absolute -left-[2px] -top-2 h-5 w-5 text-violet-400 bg-[#0a0a0a] px-0.5"
+                          className="absolute -left-[2px] -top-2 h-5 w-5 text-de-accent-ink bg-[#0a0a0a] px-0.5"
                         />
                         <blockquote className="text-white/90 text-xl sm:text-2xl leading-[1.45] font-serif italic">
                           “{renderTokens(block.text, wordCounter)}”
@@ -800,12 +800,12 @@ export default function BlogPost() {
                     return (
                       <figure
                         key={idx}
-                        className="relative my-10 pl-6 sm:pl-8 border-l-[3px] border-violet-400/70"
+                        className="relative my-10 pl-6 sm:pl-8 border-l-[3px] border-de-hairline"
                         data-testid="pullquote"
                       >
                         <Quote
                           aria-hidden
-                          className="absolute -left-[2px] -top-2 h-5 w-5 text-violet-400 bg-[#0a0a0a] px-0.5"
+                          className="absolute -left-[2px] -top-2 h-5 w-5 text-de-accent-ink bg-[#0a0a0a] px-0.5"
                         />
                         <blockquote className="text-white/90 text-xl sm:text-2xl leading-[1.45] font-serif italic">
                           “{renderTokens(raw.slice(2), wordCounter)}”
@@ -830,17 +830,17 @@ export default function BlogPost() {
                     const toneCfg = {
                       insight: {
                         Icon: Sparkles,
-                        ring: "border-violet-400/40",
-                        bg: "from-violet-600/15 to-fuchsia-600/10",
-                        glow: "bg-violet-500/20",
-                        accent: "text-violet-200",
-                        chip: "bg-violet-500/20 text-violet-100 border-violet-400/40",
+                        ring: "border-de-hairline",
+                        bg: " to-fuchsia-600/10",
+                        glow: "bg-de-raised",
+                        accent: "text-de-accent-ink",
+                        chip: "bg-de-raised text-white/80 border-de-hairline",
                         title: "Key insight",
                       },
                       warning: {
                         Icon: AlertTriangle,
                         ring: "border-fuchsia-400/50",
-                        bg: "from-fuchsia-600/20 to-violet-700/15",
+                        bg: "from-fuchsia-600/20 ",
                         glow: "bg-fuchsia-500/25",
                         accent: "text-fuchsia-200",
                         chip: "bg-fuchsia-500/20 text-fuchsia-100 border-fuchsia-400/40",
@@ -848,20 +848,20 @@ export default function BlogPost() {
                       },
                       note: {
                         Icon: Info,
-                        ring: "border-violet-400/35",
-                        bg: "from-violet-700/15 to-violet-900/10",
-                        glow: "bg-violet-500/20",
-                        accent: "text-violet-200",
-                        chip: "bg-violet-500/15 text-violet-100 border-violet-400/35",
+                        ring: "border-de-hairline",
+                        bg: " ",
+                        glow: "bg-de-raised",
+                        accent: "text-de-accent-ink",
+                        chip: "bg-de-raised text-white/80 border-de-hairline",
                         title: "Note",
                       },
                       tip: {
                         Icon: Lightbulb,
-                        ring: "border-violet-300/40",
-                        bg: "from-violet-500/15 to-violet-700/10",
-                        glow: "bg-violet-400/20",
-                        accent: "text-violet-200",
-                        chip: "bg-violet-400/20 text-violet-100 border-violet-300/40",
+                        ring: "border-de-hairline",
+                        bg: " ",
+                        glow: "bg-de-raised",
+                        accent: "text-de-accent-ink",
+                        chip: "bg-de-raised text-white/80 border-de-hairline",
                         title: "Pro tip",
                       },
                     }[tone];
@@ -900,7 +900,7 @@ export default function BlogPost() {
                       key={idx}
                       className={`text-white/85 text-[18px] leading-[1.85] mb-7 ${
                         isFirst
-                          ? "first-letter:float-left first-letter:mr-3 first-letter:mt-1 first-letter:text-7xl first-letter:font-bold first-letter:leading-[0.85] first-letter:bg-gradient-to-br first-letter:from-violet-300 first-letter:to-fuchsia-400 first-letter:bg-clip-text first-letter:text-transparent"
+                          ? "first-letter:float-left first-letter:mr-3 first-letter:mt-1 first-letter:text-7xl first-letter:font-bold first-letter:leading-[0.85] first-letter:bg-gradient-to-br first-letter: first-letter:to-fuchsia-400 first-letter:bg-clip-text first-letter:text-transparent"
                           : ""
                       }`}
                     >
@@ -911,7 +911,7 @@ export default function BlogPost() {
               </article>
 
               {/* Bottom CTA */}
-              <Card className="mt-14 max-w-3xl border-violet-500/30 bg-gradient-to-br from-violet-600/15 via-[#0a0a0a] to-fuchsia-600/15 overflow-hidden">
+              <Card className="mt-14 max-w-3xl border-de-hairline bg-de-raised via-[#0a0a0a] to-fuchsia-600/15 overflow-hidden">
                 <CardContent className="p-7 sm:p-9 relative">
                   <div
                     aria-hidden
@@ -954,7 +954,7 @@ export default function BlogPost() {
               {/* Author card */}
               <Card className="mt-8 max-w-3xl border-white/10 bg-white/[0.02]">
                 <CardContent className="p-6 flex items-start gap-5">
-                  <div className="w-14 h-14 flex-shrink-0 rounded-full bg-gradient-to-br from-violet-500 to-fuchsia-500 flex items-center justify-center shadow-[0_0_20px_rgba(179,0,255,0.35)]">
+                  <div className="w-14 h-14 flex-shrink-0 rounded-full bg-de-raised flex items-center justify-center shadow-[0_0_20px_rgba(179,0,255,0.35)]">
                     <User className="h-6 w-6 text-white" />
                   </div>
                   <div className="flex-1">
@@ -971,7 +971,7 @@ export default function BlogPost() {
                     <div className="flex items-center gap-3">
                       <Link
                         href="/about"
-                        className="text-violet-300 hover:text-violet-200 text-sm inline-flex items-center"
+                        className="text-de-accent-ink hover:text-de-accent-ink text-sm inline-flex items-center"
                       >
                         About Digerati Experts
                         <ArrowRight className="ml-1 h-3.5 w-3.5" />
@@ -979,7 +979,7 @@ export default function BlogPost() {
                       <span className="text-white/20">•</span>
                       <Link
                         href="/#contact"
-                        className="text-violet-300 hover:text-violet-200 text-sm inline-flex items-center"
+                        className="text-de-accent-ink hover:text-de-accent-ink text-sm inline-flex items-center"
                       >
                         Get in touch
                         <ArrowRight className="ml-1 h-3.5 w-3.5" />
@@ -1000,7 +1000,7 @@ export default function BlogPost() {
                     variant="outline"
                     size="sm"
                     onClick={() => handleShare("twitter")}
-                    className="border-white/20 bg-transparent text-white/90 hover:text-white hover:bg-violet-500/10 hover:border-violet-500/60"
+                    className="border-white/20 bg-transparent text-white/90 hover:text-white hover:bg-de-raised hover:border-de-hairline"
                     data-testid="button-share-twitter-bottom"
                   >
                     <Twitter className="h-4 w-4 mr-2" />
@@ -1010,7 +1010,7 @@ export default function BlogPost() {
                     variant="outline"
                     size="sm"
                     onClick={() => handleShare("linkedin")}
-                    className="border-white/20 bg-transparent text-white/90 hover:text-white hover:bg-violet-500/10 hover:border-violet-500/60"
+                    className="border-white/20 bg-transparent text-white/90 hover:text-white hover:bg-de-raised hover:border-de-hairline"
                     data-testid="button-share-linkedin-bottom"
                   >
                     <Linkedin className="h-4 w-4 mr-2" />
@@ -1020,7 +1020,7 @@ export default function BlogPost() {
                     variant="outline"
                     size="sm"
                     onClick={handleCopyLink}
-                    className="border-white/20 bg-transparent text-white/90 hover:text-white hover:bg-violet-500/10 hover:border-violet-500/60"
+                    className="border-white/20 bg-transparent text-white/90 hover:text-white hover:bg-de-raised hover:border-de-hairline"
                     data-testid="button-share-copy-bottom"
                   >
                     {copied ? (
@@ -1057,7 +1057,7 @@ export default function BlogPost() {
                 </div>
                 <Link
                   href="/resources/blog"
-                  className="hidden sm:inline-flex items-center text-violet-300 hover:text-violet-200 text-sm font-medium"
+                  className="hidden sm:inline-flex items-center text-de-accent-ink hover:text-de-accent-ink text-sm font-medium"
                 >
                   All articles
                   <ArrowRight className="ml-1 h-4 w-4" />
@@ -1067,7 +1067,7 @@ export default function BlogPost() {
                 {relatedPosts.map((rp) => (
                   <Link key={rp.slug} href={`/resources/blog/${rp.slug}`}>
                     <Card
-                      className="group h-full overflow-hidden border-white/10 bg-white/[0.02] hover:border-violet-500/50 transition-all cursor-pointer"
+                      className="group h-full overflow-hidden border-white/10 bg-white/[0.02] hover:border-de-hairline transition-all cursor-pointer"
                       data-testid={`card-related-${rp.slug}`}
                     >
                       <div className="relative aspect-[16/9] overflow-hidden">
@@ -1084,13 +1084,13 @@ export default function BlogPost() {
                         </Badge>
                       </div>
                       <CardContent className="p-5">
-                        <h4 className="text-base font-semibold text-white mb-2 leading-snug group-hover:text-violet-300 transition-colors line-clamp-2">
+                        <h4 className="text-base font-semibold text-white mb-2 leading-snug group-hover:text-de-accent-ink transition-colors line-clamp-2">
                           {rp.title}
                         </h4>
                         <p className="text-sm text-white/55 line-clamp-2 mb-4 leading-relaxed">
                           {rp.excerpt}
                         </p>
-                        <span className="text-violet-300 text-sm inline-flex items-center font-medium">
+                        <span className="text-de-accent-ink text-sm inline-flex items-center font-medium">
                           Read article
                           <ArrowRight className="ml-1.5 h-3.5 w-3.5 transition-transform group-hover:translate-x-1" />
                         </span>

--- a/client/src/pages/resources/CaseStudies.tsx
+++ b/client/src/pages/resources/CaseStudies.tsx
@@ -76,7 +76,7 @@ export default function CaseStudies() {
           {focusAreas.map((item) => (
             <div key={item.value} className="text-center p-4 bg-white/10 rounded-xl backdrop-blur-sm">
               <p className="text-xl font-bold mb-1">{item.value}</p>
-              <p className="text-purple-100 text-sm">{item.label}</p>
+              <p className="text-white/80 text-sm">{item.label}</p>
             </div>
           ))}
         </motion.div>
@@ -91,7 +91,7 @@ export default function CaseStudies() {
               transition={{ delay: index * 0.05, duration: 0.45 }}
             >
               <Card
-                className="overflow-hidden bg-white/5 backdrop-blur-sm border border-white/10 hover:border-[#5034ff]/50 hover:shadow-xl transition-all duration-300"
+                className="overflow-hidden bg-white/5 backdrop-blur-sm border border-white/10 hover:border-de-accent/50 hover:shadow-xl transition-all duration-300"
                 data-testid={`case-study-card-${study.slug}`}
               >
                 <CardHeader className="border-b border-white/10 bg-white/[0.03]">
@@ -106,7 +106,7 @@ export default function CaseStudies() {
                     </div>
                     <Link
                       href={`/resources/case-studies/${study.slug}`}
-                      className="inline-flex items-center gap-2 text-sm font-medium text-violet-300 hover:text-violet-200"
+                      className="inline-flex items-center gap-2 text-sm font-medium text-de-accent-ink hover:text-de-accent-ink"
                       data-testid={`link-case-study-${study.slug}`}
                     >
                       View structure
@@ -145,15 +145,15 @@ export default function CaseStudies() {
                     </div>
                     <div className="space-y-2">
                       <div className="flex items-center gap-2">
-                        <div className="w-8 h-8 rounded-lg bg-violet-500/20 flex items-center justify-center">
-                          <Layers className="w-4 h-4 text-violet-300" />
+                        <div className="w-8 h-8 rounded-lg bg-de-raised flex items-center justify-center">
+                          <Layers className="w-4 h-4 text-de-accent-ink" />
                         </div>
                         <h4 className="font-semibold text-white">Stack</h4>
                       </div>
                       <ul className="space-y-1.5">
                         {study.stack.map((item) => (
                           <li key={item} className="text-gray-300 text-sm flex items-start gap-2">
-                            <span className="text-violet-400 mt-1">•</span>
+                            <span className="text-de-accent-ink mt-1">•</span>
                             {item}
                           </li>
                         ))}
@@ -173,7 +173,7 @@ export default function CaseStudies() {
           viewport={{ once: true }}
           transition={{ duration: 0.5 }}
         >
-          <div className="absolute inset-0 bg-gradient-to-r from-purple-600 via-indigo-600 to-blue-600" />
+          <div className="absolute inset-0 bg-de-raised" />
           <div className="relative p-8 md:p-12 text-center">
             <h2 className="text-3xl md:text-4xl font-bold mb-4 text-white">
               Ready to discuss your environment?
@@ -184,7 +184,7 @@ export default function CaseStudies() {
             </p>
             <a
               href="/book"
-              className="inline-flex items-center justify-center bg-white text-purple-700 hover:bg-purple-50 px-8 py-4 rounded-xl font-semibold transition-all shadow-lg hover:shadow-xl hover:scale-105"
+              className="inline-flex items-center justify-center bg-white text-de-accent hover:bg-de-paper-raised px-8 py-4 rounded-xl font-semibold transition-all shadow-lg hover:shadow-xl hover:scale-105"
               data-testid="button-contact-us"
             >
               {CTA.primary}

--- a/client/src/pages/resources/CaseStudies.tsx
+++ b/client/src/pages/resources/CaseStudies.tsx
@@ -67,7 +67,7 @@ export default function CaseStudies() {
         )}
 
         <motion.div
-          className="grid md:grid-cols-4 gap-6 bg-gradient-to-r from-[#1a0a2e] via-[#2d1060] to-[#1a0a2e] rounded-2xl p-8 text-white border border-white/10"
+          className="grid md:grid-cols-4 gap-6 bg-gradient-to-r from-[#050312] via-[#0a0a0a] to-[#050312] rounded-2xl p-8 text-white border border-white/10"
           initial={prefersReducedMotion ? {} : { opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}

--- a/client/src/pages/resources/CaseStudyDetail.tsx
+++ b/client/src/pages/resources/CaseStudyDetail.tsx
@@ -30,7 +30,7 @@ export default function CaseStudyDetail() {
       >
         <Link
           href="/resources/case-studies"
-          className="inline-flex items-center gap-2 text-violet-300 hover:text-violet-200"
+          className="inline-flex items-center gap-2 text-de-accent-ink hover:text-de-accent-ink"
         >
           <ArrowLeft className="h-4 w-4" />
           Back to case studies
@@ -78,7 +78,7 @@ export default function CaseStudyDetail() {
             </Badge>
           )}
           {study.clientLabel && (
-            <Badge className="bg-violet-500/20 text-violet-200 border border-violet-500/30">
+            <Badge className="bg-de-raised text-de-accent-ink border border-de-hairline">
               {study.clientLabel}
             </Badge>
           )}
@@ -112,8 +112,8 @@ export default function CaseStudyDetail() {
 
           <section className="rounded-2xl border border-white/10 bg-white/[0.03] p-6">
             <div className="flex items-center gap-3 mb-4">
-              <div className="w-9 h-9 rounded-lg bg-violet-500/20 flex items-center justify-center">
-                <Layers className="w-4 h-4 text-violet-300" />
+              <div className="w-9 h-9 rounded-lg bg-de-raised flex items-center justify-center">
+                <Layers className="w-4 h-4 text-de-accent-ink" />
               </div>
               <h2 className="text-xl font-semibold text-white">Stack</h2>
             </div>
@@ -132,7 +132,7 @@ export default function CaseStudyDetail() {
 
         <Link
           href="/resources/case-studies"
-          className="inline-flex items-center gap-2 text-violet-300 hover:text-violet-200"
+          className="inline-flex items-center gap-2 text-de-accent-ink hover:text-de-accent-ink"
           data-testid="link-back-case-studies"
         >
           <ArrowLeft className="h-4 w-4" />

--- a/client/src/pages/resources/CyberFacts.tsx
+++ b/client/src/pages/resources/CyberFacts.tsx
@@ -133,16 +133,16 @@ const featuredFacts = allFacts.filter((f) =>
 
 const accentStyles: Record<AccentColor, { bg: string; border: string; glow: string; stat: string }> = {
   violet: {
-    bg: "from-violet-500/10 to-purple-500/5",
-    border: "border-violet-500/30 hover:border-violet-400/50",
-    glow: "hover:shadow-violet-500/20",
-    stat: "from-violet-400 to-purple-400"
+    bg: " ",
+    border: "border-de-hairline hover:border-de-hairline",
+    glow: "hover:shadow-none",
+    stat: " "
   },
   purple: {
-    bg: "from-purple-500/10 to-fuchsia-500/5",
-    border: "border-purple-500/30 hover:border-purple-400/50",
-    glow: "hover:shadow-purple-500/20",
-    stat: "from-purple-400 to-fuchsia-400"
+    bg: " to-fuchsia-500/5",
+    border: "border-de-hairline hover:border-de-hairline",
+    glow: "hover:shadow-none",
+    stat: " to-fuchsia-400"
   },
   fuchsia: {
     bg: "from-fuchsia-500/10 to-pink-500/5",
@@ -208,10 +208,10 @@ const FactCard = ({ fact, featured = false, onCopy, copiedId }: FactCardProps) =
           href={fact.sourceUrl} 
           target="_blank" 
           rel="noopener noreferrer"
-          className="inline-flex items-center gap-2 text-sm text-violet-300 hover:text-violet-200 transition-colors"
+          className="inline-flex items-center gap-2 text-sm text-de-accent-ink hover:text-de-accent-ink transition-colors"
           data-testid={`fact-source-${fact.id}`}
         >
-          <span className="text-white/40">Source:</span>
+          <span className="text-white/55">Source:</span>
           <span className="font-medium">{fact.source}</span>
           <ExternalLink className="w-3.5 h-3.5 opacity-60" />
         </a>
@@ -310,7 +310,7 @@ const CyberFacts = () => {
       <main className="relative z-10 de-nav-clear pb-16">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
           {/* Back Link */}
-          <Link href="/resources/blog" className="inline-flex items-center gap-2 text-violet-400 hover:text-violet-300 transition-colors mb-8" data-testid="link-back">
+          <Link href="/resources/blog" className="inline-flex items-center gap-2 text-de-accent-ink hover:text-de-accent-ink transition-colors mb-8" data-testid="link-back">
             <ArrowLeft className="w-4 h-4" />
             <span>Back to Blog</span>
           </Link>
@@ -322,13 +322,13 @@ const CyberFacts = () => {
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5 }}
           >
-            <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-violet-500/10 border border-violet-500/30 text-violet-300 text-sm font-medium mb-4">
+            <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-de-raised border border-de-hairline text-de-accent-ink text-sm font-medium mb-4">
               <Sparkles className="w-4 h-4" />
               <span>Credibility Layer</span>
             </div>
             <h1 className="text-4xl md:text-5xl lg:text-6xl font-black text-white mb-4 tracking-tight" data-testid="heading-cyber-facts">
               Real Cybersecurity Facts
-              <span className="block text-transparent bg-clip-text bg-gradient-to-r from-violet-400 via-purple-400 to-fuchsia-400">
+              <span className="block text-de-accent-ink">
                 (With Sources)
               </span>
             </h1>
@@ -339,14 +339,14 @@ const CyberFacts = () => {
           </motion.div>
 
           {/* Divider */}
-          <div className="h-px bg-gradient-to-r from-transparent via-violet-500/30 to-transparent mb-16" />
+          <div className="h-px bg-gradient-to-r from-transparent to-transparent mb-16" />
 
           {/* Section 1: Today's Cyber Fact */}
           <section className="mb-20">
             <div className="flex items-center justify-between gap-4 flex-wrap mb-8">
               <div>
                 <h2 className="text-2xl md:text-3xl font-bold text-white mb-1">Today's Cyber Fact</h2>
-                <p className="text-sm text-white/40 uppercase tracking-wider font-semibold">Auto-randomizes on load</p>
+                <p className="text-sm text-white/55 uppercase tracking-wider font-semibold">Auto-randomizes on load</p>
               </div>
               <Button
                 variant="outline"
@@ -372,20 +372,20 @@ const CyberFacts = () => {
               )}
             </AnimatePresence>
 
-            <div className="mt-6 p-4 rounded-xl bg-violet-500/5 border-l-4 border-violet-500 text-white/60 text-sm">
+            <div className="mt-6 p-4 rounded-xl bg-de-raised border-l-4 border-de-hairline text-white/60 text-sm">
               <strong className="text-white/80">Tip:</strong> Put this under your hero or above pricing to add immediate proof without adding clutter.
             </div>
           </section>
 
           {/* Divider */}
-          <div className="h-px bg-gradient-to-r from-transparent via-purple-500/30 to-transparent mb-16" />
+          <div className="h-px bg-gradient-to-r from-transparent to-transparent mb-16" />
 
           {/* Section 2: Quick Proof */}
           <section className="mb-20">
             <div className="flex items-center justify-between gap-4 flex-wrap mb-8">
               <div>
                 <h2 className="text-2xl md:text-3xl font-bold text-white mb-1">Quick Proof</h2>
-                <p className="text-sm text-white/40 uppercase tracking-wider font-semibold">Most persuasive • 2 cards is the sweet spot</p>
+                <p className="text-sm text-white/55 uppercase tracking-wider font-semibold">Most persuasive • 2 cards is the sweet spot</p>
               </div>
             </div>
 
@@ -411,7 +411,7 @@ const CyberFacts = () => {
             <div className="flex items-center justify-between gap-4 flex-wrap mb-8">
               <div>
                 <h2 className="text-2xl md:text-3xl font-bold text-white mb-1">Fact Library</h2>
-                <p className="text-sm text-white/40 uppercase tracking-wider font-semibold">
+                <p className="text-sm text-white/55 uppercase tracking-wider font-semibold">
                   Copy anywhere • Use 1–3 per page • {filteredFacts.length} facts
                 </p>
               </div>
@@ -441,7 +441,7 @@ const CyberFacts = () => {
                       <button
                         onClick={() => { setSelectedCategory("all"); setIsFilterOpen(false); }}
                         className={`w-full px-4 py-3 text-left text-sm hover:bg-white/5 transition-colors flex items-center gap-3
-                          ${selectedCategory === "all" ? 'text-violet-300 bg-violet-500/10' : 'text-white/70'}`}
+                          ${selectedCategory === "all" ? 'text-de-accent-ink bg-de-raised' : 'text-white/70'}`}
                         data-testid="filter-all"
                       >
                         <Sparkles className="w-4 h-4" />
@@ -452,7 +452,7 @@ const CyberFacts = () => {
                           key={key}
                           onClick={() => { setSelectedCategory(key as FactCategory); setIsFilterOpen(false); }}
                           className={`w-full px-4 py-3 text-left text-sm hover:bg-white/5 transition-colors flex items-center gap-3
-                            ${selectedCategory === key ? 'text-violet-300 bg-violet-500/10' : 'text-white/70'}`}
+                            ${selectedCategory === key ? 'text-de-accent-ink bg-de-raised' : 'text-white/70'}`}
                           data-testid={`filter-${key}`}
                         >
                           {info.icon}
@@ -483,7 +483,7 @@ const CyberFacts = () => {
               </AnimatePresence>
             </motion.div>
 
-            <div className="mt-8 p-4 rounded-xl bg-purple-500/5 border-l-4 border-purple-500 text-white/60 text-sm">
+            <div className="mt-8 p-4 rounded-xl bg-de-raised border-l-4 border-de-hairline text-white/60 text-sm">
               <strong className="text-white/80">Best practice:</strong> Keep "Source:" links clickable. It builds trust and reduces skepticism.
             </div>
           </section>

--- a/client/src/pages/resources/CyberFacts.tsx
+++ b/client/src/pages/resources/CyberFacts.tsx
@@ -133,23 +133,23 @@ const featuredFacts = allFacts.filter((f) =>
 
 const accentStyles: Record<AccentColor, { bg: string; border: string; glow: string; stat: string }> = {
   violet: {
-    bg: " ",
+    bg: "bg-de-raised",
     border: "border-de-hairline hover:border-de-hairline",
     glow: "hover:shadow-none",
-    stat: " "
+    stat: "text-de-accent-ink",
   },
   purple: {
-    bg: " to-fuchsia-500/5",
+    bg: "bg-de-raised",
     border: "border-de-hairline hover:border-de-hairline",
     glow: "hover:shadow-none",
-    stat: " to-fuchsia-400"
+    stat: "text-de-accent-ink",
   },
   fuchsia: {
-    bg: "from-fuchsia-500/10 to-pink-500/5",
-    border: "border-fuchsia-500/30 hover:border-fuchsia-400/50",
-    glow: "hover:shadow-fuchsia-500/20",
-    stat: "from-fuchsia-400 to-pink-400"
-  }
+    bg: "bg-de-raised",
+    border: "border-de-hairline hover:border-de-accent/40",
+    glow: "hover:shadow-none",
+    stat: "text-de-accent-ink",
+  },
 };
 
 interface FactCardProps {
@@ -186,7 +186,7 @@ const FactCard = ({ fact, featured = false, onCopy, copiedId }: FactCardProps) =
 
       {/* Stat & Label */}
       <div className={`flex items-baseline gap-4 flex-wrap ${featured ? 'mb-6 pb-6 border-b border-white/10' : 'mb-4'}`}>
-        <span className={`font-black tracking-tight bg-gradient-to-r ${styles.stat} bg-clip-text text-transparent
+        <span className={`font-black tracking-tight ${styles.stat}
           ${featured ? 'text-5xl md:text-7xl' : 'text-3xl md:text-4xl'}`}>
           {fact.stat}
         </span>
@@ -404,7 +404,7 @@ const CyberFacts = () => {
           </section>
 
           {/* Divider */}
-          <div className="h-px bg-gradient-to-r from-transparent via-fuchsia-500/30 to-transparent mb-16" />
+          <div className="h-px bg-gradient-to-r from-transparent via-de-accent/30 to-transparent mb-16" />
 
           {/* Section 3: Full Fact Library */}
           <section>

--- a/client/src/pages/resources/Datasheets.tsx
+++ b/client/src/pages/resources/Datasheets.tsx
@@ -167,8 +167,8 @@ const categories = ["All", "Services", "Security", "Backup", "Compliance", "Trai
 
 const getTypeColor = (type: string) => {
   switch (type) {
-    case "datasheet": return "bg-violet-500/20 text-violet-400 border-violet-500/30";
-    case "whitepaper": return "bg-purple-500/20 text-purple-400 border-purple-500/30";
+    case "datasheet": return "bg-de-raised text-de-accent-ink border-de-hairline";
+    case "whitepaper": return "bg-de-raised text-de-accent-ink border-de-hairline";
     case "guide": return "bg-emerald-500/20 text-emerald-400 border-emerald-500/30";
     case "infographic": return "bg-fuchsia-500/20 text-fuchsia-400 border-fuchsia-500/30";
     default: return "bg-white/10 text-white/70 border-white/20";
@@ -186,7 +186,7 @@ export default function Datasheets() {
         <div className="container mx-auto px-4 max-w-7xl">
           {/* Header */}
           <div className="text-center mb-12">
-            <Badge className="mb-4 bg-violet-500/20 text-violet-400 border-violet-500/30">
+            <Badge className="mb-4 bg-de-raised text-de-accent-ink border-de-hairline">
               Resource Library
             </Badge>
             <h1 className="text-4xl md:text-5xl font-bold text-white mb-4">
@@ -205,7 +205,7 @@ export default function Datasheets() {
                 key={category}
                 variant="outline"
                 size="sm"
-                className="border-violet-500/30 bg-transparent text-white/70 hover:bg-violet-500/10 hover:text-violet-400 hover:border-violet-400"
+                className="border-de-hairline bg-transparent text-white/70 hover:bg-de-raised hover:text-de-accent-ink hover:border-de-hairline"
                 data-testid={`button-filter-${category.toLowerCase()}`}
               >
                 {category}
@@ -216,11 +216,11 @@ export default function Datasheets() {
           {/* Document Grid */}
           <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
             {documents.map((doc) => (
-              <Card key={doc.id} className="bg-white/[0.02] border-white/10 hover:border-violet-500/50 transition-colors" data-testid={`card-document-${doc.id}`}>
+              <Card key={doc.id} className="bg-white/[0.02] border-white/10 hover:border-de-hairline transition-colors" data-testid={`card-document-${doc.id}`}>
                 <CardHeader>
                   <div className="flex items-start justify-between mb-2">
-                    <div className="w-12 h-12 rounded-lg bg-violet-500/20 flex items-center justify-center">
-                      <doc.icon className="h-6 w-6 text-violet-400" />
+                    <div className="w-12 h-12 rounded-lg bg-de-raised flex items-center justify-center">
+                      <doc.icon className="h-6 w-6 text-de-accent-ink" />
                     </div>
                     <Badge className={getTypeColor(doc.type)}>
                       {doc.type}
@@ -239,7 +239,7 @@ export default function Datasheets() {
                   {doc.downloadUrl ? (
                     <Button
                       asChild
-                      className="w-full bg-violet-600 hover:bg-violet-500 text-white"
+                      className="w-full bg-de-accent hover:bg-de-accent text-white"
                       data-testid={`button-download-${doc.id}`}
                     >
                       <a href={doc.downloadUrl} download target="_blank" rel="noopener noreferrer">
@@ -251,7 +251,7 @@ export default function Datasheets() {
                     <Button
                       asChild
                       variant="outline"
-                      className="w-full border-violet-500/40 text-violet-300 hover:bg-violet-500/10 hover:text-violet-200"
+                      className="w-full border-de-hairline text-de-accent-ink hover:bg-de-raised hover:text-de-accent-ink"
                       data-testid={`button-request-${doc.id}`}
                     >
                       <Link href="/book">
@@ -266,7 +266,7 @@ export default function Datasheets() {
           </div>
 
           {/* Request Custom Content */}
-          <Card className="mt-12 bg-gradient-to-r from-violet-600/20 to-purple-600/20 border-violet-500/30">
+          <Card className="mt-12 bg-de-raised border-de-hairline">
             <CardContent className="p-8">
               <div className="flex flex-col md:flex-row items-center justify-between gap-6">
                 <div>
@@ -274,7 +274,7 @@ export default function Datasheets() {
                   <p className="text-white/70">We can provide tailored proposals, assessments, and documentation for your specific needs.</p>
                 </div>
                 <Button 
-                  className="bg-white text-violet-700 hover:bg-white/90 whitespace-nowrap"
+                  className="bg-white text-de-accent hover:bg-white/90 whitespace-nowrap"
                   onClick={() => window.location.href = "/book"}
                   data-testid="button-request-docs"
                 >
@@ -286,7 +286,7 @@ export default function Datasheets() {
           </Card>
 
           {/* Legal Notice */}
-          <div className="mt-8 text-center text-sm text-gray-500">
+          <div className="mt-8 text-center text-sm text-white/70">
             <p>All documents are for informational purposes. Contact us for specific pricing and service details.</p>
             <p className="mt-1">© {new Date().getFullYear()} Digerati Experts. All rights reserved.</p>
           </div>

--- a/client/src/pages/resources/Datasheets.tsx
+++ b/client/src/pages/resources/Datasheets.tsx
@@ -170,7 +170,7 @@ const getTypeColor = (type: string) => {
     case "datasheet": return "bg-de-raised text-de-accent-ink border-de-hairline";
     case "whitepaper": return "bg-de-raised text-de-accent-ink border-de-hairline";
     case "guide": return "bg-emerald-500/20 text-emerald-400 border-emerald-500/30";
-    case "infographic": return "bg-fuchsia-500/20 text-fuchsia-400 border-fuchsia-500/30";
+    case "infographic": return "bg-de-raised text-de-accent-ink border-de-hairline";
     default: return "bg-white/10 text-white/70 border-white/20";
   }
 };

--- a/client/src/pages/resources/DowntimeCalculator.tsx
+++ b/client/src/pages/resources/DowntimeCalculator.tsx
@@ -200,7 +200,7 @@ export default function DowntimeCalculator() {
                         type="number"
                         value={employees}
                         onChange={(e) => setEmployees(e.target.value)}
-                        className="h-14 bg-[#252550] border-2 border-[#FFB800]/15 text-white placeholder:text-gray-500 hover:border-[#FFB800] focus:border-[#FFB800] focus:ring-2 focus:ring-[#FFB800]/30 transition-all"
+                        className="h-14 bg-[#252550] border-2 border-[#FFB800]/15 text-white placeholder:text-white/70 hover:border-[#FFB800] focus:border-[#FFB800] focus:ring-2 focus:ring-[#FFB800]/30 transition-all"
                         placeholder="25"
                         data-testid="input-employees"
                       />
@@ -211,7 +211,7 @@ export default function DowntimeCalculator() {
                         type="number"
                         value={hourlyWage}
                         onChange={(e) => setHourlyWage(e.target.value)}
-                        className="h-14 bg-[#252550] border-2 border-[#FFB800]/15 text-white placeholder:text-gray-500 hover:border-[#FFB800] focus:border-[#FFB800] focus:ring-2 focus:ring-[#FFB800]/30 transition-all"
+                        className="h-14 bg-[#252550] border-2 border-[#FFB800]/15 text-white placeholder:text-white/70 hover:border-[#FFB800] focus:border-[#FFB800] focus:ring-2 focus:ring-[#FFB800]/30 transition-all"
                         placeholder="35"
                         data-testid="input-hourly-wage"
                       />
@@ -225,7 +225,7 @@ export default function DowntimeCalculator() {
                       type="number"
                       value={downtimeHours}
                       onChange={(e) => setDowntimeHours(e.target.value)}
-                      className="h-14 bg-[#252550] border-2 border-[#FFB800]/15 text-white placeholder:text-gray-500 hover:border-[#FFB800] focus:border-[#FFB800] focus:ring-2 focus:ring-[#FFB800]/30 transition-all"
+                      className="h-14 bg-[#252550] border-2 border-[#FFB800]/15 text-white placeholder:text-white/70 hover:border-[#FFB800] focus:border-[#FFB800] focus:ring-2 focus:ring-[#FFB800]/30 transition-all"
                       placeholder="4"
                       data-testid="input-downtime-hours"
                     />
@@ -246,7 +246,7 @@ export default function DowntimeCalculator() {
                               type="number"
                               value={rtoHours}
                               onChange={(e) => setRtoHours(e.target.value)}
-                              className="h-12 bg-[#1a1a3e] border-2 border-[#FFB800]/15 text-white placeholder:text-gray-500 hover:border-[#FFB800] focus:border-[#FFB800] transition-all"
+                              className="h-12 bg-[#1a1a3e] border-2 border-[#FFB800]/15 text-white placeholder:text-white/70 hover:border-[#FFB800] focus:border-[#FFB800] transition-all"
                               placeholder="4"
                               data-testid="input-rto"
                             />
@@ -257,7 +257,7 @@ export default function DowntimeCalculator() {
                               type="number"
                               value={rpoHours}
                               onChange={(e) => setRpoHours(e.target.value)}
-                              className="h-12 bg-[#1a1a3e] border-2 border-[#FFB800]/15 text-white placeholder:text-gray-500 hover:border-[#FFB800] focus:border-[#FFB800] transition-all"
+                              className="h-12 bg-[#1a1a3e] border-2 border-[#FFB800]/15 text-white placeholder:text-white/70 hover:border-[#FFB800] focus:border-[#FFB800] transition-all"
                               placeholder="1"
                               data-testid="input-rpo"
                             />
@@ -269,7 +269,7 @@ export default function DowntimeCalculator() {
                             type="number"
                             value={incidentsPerYear}
                             onChange={(e) => setIncidentsPerYear(e.target.value)}
-                            className="h-12 bg-[#1a1a3e] border-2 border-[#FFB800]/15 text-white placeholder:text-gray-500 hover:border-[#FFB800] focus:border-[#FFB800] transition-all"
+                            className="h-12 bg-[#1a1a3e] border-2 border-[#FFB800]/15 text-white placeholder:text-white/70 hover:border-[#FFB800] focus:border-[#FFB800] transition-all"
                             placeholder="4"
                             data-testid="input-incidents"
                           />
@@ -358,7 +358,7 @@ export default function DowntimeCalculator() {
                       type="number"
                       value={serviceEmployees}
                       onChange={(e) => setServiceEmployees(e.target.value)}
-                      className="h-14 bg-[#252550] border-2 border-[#FFB800]/15 text-white placeholder:text-gray-500 hover:border-[#FFB800] focus:border-[#FFB800] focus:ring-2 focus:ring-[#FFB800]/30 transition-all"
+                      className="h-14 bg-[#252550] border-2 border-[#FFB800]/15 text-white placeholder:text-white/70 hover:border-[#FFB800] focus:border-[#FFB800] focus:ring-2 focus:ring-[#FFB800]/30 transition-all"
                       placeholder="10"
                       data-testid="input-service-employees"
                     />

--- a/client/src/pages/resources/Ebook.tsx
+++ b/client/src/pages/resources/Ebook.tsx
@@ -516,7 +516,7 @@ export default function Ebook() {
 
       <main className="de-nav-clear pb-20">
         <div className="container mx-auto px-4 max-w-7xl">
-          <Link href="/resources/blog" className="inline-flex items-center text-violet-400 hover:text-violet-300 mb-6 transition-colors" data-testid="link-back-blog">
+          <Link href="/resources/blog" className="inline-flex items-center text-de-accent-ink hover:text-de-accent-ink mb-6 transition-colors" data-testid="link-back-blog">
             <ArrowLeft className="mr-2 h-4 w-4" />
             Back to Resources
           </Link>
@@ -579,7 +579,7 @@ export default function Ebook() {
               </div>
               <div className="flex justify-center mb-10">
                 <div className="flex flex-col items-center gap-2">
-                  <p className="text-xs uppercase tracking-wider text-white/45">
+                  <p className="text-xs uppercase tracking-wider text-white/55">
                     Read Chapter 1 to you
                   </p>
                   <BlogAudioPlayer

--- a/client/src/pages/resources/SecurityChecklist.tsx
+++ b/client/src/pages/resources/SecurityChecklist.tsx
@@ -113,7 +113,7 @@ export default function SecurityChecklist() {
         <div className="container mx-auto px-4 max-w-5xl">
           {/* Header */}
           <div className="text-center mb-12">
-            <Badge className="mb-4 bg-violet-500/20 text-violet-400 border-violet-500/30">
+            <Badge className="mb-4 bg-de-raised text-de-accent-ink border-de-hairline">
               Security Checklist
             </Badge>
             <h1 className="text-4xl md:text-5xl font-bold text-white mb-4">
@@ -125,28 +125,28 @@ export default function SecurityChecklist() {
           </div>
 
           {/* Progress Card */}
-          <Card className="mb-8 bg-gradient-to-r from-violet-600/20 to-purple-600/20 border-violet-500/30">
+          <Card className="mb-8 bg-de-raised border-de-hairline">
             <CardContent className="p-6">
               <div className="flex items-center justify-between mb-4">
                 <div>
                   <h3 className="text-xl font-bold text-white">Your Progress</h3>
                   <p className="text-white/70">{completedItems} of {totalItems} items completed</p>
                 </div>
-                <div className="text-4xl font-bold text-violet-400">{percentComplete}%</div>
+                <div className="text-4xl font-bold text-de-accent-ink">{percentComplete}%</div>
               </div>
               <div className="w-full bg-white/10 rounded-full h-4">
                 <div 
-                  className="bg-gradient-to-r from-violet-600 to-purple-500 h-4 rounded-full transition-all duration-500"
+                  className="bg-de-raised h-4 rounded-full transition-all duration-500"
                   style={{ width: `${percentComplete}%` }}
                 />
               </div>
               <div className="mt-4 flex gap-4">
-                <Button variant="outline" className="border-violet-500/30 bg-transparent text-white/70 hover:bg-violet-500/10 hover:text-violet-400 hover:border-violet-400" data-testid="button-download-pdf">
+                <Button variant="outline" className="border-de-hairline bg-transparent text-white/70 hover:bg-de-raised hover:text-de-accent-ink hover:border-de-hairline" data-testid="button-download-pdf">
                   <Download className="mr-2 h-4 w-4" />
                   Download PDF
                 </Button>
                 <Button 
-                  className="bg-white text-violet-700 hover:bg-white/90"
+                  className="bg-white text-de-accent hover:bg-white/90"
                   onClick={() => window.location.href = "/book"}
                   data-testid="button-get-assessment"
                 >
@@ -163,7 +163,7 @@ export default function SecurityChecklist() {
               <Card key={category.name} className="bg-white/[0.02] border-white/10" data-testid={`card-category-${category.name.toLowerCase().replace(/\s+/g, '-')}`}>
                 <CardHeader>
                   <CardTitle className="text-xl text-white flex items-center gap-3">
-                    <category.icon className="h-6 w-6 text-violet-400" />
+                    <category.icon className="h-6 w-6 text-de-accent-ink" />
                     {category.name}
                   </CardTitle>
                 </CardHeader>
@@ -216,7 +216,7 @@ export default function SecurityChecklist() {
               <h3 className="text-2xl font-bold text-white mb-2">Need Help Completing Your Checklist?</h3>
               <p className="text-white/70 mb-6">Our security experts can help you implement these controls and more. Schedule a free consultation.</p>
               <Button 
-                className="bg-violet-600 hover:bg-violet-500 text-white"
+                className="bg-de-accent hover:bg-de-accent text-white"
                 onClick={() => window.location.href = "/book"}
                 data-testid="button-schedule-consultation"
               >

--- a/client/src/pages/resources/SecurityUpdates.tsx
+++ b/client/src/pages/resources/SecurityUpdates.tsx
@@ -146,7 +146,7 @@ export default function SecurityUpdates() {
                           {update.category}
                         </span>
                       </Badge>
-                      <span className="text-xs text-gray-500 flex items-center gap-1 whitespace-nowrap">
+                      <span className="text-xs text-white/70 flex items-center gap-1 whitespace-nowrap">
                         <Calendar className="h-3 w-3" />
                         {formatThreatDate(update.publishedAt, "short")}
                       </span>
@@ -161,7 +161,7 @@ export default function SecurityUpdates() {
                       {update.excerpt}
                     </CardDescription>
                     <div className="flex items-center justify-between pt-4 border-t border-white/10 gap-3">
-                      <span className="text-xs text-gray-500 truncate">
+                      <span className="text-xs text-white/70 truncate">
                         {update.sourceName}
                         {update.cve ? ` · ${update.cve}` : ""}
                       </span>
@@ -210,7 +210,7 @@ export default function SecurityUpdates() {
                             Compliance Update
                           </span>
                         </Badge>
-                        <span className="text-xs text-gray-500 flex items-center gap-1">
+                        <span className="text-xs text-white/70 flex items-center gap-1">
                           <Calendar className="h-3 w-3" />
                           {formatUpdateDisplayDate(update.date)}
                         </span>

--- a/client/src/pages/resources/Videos.tsx
+++ b/client/src/pages/resources/Videos.tsx
@@ -85,7 +85,7 @@ export default function Videos() {
         <div className="container mx-auto px-4 max-w-7xl">
           {/* Header */}
           <div className="text-center mb-12">
-            <Badge className="mb-4 bg-violet-500/20 text-violet-400 border-violet-500/30">
+            <Badge className="mb-4 bg-de-raised text-de-accent-ink border-de-hairline">
               Learning Topics
             </Badge>
             <h1 className="text-4xl md:text-5xl font-bold text-white mb-4">
@@ -97,10 +97,10 @@ export default function Videos() {
           </div>
 
           {/* Book a session */}
-          <Card className="mb-12 bg-gradient-to-r from-violet-600/20 to-purple-600/20 border-violet-500/30">
+          <Card className="mb-12 bg-de-raised border-de-hairline">
             <CardHeader>
               <CardTitle className="text-2xl text-white flex items-center gap-2">
-                <Calendar className="h-6 w-6 text-violet-400" />
+                <Calendar className="h-6 w-6 text-de-accent-ink" />
                 Request a Live Session
               </CardTitle>
               <CardDescription className="text-white/60">
@@ -115,7 +115,7 @@ export default function Videos() {
                       <h4 className="font-semibold text-white mb-2">{topic.title}</h4>
                       <p className="text-sm text-white/50 mb-4">{topic.summary}</p>
                       <Link href="/book">
-                        <Button className="w-full bg-violet-600 hover:bg-violet-500 text-white" data-testid={`button-register-${topic.id}`}>
+                        <Button className="w-full bg-de-accent hover:bg-de-accent text-white" data-testid={`button-register-${topic.id}`}>
                           Book a Session
                         </Button>
                       </Link>
@@ -134,7 +134,7 @@ export default function Videos() {
             </p>
             <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
               {topics.map((topic) => (
-                <Card key={topic.id} className="bg-white/[0.02] border-white/10 overflow-hidden hover:border-violet-500/50 transition-colors group" data-testid={`card-video-${topic.id}`}>
+                <Card key={topic.id} className="bg-white/[0.02] border-white/10 overflow-hidden hover:border-de-hairline transition-colors group" data-testid={`card-video-${topic.id}`}>
                   <div className="aspect-video relative overflow-hidden">
                     <img 
                       src={topic.thumbnail} 
@@ -146,18 +146,18 @@ export default function Videos() {
                       className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
                     />
                     <div className="absolute inset-0 bg-black/40 flex items-center justify-center pointer-events-none">
-                      <div className="w-16 h-16 bg-violet-600/90 rounded-full flex items-center justify-center group-hover:scale-110 transition-transform">
+                      <div className="w-16 h-16 bg-de-raised rounded-full flex items-center justify-center group-hover:scale-110 transition-transform">
                         <BookOpen className="h-8 w-8 text-white" />
                       </div>
                     </div>
                   </div>
                   <CardHeader>
                     <div className="flex items-center gap-2 mb-2">
-                      <Badge variant="secondary" className="bg-violet-500/20 text-violet-400">
+                      <Badge variant="secondary" className="bg-de-raised text-de-accent-ink">
                         {topic.type}
                       </Badge>
                     </div>
-                    <CardTitle className="text-lg text-white group-hover:text-violet-400 transition-colors">
+                    <CardTitle className="text-lg text-white group-hover:text-de-accent-ink transition-colors">
                       {topic.title}
                     </CardTitle>
                     <CardDescription className="text-white/60">
@@ -168,7 +168,7 @@ export default function Videos() {
                     <Link href="/resources/blog">
                       <Button
                         variant="outline"
-                        className="w-full border-violet-500/40 text-violet-300 hover:bg-violet-500/10 hover:text-violet-200"
+                        className="w-full border-de-hairline text-de-accent-ink hover:bg-de-raised hover:text-de-accent-ink"
                         data-testid={`button-related-reading-${topic.id}`}
                       >
                         <BookOpen className="mr-2 h-4 w-4" />
@@ -187,7 +187,7 @@ export default function Videos() {
               <h3 className="text-2xl font-bold text-white mb-2">Want a Custom Training Session?</h3>
               <p className="text-white/70 mb-6">We offer personalized security training for your team. Contact us to schedule.</p>
               <Button 
-                className="bg-violet-600 hover:bg-violet-500 text-white"
+                className="bg-de-accent hover:bg-de-accent text-white"
                 onClick={() => window.location.href = "/book"}
                 data-testid="button-schedule-training"
               >

--- a/client/src/pages/routes/servicePages.tsx
+++ b/client/src/pages/routes/servicePages.tsx
@@ -21,7 +21,7 @@ export const servicePageData = {
       "Compliance optional: add modules only when needed",
       "Monthly service summaries and quarterly business reviews available"
     ],
-    gradientColors: "from-violet-600 via-purple-600 to-fuchsia-600",
+    gradientColors: "from-[#050312] via-[#0a0a0a] to-[#050312]",
     recommendedTier: "office" as const,
   },
   'managed-it-support': {
@@ -44,7 +44,7 @@ export const servicePageData = {
       "Stack-native support: we built these tools",
       "Help + education: users learn safer behaviors"
     ],
-    gradientColors: "from-violet-600 via-purple-600 to-fuchsia-600",
+    gradientColors: "from-[#050312] via-[#0a0a0a] to-[#050312]",
     recommendedTier: "office" as const,
   },
   'managed-workplace': {
@@ -67,7 +67,7 @@ export const servicePageData = {
       "Zero-Trust identity posture at every login",
       "Automated offboarding: revoked access in minutes, not hours"
     ],
-    gradientColors: "from-violet-600 via-purple-600 to-fuchsia-600",
+    gradientColors: "from-[#050312] via-[#0a0a0a] to-[#050312]",
     recommendedTier: "office" as const
   },
   'cloud-backup': {
@@ -90,7 +90,7 @@ export const servicePageData = {
       "Compliance-grade encryption audit trail",
       "Peace of mind: tested backups, not just 'set and forget'"
     ],
-    gradientColors: "from-violet-600 via-purple-600 to-fuchsia-600",
+    gradientColors: "from-[#050312] via-[#0a0a0a] to-[#050312]",
     stat: { value: "54%", label: "used backups to restore encrypted data (lowest in 6 years)", source: "Sophos 2025" },
     recommendedTier: "office" as const,
   },
@@ -114,7 +114,7 @@ export const servicePageData = {
       "Reduced support tickets from malware/ransomware",
       "Lower breach risk from insider mistakes"
     ],
-    gradientColors: "from-violet-600 via-purple-600 to-fuchsia-600",
+    gradientColors: "from-[#050312] via-[#0a0a0a] to-[#050312]",
     stat: toDisplayStat(getCyberFact("dbir-human-element-2026")),
     recommendedTier: "business" as const,
   },
@@ -138,7 +138,7 @@ export const servicePageData = {
       "Strategic IT planning and technology roadmap alignment",
       "Your IT team + DE stack = higher maturity without hiring"
     ],
-    gradientColors: "from-violet-700 via-purple-700 to-fuchsia-700",
+    gradientColors: "from-[#050312] via-[#0a0a0a] to-[#050312]",
     recommendedTier: "business" as const
   },
   'threat-detection': {
@@ -161,7 +161,7 @@ export const servicePageData = {
       "Compliance-ready incident documentation",
       "24/7 detection + real response, not 'good luck with alerts'"
     ],
-    gradientColors: "from-violet-700 via-purple-700 to-fuchsia-700",
+    gradientColors: "from-[#050312] via-[#0a0a0a] to-[#050312]",
     stat: toDisplayStat(getCyberFact("dbir-smb-ransomware-victims-2026")),
     recommendedTier: "business" as const,
   },
@@ -185,7 +185,7 @@ export const servicePageData = {
       "Compliance evidence and audit readiness",
       "Full SOC maturity without hiring SOC analysts"
     ],
-    gradientColors: "from-violet-600 via-purple-600 to-fuchsia-600",
+    gradientColors: "from-[#050312] via-[#0a0a0a] to-[#050312]",
     recommendedTier: "business" as const,
   },
   'backup-disaster-recovery': {
@@ -209,7 +209,7 @@ export const servicePageData = {
       "Compliance-ready DR documentation",
       "Peace of mind: proven recovery capabilities"
     ],
-    gradientColors: "from-violet-600 via-purple-600 to-fuchsia-600",
+    gradientColors: "from-[#050312] via-[#0a0a0a] to-[#050312]",
     recommendedTier: "enterprise" as const
   },
   'vcio-strategy': {
@@ -232,7 +232,7 @@ export const servicePageData = {
       "Reduced surprise costs and projects",
       "IT becomes a strategic business partner, not a cost center"
     ],
-    gradientColors: "from-violet-600 via-purple-600 to-fuchsia-600",
+    gradientColors: "from-[#050312] via-[#0a0a0a] to-[#050312]",
     recommendedTier: "enterprise" as const,
   },
   'data-encryption': {
@@ -255,7 +255,7 @@ export const servicePageData = {
       "Default for healthcare, finance, and legal verticals",
       "Works alongside endpoint security, not instead of it"
     ],
-    gradientColors: "from-violet-600 via-purple-600 to-fuchsia-600",
+    gradientColors: "from-[#050312] via-[#0a0a0a] to-[#050312]",
     recommendedTier: "business" as const,
   },
   'compliance-reports': {
@@ -278,7 +278,7 @@ export const servicePageData = {
       "Regulatory confidence: proactive, not reactive",
       "Clear roadmap to full compliance certification"
     ],
-    gradientColors: "from-violet-600 via-purple-600 to-fuchsia-600",
+    gradientColors: "from-[#050312] via-[#0a0a0a] to-[#050312]",
     recommendedTier: "enterprise" as const,
   },
   'unified-security': {
@@ -301,7 +301,7 @@ export const servicePageData = {
       "Measurable risk reduction over time",
       "Compliance readiness score when modules active"
     ],
-    gradientColors: "from-violet-600 via-purple-600 to-fuchsia-600",
+    gradientColors: "from-[#050312] via-[#0a0a0a] to-[#050312]",
     recommendedTier: "enterprise" as const,
   }
 };
@@ -323,7 +323,7 @@ export const industryPageData = {
       "Backup and recovery",
       "Cybersecurity insurance support"
     ],
-    gradientColors: "from-violet-600 via-purple-600 to-fuchsia-600"
+    gradientColors: "from-[#050312] via-[#0a0a0a] to-[#050312]"
   },
   'real-estate': {
     title: "IT Solutions for Real Estate",
@@ -341,7 +341,7 @@ export const industryPageData = {
       "RESPA compliance support",
       "Transaction monitoring"
     ],
-    gradientColors: "from-violet-600 via-purple-600 to-fuchsia-600"
+    gradientColors: "from-[#050312] via-[#0a0a0a] to-[#050312]"
   },
   'nonprofits': {
     title: "IT Solutions for Nonprofits",
@@ -359,7 +359,7 @@ export const industryPageData = {
       "Fundraising platform support",
       "Budget-friendly solutions"
     ],
-    gradientColors: "from-violet-600 via-purple-600 to-fuchsia-600"
+    gradientColors: "from-[#050312] via-[#0a0a0a] to-[#050312]"
   },
   'professional-services': {
     title: "IT Solutions for Professional Services",
@@ -377,7 +377,7 @@ export const industryPageData = {
       "Document version control",
       "Compliance support for industry regulations"
     ],
-    gradientColors: "from-violet-600 via-purple-600 to-fuchsia-600"
+    gradientColors: "from-[#050312] via-[#0a0a0a] to-[#050312]"
   }
 };
 
@@ -398,7 +398,7 @@ export const resourcePageData = {
       "Compliance updates",
       "Technology trends"
     ],
-    gradientColors: "from-violet-700 via-purple-700 to-fuchsia-700"
+    gradientColors: "from-[#050312] via-[#0a0a0a] to-[#050312]"
   },
   'videos': {
     title: "Videos & Webinars",
@@ -416,7 +416,7 @@ export const resourcePageData = {
       "Expert presenters",
       "Quarterly live webinars"
     ],
-    gradientColors: "from-violet-600 via-purple-600 to-fuchsia-600"
+    gradientColors: "from-[#050312] via-[#0a0a0a] to-[#050312]"
   },
   'security-checklist': {
     title: "Security Checklist",
@@ -434,7 +434,7 @@ export const resourcePageData = {
       "Benchmark against peers",
       "Detailed report"
     ],
-    gradientColors: "from-violet-600 via-purple-600 to-fuchsia-600"
+    gradientColors: "from-[#050312] via-[#0a0a0a] to-[#050312]"
   },
   'datasheets': {
     title: "Datasheets & Documentation",
@@ -452,7 +452,7 @@ export const resourcePageData = {
       "Compliance evidence",
       "Integration guides"
     ],
-    gradientColors: "from-violet-700 via-purple-700 to-fuchsia-700"
+    gradientColors: "from-[#050312] via-[#0a0a0a] to-[#050312]"
   }
 };
 
@@ -473,7 +473,7 @@ export const supportPageData = {
       "Multi-monitor support",
       "File transfer capability"
     ],
-    gradientColors: "from-violet-600 via-purple-600 to-fuchsia-600"
+    gradientColors: "from-[#050312] via-[#0a0a0a] to-[#050312]"
   },
   'pay-invoice': {
     title: "Pay Invoice",
@@ -491,7 +491,7 @@ export const supportPageData = {
       "Payment history",
       "Secure portal access"
     ],
-    gradientColors: "from-violet-600 via-purple-600 to-fuchsia-600"
+    gradientColors: "from-[#050312] via-[#0a0a0a] to-[#050312]"
   },
   'knowledge-base': {
     title: "Knowledge Base",
@@ -509,7 +509,7 @@ export const supportPageData = {
       "Video tutorials",
       "Printable guides"
     ],
-    gradientColors: "from-violet-600 via-purple-600 to-fuchsia-600"
+    gradientColors: "from-[#050312] via-[#0a0a0a] to-[#050312]"
   },
   'system-status': {
     title: "System Status",
@@ -527,6 +527,6 @@ export const supportPageData = {
       "Uptime reports",
       "SLA tracking"
     ],
-    gradientColors: "from-violet-600 via-purple-600 to-fuchsia-600"
+    gradientColors: "from-[#050312] via-[#0a0a0a] to-[#050312]"
   }
 };

--- a/client/src/pages/sections/BlogSection.tsx
+++ b/client/src/pages/sections/BlogSection.tsx
@@ -80,7 +80,7 @@ export const BlogSection = (): JSX.Element => {
 
         <div className="flex flex-col gap-8 lg:gap-14 mb-10 lg:mb-[72px]">
           <section className="flex flex-col gap-4 lg:gap-[23px]">
-            <h2 className="font-bold text-violet-400 text-xs sm:text-[15px] tracking-[1.50px] leading-[25.5px] text-center lg:text-left">
+            <h2 className="font-bold text-de-accent-ink text-xs sm:text-[15px] tracking-[1.50px] leading-[25.5px] text-center lg:text-left">
               SERVING GREATER PHOENIX
             </h2>
 

--- a/client/src/pages/sections/DigeratiAIAssistanceSection.tsx
+++ b/client/src/pages/sections/DigeratiAIAssistanceSection.tsx
@@ -55,7 +55,7 @@ export const DigeratiAIAssistanceSection = (): JSX.Element => {
             viewport={{ once: true }}
             transition={{ duration: 0.5, delay: 0.1 }}
           >
-            <div className="inline-flex items-center gap-2 text-base font-medium text-[#D3126A] mb-4">
+            <div className="inline-flex items-center gap-2 text-base font-medium text-de-magenta-ink mb-4">
               <Radio className="h-4 w-4" aria-hidden />
               Detection & response
             </div>

--- a/client/src/pages/sections/DigeratiCalculatorsSection.tsx
+++ b/client/src/pages/sections/DigeratiCalculatorsSection.tsx
@@ -63,7 +63,7 @@ export const DigeratiCalculatorsSection = (props: CalculatorProps): JSX.Element 
             <span className="text-sm md:text-base font-medium text-[#FF477F]">Assessment</span>
           </div>
           <h2 className="text-3xl sm:text-4xl md:text-5xl lg:text-5xl font-bold text-white mb-3 md:mb-4 px-2">
-            Calculate Your <span className="bg-gradient-to-r from-[#FF477F] via-[#D3126A] to-fuchsia-400 bg-clip-text text-transparent">Investment</span>
+            Calculate Your <span className="text-de-magenta-ink">Investment</span>
           </h2>
           <p className="text-lg md:text-xl text-white/60 max-w-2xl mx-auto px-4">
             Start with the numbers — downtime risk and monthly protection — then schedule a full cyber risk assessment.

--- a/client/src/pages/sections/DigeratiCalculatorsSection.tsx
+++ b/client/src/pages/sections/DigeratiCalculatorsSection.tsx
@@ -88,7 +88,7 @@ export const DigeratiCalculatorsSection = (props: CalculatorProps): JSX.Element 
               >
                 <div className="flex items-center gap-4">
                   <div className="w-10 h-10 md:w-12 md:h-12 rounded-xl border border-de-hairline bg-de-bg flex items-center justify-center">
-                    <TrendingDown className="w-5 h-5 md:w-6 md:h-6 text-violet-400" />
+                    <TrendingDown className="w-5 h-5 md:w-6 md:h-6 text-de-accent-ink" />
                   </div>
                   <div className="text-left">
                     <h3 className="text-lg md:text-xl font-bold text-white">Downtime Cost Calculator</h3>
@@ -97,7 +97,7 @@ export const DigeratiCalculatorsSection = (props: CalculatorProps): JSX.Element 
                 </div>
                 <div className="flex items-center gap-3">
                   {!downtimeExpanded && (
-                    <span className="hidden sm:block text-sm text-violet-400 font-medium">
+                    <span className="hidden sm:block text-sm text-de-accent-ink font-medium">
                       Current estimate: ${downtimeCost.toLocaleString()}/incident
                     </span>
                   )}
@@ -124,7 +124,7 @@ export const DigeratiCalculatorsSection = (props: CalculatorProps): JSX.Element 
                           {/* Industry Select */}
                           <div className="space-y-3">
                             <Label htmlFor="industry" className="text-sm font-semibold text-white/70 uppercase tracking-wider flex items-center gap-2">
-                              <Building2 className="w-4 h-4 text-violet-400" />
+                              <Building2 className="w-4 h-4 text-de-accent-ink" />
                               Industry
                             </Label>
                             <Select value={industry} onValueChange={setIndustry}>
@@ -153,7 +153,7 @@ export const DigeratiCalculatorsSection = (props: CalculatorProps): JSX.Element 
                           <div className="space-y-3">
                             <Label htmlFor="employees-affected" className="text-sm font-semibold text-white/70 uppercase tracking-wider flex items-center justify-between">
                               <span>Employees Affected</span>
-                              <span className="text-lg font-bold text-violet-400">{employees}</span>
+                              <span className="text-lg font-bold text-de-accent-ink">{employees}</span>
                             </Label>
                             <div className="pt-2">
                               <PremiumSlider 
@@ -172,7 +172,7 @@ export const DigeratiCalculatorsSection = (props: CalculatorProps): JSX.Element 
                           <div className="space-y-3">
                             <Label htmlFor="hourly-wage" className="text-sm font-semibold text-white/70 uppercase tracking-wider flex items-center justify-between">
                               <span>Avg Hourly Wage</span>
-                              <span className="text-lg font-bold text-violet-400">${hourlyWage}</span>
+                              <span className="text-lg font-bold text-de-accent-ink">${hourlyWage}</span>
                             </Label>
                             <div className="pt-2">
                               <PremiumSlider 
@@ -191,7 +191,7 @@ export const DigeratiCalculatorsSection = (props: CalculatorProps): JSX.Element 
                           <div className="space-y-3">
                             <Label htmlFor="downtime-hours" className="text-sm font-semibold text-white/70 uppercase tracking-wider flex items-center justify-between">
                               <span>Expected Downtime</span>
-                              <span className="text-lg font-bold text-violet-400">{downtime}h</span>
+                              <span className="text-lg font-bold text-de-accent-ink">{downtime}h</span>
                             </Label>
                             <div className="pt-2">
                               <PremiumSlider 
@@ -266,7 +266,7 @@ export const DigeratiCalculatorsSection = (props: CalculatorProps): JSX.Element 
               >
                 <div className="flex items-center gap-4">
                   <div className="w-10 h-10 md:w-12 md:h-12 rounded-xl border border-de-hairline bg-de-bg flex items-center justify-center">
-                    <DollarSign className="w-5 h-5 md:w-6 md:h-6 text-violet-400" />
+                    <DollarSign className="w-5 h-5 md:w-6 md:h-6 text-de-accent-ink" />
                   </div>
                   <div className="text-left">
                     <h3 className="text-lg md:text-xl font-bold text-white">Monthly Investment Estimator</h3>
@@ -278,7 +278,7 @@ export const DigeratiCalculatorsSection = (props: CalculatorProps): JSX.Element 
                     <motion.span 
                       initial={{ opacity: 0, x: 10 }}
                       animate={{ opacity: 1, x: 0 }}
-                      className="hidden sm:block text-sm text-violet-400 font-medium"
+                      className="hidden sm:block text-sm text-de-accent-ink font-medium"
                     >
                       Current estimate: ${serviceCost.toLocaleString()}/mo
                     </motion.span>
@@ -306,7 +306,7 @@ export const DigeratiCalculatorsSection = (props: CalculatorProps): JSX.Element 
                           <div className="space-y-3">
                             <Label htmlFor="service-employees" className="text-sm font-semibold text-white/70 uppercase tracking-wider flex items-center justify-between">
                               <span>Number of Employees</span>
-                              <span className="text-lg font-bold text-violet-400">{serviceEmployees}</span>
+                              <span className="text-lg font-bold text-de-accent-ink">{serviceEmployees}</span>
                             </Label>
                             <div className="pt-2">
                               <PremiumSlider 

--- a/client/src/pages/sections/DigeratiCalculatorsSection.tsx
+++ b/client/src/pages/sections/DigeratiCalculatorsSection.tsx
@@ -87,7 +87,7 @@ export const DigeratiCalculatorsSection = (props: CalculatorProps): JSX.Element 
                 data-testid="calculator-downtime-trigger"
               >
                 <div className="flex items-center gap-4">
-                  <div className="w-10 h-10 md:w-12 md:h-12 rounded-xl bg-gradient-to-br from-violet-500/20 to-purple-500/20 flex items-center justify-center">
+                  <div className="w-10 h-10 md:w-12 md:h-12 rounded-xl border border-de-hairline bg-de-bg flex items-center justify-center">
                     <TrendingDown className="w-5 h-5 md:w-6 md:h-6 text-violet-400" />
                   </div>
                   <div className="text-left">
@@ -218,7 +218,7 @@ export const DigeratiCalculatorsSection = (props: CalculatorProps): JSX.Element 
                         <div className="grid sm:grid-cols-2 gap-6">
                           <div className="text-center sm:text-left">
                             <p className="text-xs font-bold text-white/50 uppercase tracking-widest mb-2">Per-Incident Cost</p>
-                            <p className="text-3xl md:text-4xl font-bold bg-gradient-to-r from-violet-400 via-purple-400 to-fuchsia-400 bg-clip-text text-transparent">
+                            <p className="text-3xl md:text-4xl font-bold text-de-magenta-ink">
                               ${downtimeCost.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 })}
                             </p>
                           </div>
@@ -265,7 +265,7 @@ export const DigeratiCalculatorsSection = (props: CalculatorProps): JSX.Element 
                 data-testid="calculator-pricing-trigger"
               >
                 <div className="flex items-center gap-4">
-                  <div className="w-10 h-10 md:w-12 md:h-12 rounded-xl bg-gradient-to-br from-violet-500/20 to-purple-500/20 flex items-center justify-center">
+                  <div className="w-10 h-10 md:w-12 md:h-12 rounded-xl border border-de-hairline bg-de-bg flex items-center justify-center">
                     <DollarSign className="w-5 h-5 md:w-6 md:h-6 text-violet-400" />
                   </div>
                   <div className="text-left">
@@ -354,7 +354,7 @@ export const DigeratiCalculatorsSection = (props: CalculatorProps): JSX.Element 
                       >
                         <div className="text-center">
                           <p className="text-xs font-bold text-white/50 uppercase tracking-widest mb-2">Estimated Monthly Cost</p>
-                          <p className="text-4xl md:text-5xl font-bold bg-gradient-to-r from-violet-400 via-purple-400 to-fuchsia-400 bg-clip-text text-transparent">
+                          <p className="text-4xl md:text-5xl font-bold text-de-magenta-ink">
                             ${serviceCost.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 })}
                           </p>
                           <p className="text-base text-white/50 mt-2">
@@ -371,7 +371,7 @@ export const DigeratiCalculatorsSection = (props: CalculatorProps): JSX.Element 
                           <a href="/book">
                             <Button 
                               size="lg"
-                              className="h-12 px-6 bg-gradient-to-r from-violet-500 to-purple-500 text-white hover:from-violet-400 hover:to-purple-400 font-semibold rounded-xl shadow-lg shadow-violet-500/25 transition-all duration-300 hover:scale-[1.02] hover:shadow-violet-500/40" 
+                              className="h-12 px-6 bg-de-magenta text-white hover:bg-[#e01874] font-semibold rounded-xl transition-colors" 
                               data-testid="button-schedule-consultation"
                             >
                               Schedule Consultation

--- a/client/src/pages/sections/DigeratiContactSection.tsx
+++ b/client/src/pages/sections/DigeratiContactSection.tsx
@@ -182,7 +182,7 @@ export const DigeratiContactSection = ({
               </a>
               <a
                 href={PRIMARY_PHONE.telHref}
-                className="inline-flex min-h-11 items-center justify-center rounded-lg border border-white/20 px-6 py-2.5 text-base font-semibold text-white transition-colors hover:border-white/40 hover:bg-white/[0.04] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-300/60 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--de-bg)]"
+                className="inline-flex min-h-11 items-center justify-center rounded-lg border border-white/20 px-6 py-2.5 text-base font-semibold text-white transition-colors hover:border-white/40 hover:bg-white/[0.04] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-de-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--de-bg)]"
                 data-testid="contact-cta-call"
               >
                 Call {PRIMARY_PHONE.display}
@@ -196,7 +196,7 @@ export const DigeratiContactSection = ({
                   href={item.href}
                   {...(item.external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
                   data-testid={item.testId}
-                  className={`group flex items-start gap-4 border-b border-de-hairline py-4 transition-colors hover:bg-white/[0.02] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-300/60 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--de-bg)] ${
+                  className={`group flex items-start gap-4 border-b border-de-hairline py-4 transition-colors hover:bg-white/[0.02] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-de-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--de-bg)] ${
                     item.testId === "contact-address" ? "md:col-span-2" : ""
                   } ${item.testId === "contact-phone" ? "md:border-l md:pl-4" : ""}`}
                 >
@@ -240,7 +240,7 @@ export const DigeratiContactSection = ({
                   rel="noopener noreferrer"
                   data-testid={social.testId}
                   aria-label={social.name}
-                  className="inline-flex h-11 w-11 items-center justify-center rounded-lg border border-de-hairline bg-de-raised text-white/60 transition-colors hover:border-white/25 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-300/60 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--de-bg)]"
+                  className="inline-flex h-11 w-11 items-center justify-center rounded-lg border border-de-hairline bg-de-raised text-white/60 transition-colors hover:border-white/25 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-de-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--de-bg)]"
                 >
                   <social.icon className="h-4 w-4" aria-hidden="true" />
                 </a>

--- a/client/src/pages/sections/DigeratiContactSection.tsx
+++ b/client/src/pages/sections/DigeratiContactSection.tsx
@@ -174,7 +174,7 @@ export const DigeratiContactSection = ({
             <div className="mb-10 flex flex-col items-stretch gap-3 sm:flex-row sm:items-center">
               <a
                 href="/book"
-                className="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg border border-pink-300/30 bg-gradient-to-r from-fuchsia-600 via-pink-600 to-rose-500 px-6 py-2.5 text-base font-semibold text-white shadow-lg shadow-pink-500/25 transition-all duration-200 hover:from-fuchsia-500 hover:via-pink-500 hover:to-rose-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--de-bg)]"
+                className="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg bg-[#D3126A] px-6 py-2.5 text-base font-semibold text-white transition-colors duration-200 hover:bg-[#e01874] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--de-bg)]"
                 data-testid="contact-cta-assessment"
               >
                 {CTA.primary}
@@ -403,7 +403,7 @@ export const DigeratiContactSection = ({
                   />
 
                   <Button
-                    className="h-11 w-full text-base font-semibold bg-[#1A1228] text-white hover:bg-[#2a1a3a] focus-visible:ring-2 focus-visible:ring-[#D3126A] focus-visible:ring-offset-2"
+                    className="h-11 w-full text-base font-semibold bg-[#1A1228] text-white transition-colors hover:bg-[#D3126A] focus-visible:ring-2 focus-visible:ring-[#D3126A] focus-visible:ring-offset-2"
                     data-testid="button-send-message"
                     type="submit"
                     disabled={isSubmitting}

--- a/client/src/pages/sections/DigeratiContactSection.tsx
+++ b/client/src/pages/sections/DigeratiContactSection.tsx
@@ -73,7 +73,7 @@ const contactSocials = [
 ] as const;
 
 const fieldClass =
-  "h-11 bg-white border-[var(--de-paper-hairline)] text-[#1A1228] placeholder:text-black/35 focus-visible:ring-2 focus-visible:ring-[#D3126A]/40 focus-visible:border-[#D3126A]";
+  "h-11 bg-white border-[var(--de-paper-hairline)] text-[#1A1228] placeholder:text-black/55 focus-visible:ring-2 focus-visible:ring-[#D3126A]/40 focus-visible:border-[#D3126A]";
 
 export const DigeratiContactSection = ({
   headingAs = "h2",
@@ -362,7 +362,7 @@ export const DigeratiContactSection = ({
                         >
                           <FormControl>
                             <SelectTrigger
-                              className="h-11 border-[var(--de-paper-hairline)] bg-white text-base text-[#1A1228] focus:ring-2 focus:ring-[#D3126A]/40 [&>span]:text-black/35"
+                              className="h-11 border-[var(--de-paper-hairline)] bg-white text-base text-[#1A1228] focus:ring-2 focus:ring-[#D3126A]/40 data-[placeholder]:text-black/55"
                               data-testid="select-contact-service"
                             >
                               <SelectValue placeholder="Select a service" />
@@ -392,7 +392,7 @@ export const DigeratiContactSection = ({
                             placeholder="Tell us about your security needs..."
                             rows={4}
                             data-testid="textarea-contact-message"
-                            className="resize-none border-[var(--de-paper-hairline)] bg-white text-[#1A1228] placeholder:text-black/35 focus-visible:border-[#D3126A] focus-visible:ring-2 focus-visible:ring-[#D3126A]/40"
+                            className="resize-none border-[var(--de-paper-hairline)] bg-white text-[#1A1228] placeholder:text-black/55 focus-visible:border-[#D3126A] focus-visible:ring-2 focus-visible:ring-[#D3126A]/40"
                             disabled={isSubmitting}
                             {...field}
                           />

--- a/client/src/pages/sections/DigeratiEnhancedFooterSection.tsx
+++ b/client/src/pages/sections/DigeratiEnhancedFooterSection.tsx
@@ -120,7 +120,7 @@ export const DigeratiEnhancedFooterSection = (): JSX.Element => {
             <p className="mt-1 text-base text-white/55">
               Arizona MSP · Cybersecurity &amp; Managed IT
             </p>
-            <p className="mt-1 text-base text-white/45">
+            <p className="mt-1 text-base text-white/55">
               <a
                 href="/locations/chandler-az"
                 className="transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--de-bg)]"

--- a/client/src/pages/sections/DigeratiFooterSection.tsx
+++ b/client/src/pages/sections/DigeratiFooterSection.tsx
@@ -56,7 +56,7 @@ export const DigeratiFooterSection = (): JSX.Element => {
             </p>
             <div className="mt-4 md:mt-0 flex items-center space-x-4">
               <span className="text-gray-400">24/7 Emergency:</span>
-              <a href="tel:+13254809870" className="text-violet-400 font-semibold hover:text-violet-300">
+              <a href="tel:+13254809870" className="text-de-accent-ink font-semibold hover:text-violet-300">
                 325-480-9870
               </a>
             </div>

--- a/client/src/pages/sections/DigeratiHowWeProtectSection.tsx
+++ b/client/src/pages/sections/DigeratiHowWeProtectSection.tsx
@@ -58,7 +58,7 @@ export const DigeratiHowWeProtectSection = (): JSX.Element => {
             viewport={{ once: true, margin: "-50px" }}
             transition={{ duration: 0.35 }}
           >
-            <p className="mb-3 text-base font-semibold uppercase tracking-[0.2em] text-[#D3126A]">
+            <p className="mb-3 text-base font-semibold uppercase tracking-[0.2em] text-de-magenta">
               What we protect
             </p>
             <h2 className="mb-4 font-heading text-3xl font-semibold tracking-[-0.02em] text-gray-900 md:text-4xl">
@@ -100,7 +100,7 @@ export const DigeratiHowWeProtectSection = (): JSX.Element => {
         <div className="container relative z-10 mx-auto px-3 sm:px-4 lg:px-6">
           <div className="mb-10 flex flex-wrap items-end justify-between gap-4 md:mb-12">
             <div className="max-w-3xl">
-              <p className="mb-2 text-base font-semibold uppercase tracking-[0.2em] text-[#D3126A]">
+              <p className="mb-2 text-base font-semibold uppercase tracking-[0.2em] text-de-magenta-ink">
                 How protection works
               </p>
               <h3
@@ -127,7 +127,7 @@ export const DigeratiHowWeProtectSection = (): JSX.Element => {
                   data-testid={step.testId}
                   className={`lg:px-6 ${index > 0 ? "lg:border-l lg:border-[var(--de-hairline)]" : "lg:pl-0"}`}
                 >
-                  <p className="font-mono text-base font-semibold tracking-[0.18em] text-[#D3126A]">
+                  <p className="font-mono text-base font-semibold tracking-[0.18em] text-de-magenta-ink">
                     {String(step.number).padStart(2, "0")}
                   </p>
                   <span className="mt-3 mb-3 inline-flex h-11 w-11 items-center justify-center rounded-xl border border-[var(--de-hairline)] bg-[var(--de-bg)] text-[#D3126A]">

--- a/client/src/pages/sections/DigeratiHowWeProtectSection.tsx
+++ b/client/src/pages/sections/DigeratiHowWeProtectSection.tsx
@@ -94,13 +94,13 @@ export const DigeratiHowWeProtectSection = (): JSX.Element => {
 
       <section
         id="how-protection-works"
-        className="de-brand-energy-band relative overflow-hidden py-14 md:py-16 lg:py-20"
+        className="de-process-band relative overflow-hidden py-14 md:py-16 lg:py-20"
         aria-labelledby="how-protection-works-heading"
       >
         <div className="container relative z-10 mx-auto px-3 sm:px-4 lg:px-6">
           <div className="mb-10 flex flex-wrap items-end justify-between gap-4 md:mb-12">
             <div className="max-w-3xl">
-              <p className="mb-2 text-base font-semibold uppercase tracking-[0.2em] text-white/80">
+              <p className="mb-2 text-base font-semibold uppercase tracking-[0.2em] text-[#D3126A]">
                 How protection works
               </p>
               <h3
@@ -111,7 +111,7 @@ export const DigeratiHowWeProtectSection = (): JSX.Element => {
               </h3>
             </div>
             <Link href="/solutions/proactive-ecosystem">
-              <span className="inline-flex min-h-11 items-center gap-1.5 text-base font-semibold text-white underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-[#D3126A]">
+              <span className="inline-flex min-h-11 items-center gap-1.5 text-base font-semibold text-white underline-offset-4 hover:text-[#D3126A] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--de-surface)]">
                 Full methodology
                 <ArrowRight className="h-3.5 w-3.5" />
               </span>
@@ -125,18 +125,18 @@ export const DigeratiHowWeProtectSection = (): JSX.Element => {
                 <li
                   key={step.number}
                   data-testid={step.testId}
-                  className={`lg:px-6 ${index > 0 ? "lg:border-l lg:border-white/25" : "lg:pl-0"}`}
+                  className={`lg:px-6 ${index > 0 ? "lg:border-l lg:border-[var(--de-hairline)]" : "lg:pl-0"}`}
                 >
-                  <p className="font-mono text-base font-semibold tracking-[0.18em] text-white/75">
+                  <p className="font-mono text-base font-semibold tracking-[0.18em] text-[#D3126A]">
                     {String(step.number).padStart(2, "0")}
                   </p>
-                  <span className="mt-3 mb-3 inline-flex h-11 w-11 items-center justify-center rounded-xl border border-white/25 bg-[#0a0a0a]/40 text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.14)]">
+                  <span className="mt-3 mb-3 inline-flex h-11 w-11 items-center justify-center rounded-xl border border-[var(--de-hairline)] bg-[var(--de-bg)] text-[#D3126A]">
                     <IconComponent className="h-5 w-5" aria-hidden="true" />
                   </span>
                   <h4 className="mb-2 text-lg font-semibold text-white">
                     {step.title}
                   </h4>
-                  <p className="text-base leading-relaxed text-white/90 md:text-lg">
+                  <p className="text-base leading-relaxed text-white/75 md:text-lg">
                     {step.description}
                   </p>
                 </li>

--- a/client/src/pages/sections/DigeratiLeadFormSection.tsx
+++ b/client/src/pages/sections/DigeratiLeadFormSection.tsx
@@ -126,7 +126,7 @@ export const DigeratiLeadFormSection = (): JSX.Element => {
                           <Input 
                             placeholder="John Smith" 
                             data-testid="input-lead-full-name"
-                            className="h-12 border-[var(--de-paper-hairline)] bg-white text-base text-[#1A1228] placeholder:text-black/35 focus-visible:border-[#D3126A] focus-visible:ring-2 focus-visible:ring-[#D3126A]/40"
+                            className="h-12 border-[var(--de-paper-hairline)] bg-white text-base text-[#1A1228] placeholder:text-black/55 focus-visible:border-[#D3126A] focus-visible:ring-2 focus-visible:ring-[#D3126A]/40"
                             disabled={isSubmitting}
                             {...field} 
                           />
@@ -147,7 +147,7 @@ export const DigeratiLeadFormSection = (): JSX.Element => {
                             type="email" 
                             placeholder="john@company.com" 
                             data-testid="input-lead-email"
-                            className="h-12 border-[var(--de-paper-hairline)] bg-white text-base text-[#1A1228] placeholder:text-black/35 focus-visible:border-[#D3126A] focus-visible:ring-2 focus-visible:ring-[#D3126A]/40"
+                            className="h-12 border-[var(--de-paper-hairline)] bg-white text-base text-[#1A1228] placeholder:text-black/55 focus-visible:border-[#D3126A] focus-visible:ring-2 focus-visible:ring-[#D3126A]/40"
                             disabled={isSubmitting}
                             {...field} 
                           />
@@ -168,7 +168,7 @@ export const DigeratiLeadFormSection = (): JSX.Element => {
                             type="tel" 
                             placeholder="(555) 123-4567" 
                             data-testid="input-lead-phone"
-                            className="h-12 border-[var(--de-paper-hairline)] bg-white text-base text-[#1A1228] placeholder:text-black/35 focus-visible:border-[#D3126A] focus-visible:ring-2 focus-visible:ring-[#D3126A]/40"
+                            className="h-12 border-[var(--de-paper-hairline)] bg-white text-base text-[#1A1228] placeholder:text-black/55 focus-visible:border-[#D3126A] focus-visible:ring-2 focus-visible:ring-[#D3126A]/40"
                             disabled={isSubmitting}
                             {...field} 
                           />
@@ -188,7 +188,7 @@ export const DigeratiLeadFormSection = (): JSX.Element => {
                           <Input 
                             placeholder="Acme Corp" 
                             data-testid="input-lead-company"
-                            className="h-12 border-[var(--de-paper-hairline)] bg-white text-base text-[#1A1228] placeholder:text-black/35 focus-visible:border-[#D3126A] focus-visible:ring-2 focus-visible:ring-[#D3126A]/40"
+                            className="h-12 border-[var(--de-paper-hairline)] bg-white text-base text-[#1A1228] placeholder:text-black/55 focus-visible:border-[#D3126A] focus-visible:ring-2 focus-visible:ring-[#D3126A]/40"
                             disabled={isSubmitting}
                             {...field} 
                           />
@@ -232,7 +232,7 @@ export const DigeratiLeadFormSection = (): JSX.Element => {
           </motion.div>
 
           <motion.p 
-            className="mt-6 text-center text-base text-black/50"
+            className="mt-6 text-center text-base text-black/70"
             initial={prefersReducedMotion ? {} : { opacity: 0 }}
             whileInView={{ opacity: 1 }}
             viewport={{ once: true }}

--- a/client/src/pages/sections/DigeratiLeadFormSection.tsx
+++ b/client/src/pages/sections/DigeratiLeadFormSection.tsx
@@ -1,4 +1,4 @@
-import { motion } from "framer-motion";
+import { motion, useReducedMotion } from "framer-motion";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -25,6 +25,7 @@ type FormData = z.infer<typeof formSchema>;
 export const DigeratiLeadFormSection = (): JSX.Element => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { toast } = useToast();
+  const prefersReducedMotion = useReducedMotion();
 
   const form = useForm<FormData>({
     resolver: zodResolver(formSchema),
@@ -89,10 +90,10 @@ export const DigeratiLeadFormSection = (): JSX.Element => {
         <div className="max-w-4xl mx-auto">
           <motion.div 
             className="text-center mb-10"
-            initial={{ opacity: 0, y: 20 }}
+            initial={prefersReducedMotion ? {} : { opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.6 }}
+            transition={{ duration: prefersReducedMotion ? 0 : 0.6 }}
           >
             <p className="mb-3 text-base font-semibold uppercase tracking-[0.2em] text-[#D3126A]">
               Cyber Risk Assessment
@@ -107,10 +108,10 @@ export const DigeratiLeadFormSection = (): JSX.Element => {
 
           <motion.div
             className="de-paper-lift-lg rounded-2xl p-8 md:p-10"
-            initial={{ opacity: 0, y: 20 }}
+            initial={prefersReducedMotion ? {} : { opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.6, delay: 0.2 }}
+            transition={{ duration: prefersReducedMotion ? 0 : 0.6, delay: prefersReducedMotion ? 0 : 0.2 }}
           >
             <Form {...form}>
               <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-6">
@@ -232,10 +233,10 @@ export const DigeratiLeadFormSection = (): JSX.Element => {
 
           <motion.p 
             className="mt-6 text-center text-base text-black/50"
-            initial={{ opacity: 0 }}
+            initial={prefersReducedMotion ? {} : { opacity: 0 }}
             whileInView={{ opacity: 1 }}
             viewport={{ once: true }}
-            transition={{ delay: 0.4, duration: 0.5 }}
+            transition={{ delay: prefersReducedMotion ? 0 : 0.4, duration: prefersReducedMotion ? 0 : 0.5 }}
           >
             Prefer to call?{" "}
             <a 

--- a/client/src/pages/sections/DigeratiMeetExpertsSection.tsx
+++ b/client/src/pages/sections/DigeratiMeetExpertsSection.tsx
@@ -39,7 +39,7 @@ export const DigeratiMeetExpertsSection = (): JSX.Element => {
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
         >
-          <p className="mb-3 text-base font-semibold uppercase tracking-[0.2em] text-[#D3126A]">
+          <p className="mb-3 text-base font-semibold uppercase tracking-[0.2em] text-de-magenta-ink">
             Human trust
           </p>
           <h2 className="mb-3 font-heading text-3xl font-semibold tracking-[-0.02em] text-white sm:text-4xl md:text-5xl">

--- a/client/src/pages/sections/DigeratiNewsletterSection.tsx
+++ b/client/src/pages/sections/DigeratiNewsletterSection.tsx
@@ -4,8 +4,7 @@ import { Button } from "@/components/ui/button";
 import { useState } from "react";
 import { useToast } from "@/hooks/use-toast";
 import { motion, useReducedMotion } from "framer-motion";
-
-import avatarsImg from "@assets/Frame-2131330726_1767027918695.png";
+import { IconWell } from "@/components/visual/IconWell";
 
 const chipClass =
   "inline-flex min-h-11 items-center rounded-lg border border-[var(--de-hairline)] bg-transparent px-3.5 text-base text-white/80 transition-colors hover:border-[#D3126A] hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A]/70 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--de-surface)]";
@@ -128,15 +127,10 @@ export const DigeratiNewsletterSection = (): JSX.Element => {
           <div className="grid grid-cols-1 gap-6 lg:grid-cols-2 lg:gap-8">
             <div className="rounded-2xl border border-[var(--de-hairline)] bg-[var(--de-surface)] p-6 md:p-8">
               <div className="mb-5 flex items-center gap-3">
-                <img
-                  src={avatarsImg}
-                  alt="Our community members"
-                  loading="lazy"
-                  decoding="async"
-                  width={168}
-                  height={56}
-                  className="h-8 w-auto opacity-80"
-                />
+                <IconWell icon={Mail} size="sm" surface="dark" />
+                <span className="text-base font-medium uppercase tracking-[0.16em] text-white/60">
+                  Monthly · Arizona operators
+                </span>
               </div>
               <h2 className="font-heading text-xl font-semibold tracking-[-0.02em] text-white md:text-2xl">
                 Stay Updated

--- a/client/src/pages/sections/DigeratiServicesSection.tsx
+++ b/client/src/pages/sections/DigeratiServicesSection.tsx
@@ -123,7 +123,7 @@ export const DigeratiServicesSection = (): JSX.Element => {
           viewport={{ once: true, margin: "-80px" }}
           transition={{ duration: 0.45 }}
         >
-          <p className="mb-3 text-base font-semibold uppercase tracking-[0.2em] text-[#D3126A]">
+          <p className="mb-3 text-base font-semibold uppercase tracking-[0.2em] text-de-magenta-ink">
             How to work with us
           </p>
           <h2 className="mb-4 font-heading text-3xl font-semibold tracking-[-0.02em] text-white md:text-4xl">
@@ -164,7 +164,7 @@ export const DigeratiServicesSection = (): JSX.Element => {
                 <Link
                   href={path.link}
                   data-testid={`link-${path.testId}`}
-                  className="inline-flex min-h-11 items-center gap-2 text-base font-medium text-[#D3126A] hover:text-[#f0187a] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A]/70 focus-visible:ring-offset-2 focus-visible:ring-offset-de-raised"
+                  className="inline-flex min-h-11 items-center gap-2 text-base font-medium text-de-magenta-ink hover:text-[#f0187a] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A]/70 focus-visible:ring-offset-2 focus-visible:ring-offset-de-raised"
                 >
                   {path.cta}
                   <ArrowRight className="h-4 w-4" aria-hidden="true" />

--- a/client/src/pages/sections/DigeratiStatsSection.tsx
+++ b/client/src/pages/sections/DigeratiStatsSection.tsx
@@ -71,7 +71,7 @@ export const DigeratiStatsSection = (): JSX.Element => {
           transition={{ duration: 0.45 }}
           className="mb-10 max-w-3xl lg:mb-12"
         >
-          <p className="mb-3 text-base font-semibold uppercase tracking-[0.2em] text-[#D3126A]">
+          <p className="mb-3 text-base font-semibold uppercase tracking-[0.2em] text-de-magenta-ink">
             Why Digerati Experts
           </p>
           <h2 className="mb-4 font-heading text-3xl font-semibold tracking-[-0.02em] text-white md:text-4xl">
@@ -96,7 +96,7 @@ export const DigeratiStatsSection = (): JSX.Element => {
 
         <p className="mt-6">
           <Link href="/resources/cyber-facts">
-            <span className="inline-flex items-center gap-1 text-base font-semibold text-[#D3126A] hover:text-[#f0187a]">
+            <span className="inline-flex items-center gap-1 text-base font-semibold text-de-magenta-ink hover:text-[#f0187a]">
               Full sourced facts
               <ArrowRight className="h-3.5 w-3.5" />
             </span>

--- a/client/src/pages/sections/DigeratiTestimonialsSection.tsx
+++ b/client/src/pages/sections/DigeratiTestimonialsSection.tsx
@@ -147,7 +147,7 @@ export const DigeratiTestimonialsSection = (): JSX.Element => {
           viewport={{ once: true }}
           transition={{ duration: 0.4 }}
         >
-          <p className="mb-3 text-base font-medium uppercase tracking-wide text-[#D3126A]">
+          <p className="mb-3 text-base font-medium uppercase tracking-wide text-de-magenta-ink">
             Client proof
           </p>
           <h2 className="mb-4 text-3xl font-bold text-white sm:text-4xl md:text-5xl">
@@ -218,7 +218,7 @@ export const DigeratiTestimonialsSection = (): JSX.Element => {
                       href={link.href}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="inline-flex items-center gap-1 text-[#D3126A] hover:text-[#f0187a]"
+                      className="inline-flex items-center gap-1 text-de-magenta-ink hover:text-[#f0187a]"
                       data-testid={
                         link.id === "google" ? "link-read-us-on-google" : `link-read-us-on-${link.id}`
                       }
@@ -311,7 +311,7 @@ export const DigeratiTestimonialsSection = (): JSX.Element => {
 
         <div className="mt-8 flex flex-wrap items-center justify-center gap-x-5 gap-y-2 text-base">
           <Link href="/about/client-bill-of-rights">
-            <span className="text-[#D3126A] hover:text-[#f0187a]" data-testid="link-proof-bill-of-rights">
+            <span className="text-de-magenta-ink hover:text-[#f0187a]" data-testid="link-proof-bill-of-rights">
               Client Bill of Rights
             </span>
           </Link>
@@ -319,7 +319,7 @@ export const DigeratiTestimonialsSection = (): JSX.Element => {
             ·
           </span>
           <Link href="/about/guarantee">
-            <span className="text-[#D3126A] hover:text-[#f0187a]" data-testid="link-proof-guarantee">
+            <span className="text-de-magenta-ink hover:text-[#f0187a]" data-testid="link-proof-guarantee">
               Our Guarantee
             </span>
           </Link>
@@ -327,7 +327,7 @@ export const DigeratiTestimonialsSection = (): JSX.Element => {
             ·
           </span>
           <Link href="/trust/trust-center">
-            <span className="text-[#D3126A] hover:text-[#f0187a]" data-testid="link-proof-trust">
+            <span className="text-de-magenta-ink hover:text-[#f0187a]" data-testid="link-proof-trust">
               Trust Center
             </span>
           </Link>
@@ -335,7 +335,7 @@ export const DigeratiTestimonialsSection = (): JSX.Element => {
             ·
           </span>
           <Link href="/industries/healthcare">
-            <span className="text-[#D3126A] hover:text-[#f0187a]">Browse industries</span>
+            <span className="text-de-magenta-ink hover:text-[#f0187a]">Browse industries</span>
           </Link>
         </div>
         <p className="mt-4 text-center text-base text-white/55">

--- a/client/src/pages/sections/DigeratiThreatsInsightsSection.tsx
+++ b/client/src/pages/sections/DigeratiThreatsInsightsSection.tsx
@@ -50,7 +50,7 @@ function InsightCard({ insight, index }: { insight: ThreatItem; index: number })
             <span className="sm:hidden">{formatThreatDate(insight.publishedAt, "short")}</span>
           </span>
         </div>
-        <p className="mb-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-[#D3126A]">
+        <p className="mb-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-de-magenta-ink">
           {insight.kicker}
         </p>
         <CardTitle className="text-base sm:text-lg text-white line-clamp-2">
@@ -71,7 +71,7 @@ function InsightCard({ insight, index }: { insight: ThreatItem; index: number })
             href={insight.sourceUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="flex items-center gap-1 text-base font-medium text-[#D3126A] hover:text-[#f0187a] shrink-0"
+            className="flex items-center gap-1 text-base font-medium text-de-magenta-ink hover:text-[#f0187a] shrink-0"
           >
             Read source
             <ExternalLink className="h-3.5 w-3.5" />

--- a/client/src/pages/sections/DigeratiThreatsInsightsSection.tsx
+++ b/client/src/pages/sections/DigeratiThreatsInsightsSection.tsx
@@ -37,8 +37,8 @@ function InsightCard({ insight, index }: { insight: ThreatItem; index: number })
       <div className="h-1 bg-[#D3126A]" />
       <CardHeader className="pb-3 p-4 sm:p-6">
         <div className="flex items-center justify-between mb-3 gap-2">
-          <Badge className={`${categoryBadgeClass(insight)} border text-base`}>
-            <span className="flex items-center gap-1">
+          <Badge className={`${categoryBadgeClass(insight)} shrink-0 border text-base`}>
+            <span className="flex items-center gap-1 whitespace-nowrap">
               {categoryIcon[insight.category]}
               <span className="hidden sm:inline">{insight.category}</span>
               <span className="sm:hidden">{insight.category.split(" ")[0]}</span>

--- a/client/src/pages/sections/DigeratiTrustPhotoSection.tsx
+++ b/client/src/pages/sections/DigeratiTrustPhotoSection.tsx
@@ -43,7 +43,7 @@ export const DigeratiTrustPhotoSection = (): JSX.Element => {
 
             <h2 className="text-3xl sm:text-4xl lg:text-5xl xl:text-6xl font-bold text-gray-900 leading-tight mb-6 tracking-tight">
               Protection that fits{" "}
-              <span className="text-transparent bg-clip-text bg-gradient-to-r from-fuchsia-600 via-pink-600 to-violet-600">
+              <span className="text-[#D3126A]">
                 how you actually operate.
               </span>
             </h2>
@@ -69,7 +69,7 @@ export const DigeratiTrustPhotoSection = (): JSX.Element => {
 
             <a
               href="/book"
-              className="inline-flex items-center gap-2 bg-gradient-to-r from-fuchsia-600 via-pink-600 to-rose-500 hover:from-fuchsia-500 hover:via-pink-500 hover:to-rose-400 text-white font-semibold px-7 py-3.5 text-base rounded-lg shadow-md shadow-pink-500/25 transition-all duration-200"
+              className="inline-flex items-center gap-2 rounded-lg bg-[#D3126A] px-7 py-3.5 text-base font-semibold text-white transition-colors duration-200 hover:bg-[#e01874] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--de-paper)]"
               data-testid="link-trust-cta"
             >
               {CTA.primary}

--- a/client/src/pages/sections/DigeratiTrustPhotoSection.tsx
+++ b/client/src/pages/sections/DigeratiTrustPhotoSection.tsx
@@ -36,7 +36,7 @@ export const DigeratiTrustPhotoSection = (): JSX.Element => {
           >
             <div className="flex items-center gap-2 mb-5">
               <Shield className="w-4 h-4 text-pink-600" aria-hidden="true" />
-              <span className="text-base font-semibold text-pink-600 uppercase tracking-wider">
+              <span className="text-base font-semibold text-de-magenta uppercase tracking-wider">
                 Why Arizona businesses work with us
               </span>
             </div>

--- a/client/src/pages/sections/DigeratiWhatWeTackleSection.tsx
+++ b/client/src/pages/sections/DigeratiWhatWeTackleSection.tsx
@@ -63,7 +63,7 @@ export const DigeratiWhatWeTackleSection = (): JSX.Element => {
             viewport={{ once: true }}
             transition={{ duration: 0.45 }}
           >
-            <p className="mb-3 text-base font-semibold uppercase tracking-[0.2em] text-[#D3126A]">
+            <p className="mb-3 text-base font-semibold uppercase tracking-[0.2em] text-de-magenta-ink">
               Problems we solve
             </p>
             <h2 className="mb-4 font-heading text-3xl font-semibold tracking-[-0.02em] text-white md:text-4xl">
@@ -74,7 +74,7 @@ export const DigeratiWhatWeTackleSection = (): JSX.Element => {
               Cyber Facts; capability detail lives on Solutions.
             </p>
             <Link href="/resources/cyber-facts">
-              <span className="mt-4 inline-flex items-center gap-1 text-base font-semibold text-[#D3126A] hover:text-[#f0187a]">
+              <span className="mt-4 inline-flex items-center gap-1 text-base font-semibold text-de-magenta-ink hover:text-[#f0187a]">
                 Full threat context
                 <ArrowRight className="h-3.5 w-3.5" />
               </span>

--- a/client/src/pages/sections/DigeratiWhatWeTackleSection.tsx
+++ b/client/src/pages/sections/DigeratiWhatWeTackleSection.tsx
@@ -117,7 +117,7 @@ export const DigeratiWhatWeTackleSection = (): JSX.Element => {
             href="/book"
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex min-h-11 items-center rounded-lg border border-pink-300/30 bg-gradient-to-r from-fuchsia-600 via-pink-600 to-rose-500 px-6 py-2.5 text-base font-semibold text-white shadow-lg shadow-pink-500/25 transition-all duration-200 hover:from-fuchsia-500 hover:via-pink-500 hover:to-rose-400"
+            className="inline-flex min-h-11 items-center rounded-lg bg-[#D3126A] px-6 py-2.5 text-base font-semibold text-white transition-colors duration-200 hover:bg-[#e01874] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--de-bg)]"
             data-testid="tackle-cta"
           >
             Discuss Your Security Needs

--- a/client/src/pages/sections/HomepageProofSection.tsx
+++ b/client/src/pages/sections/HomepageProofSection.tsx
@@ -76,7 +76,7 @@ function ProofCta({
     "focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--de-surface)]",
     quiet
       ? "text-white/50 hover:text-white"
-      : "text-[#D3126A] hover:text-[#f0187a]",
+      : "text-de-magenta-ink hover:text-[#f0187a]",
     className,
   );
 
@@ -107,7 +107,7 @@ export function HomepageProofSection() {
     <section id="proof" className="de-dark-well de-chapter-hairline py-14 lg:py-20">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="mx-auto max-w-4xl text-center">
-          <p className="mb-3 text-base font-semibold uppercase tracking-[0.2em] text-[#D3126A]/80">
+          <p className="mb-3 text-base font-semibold uppercase tracking-[0.2em] text-de-magenta-ink">
             Trust & transparency
           </p>
           <h2 className="font-heading text-3xl font-semibold tracking-[-0.03em] text-white md:text-4xl lg:text-5xl">

--- a/client/src/pages/sections/LeadCaptureBand.tsx
+++ b/client/src/pages/sections/LeadCaptureBand.tsx
@@ -27,7 +27,7 @@ const assessmentFormSchema = z.object({
 type AssessmentFormData = z.infer<typeof assessmentFormSchema>;
 
 const benefits = [
-  { icon: Shield, text: "Full vulnerability assessment included", color: "text-violet-400" },
+  { icon: Shield, text: "Full vulnerability assessment included", color: "text-de-accent-ink" },
   { icon: CheckCircle, text: "Results delivered within 48 hours", color: "text-green-400" },
   { icon: Clock, text: "No commitment required", color: "text-purple-400" },
   { icon: Award, text: "Expert recommendations included", color: "text-yellow-400" },
@@ -112,7 +112,7 @@ export const LeadCaptureBand = (): JSX.Element => {
             className="space-y-6"
           >
             <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-violet-600/20 border border-violet-500/30">
-              <span className="text-violet-400 text-base font-medium">Limited Time Offer</span>
+              <span className="text-de-accent-ink text-base font-medium">Limited Time Offer</span>
             </div>
             
             <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-white leading-tight">

--- a/client/src/pages/sections/ModernHeroSection.tsx
+++ b/client/src/pages/sections/ModernHeroSection.tsx
@@ -68,7 +68,7 @@ export const ModernHeroSection = (): JSX.Element => {
         }}
       >
         <div
-          className="absolute top-[8%] right-[-4%] w-[640px] h-[640px] pointer-events-none"
+          className="de-hero-glow absolute top-[8%] right-[-4%] w-[640px] h-[640px] pointer-events-none"
           style={{
             background:
               "radial-gradient(circle at 70% 35%, rgba(236, 72, 153, 0.20) 0%, rgba(139, 92, 246, 0.14) 38%, transparent 64%)",
@@ -193,7 +193,7 @@ export const ModernHeroSection = (): JSX.Element => {
                 }}
               >
                 <motion.div
-                  className="absolute -inset-8 -z-10 rounded-[2.5rem] pointer-events-none"
+                  className="de-hero-glow absolute -inset-8 -z-10 rounded-[2.5rem] pointer-events-none"
                   aria-hidden="true"
                   style={{
                     background:
@@ -210,7 +210,7 @@ export const ModernHeroSection = (): JSX.Element => {
                       : { duration: 4.5, repeat: Infinity, ease: "easeInOut" }
                   }
                 />
-                <div className="relative rounded-2xl overflow-hidden border border-white/12 shadow-2xl shadow-violet-950/50">
+                <div className="relative rounded-2xl overflow-hidden border border-white/12 shadow-2xl shadow-black/50">
                   <DashboardMockup className="w-full" />
                 </div>
               </motion.div>

--- a/client/src/pages/sections/ModernHeroSection.tsx
+++ b/client/src/pages/sections/ModernHeroSection.tsx
@@ -100,7 +100,7 @@ export const ModernHeroSection = (): JSX.Element => {
               <h1 className="text-[clamp(1.85rem,7.4vw,3.55rem)] font-bold leading-[1.12] tracking-[-0.03em] text-white">
                 <span>Your Arizona business,</span>
                 <br />
-                <span className="text-transparent bg-clip-text bg-gradient-to-r from-fuchsia-300 via-pink-400 to-violet-300">
+                <span className="text-[#D3126A]">
                   protected 24/7.
                 </span>
               </h1>
@@ -136,7 +136,8 @@ export const ModernHeroSection = (): JSX.Element => {
                     size="lg"
                     data-testid="button-hero-schedule"
                     onClick={handleSchedule}
-                    className="h-12 w-full sm:w-auto px-6 sm:px-7 text-base font-semibold bg-gradient-to-r from-fuchsia-600 via-pink-600 to-rose-500 hover:from-fuchsia-500 hover:via-pink-500 hover:to-rose-400 text-white border border-pink-300/35 shadow-lg shadow-pink-500/40 hover:shadow-xl hover:shadow-pink-500/50 transition-all duration-300"
+                    variant="brand"
+                    className="h-12 w-full sm:w-auto px-6 sm:px-7 text-base font-semibold"
                   >
                     {CTA.heroPrimary}
                     <ArrowRight className="ml-2 w-5 h-5" aria-hidden="true" />

--- a/client/src/pages/services/UCaaS.tsx
+++ b/client/src/pages/services/UCaaS.tsx
@@ -35,22 +35,22 @@ export default function UCaaS() {
 
   const brokenItems = [
     {
-      icon: <GitBranch className="h-6 w-6 text-violet-400" />,
+      icon: <GitBranch className="h-6 w-6 text-de-accent-ink" />,
       title: "Routing",
       description: "Calls go to the wrong person or get dropped. Ring groups and auto-attendants aren't set up correctly, frustrating customers."
     },
     {
-      icon: <MapPin className="h-6 w-6 text-violet-400" />,
+      icon: <MapPin className="h-6 w-6 text-de-accent-ink" />,
       title: "E911",
       description: "Your address records are outdated or wrong. In an emergency, first responders could be sent to the wrong location."
     },
     {
-      icon: <Building2 className="h-6 w-6 text-violet-400" />,
+      icon: <Building2 className="h-6 w-6 text-de-accent-ink" />,
       title: "Too many vendors",
       description: "Phone from one vendor, meetings from another, fax from a third. Nobody owns the stack, so problems fall through the cracks."
     },
     {
-      icon: <Archive className="h-6 w-6 text-violet-400" />,
+      icon: <Archive className="h-6 w-6 text-de-accent-ink" />,
       title: "No retention",
       description: "Call recordings and voicemails vanish after 30 days. When you need them for compliance or disputes, they're gone."
     }
@@ -164,9 +164,9 @@ export default function UCaaS() {
     <PageTemplate
       title="UCaaS: Voice & Meetings"
       subtitle="We design, secure, and run your phone system and meeting stack so it actually supports the business"
-      gradientColors="from-violet-600 via-purple-600 to-fuchsia-600"
+      gradientColors="from-[#050312] via-[#0a0a0a] to-[#050312]"
       variant="dark"
-      icon={<Phone className="h-10 w-10 text-violet-300" />}
+      icon={<Phone className="h-10 w-10 text-de-accent-ink" />}
       breadcrumbs={[
         { label: "Solutions", href: "/solutions" },
         { label: "UCaaS" }
@@ -286,7 +286,7 @@ export default function UCaaS() {
           transition={{ duration: 0.5 }}
         >
           <div className="flex items-center gap-3 mb-8">
-            <div className="w-10 h-10 rounded-lg bg-gradient-to-br from-violet-600 to-fuchsia-500 flex items-center justify-center">
+            <div className="w-10 h-10 rounded-lg bg-de-raised flex items-center justify-center">
               <Headphones className="w-5 h-5 text-white" />
             </div>
             <h2 className="text-3xl font-bold text-white">What we actually do</h2>
@@ -302,15 +302,15 @@ export default function UCaaS() {
                 transition={{ delay: index * 0.1, duration: 0.5 }}
               >
                 <Card 
-                  className="group h-full bg-white/5 backdrop-blur-sm border border-white/10 hover:border-purple-500/30 hover:bg-white/[0.08] transition-all duration-300"
+                  className="group h-full bg-white/5 backdrop-blur-sm border border-white/10 hover:border-de-hairline hover:bg-white/[0.08] transition-all duration-300"
                   data-testid={`card-service-${card.title.toLowerCase().replace(/\s+/g, '-')}`}
                 >
-                  <div className="absolute inset-0 bg-gradient-to-br from-purple-500/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300 rounded-lg" />
+                  <div className="absolute inset-0 bg-de-raised to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300 rounded-lg" />
                   <CardHeader className="relative">
-                    <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-violet-600 to-fuchsia-500 flex items-center justify-center mb-4 group-hover:scale-110 transition-transform duration-300">
+                    <div className="w-12 h-12 rounded-xl bg-de-raised flex items-center justify-center mb-4 group-hover:scale-110 transition-transform duration-300">
                       {card.icon}
                     </div>
-                    <CardTitle className="text-xl font-semibold text-white group-hover:text-purple-300 transition-colors">
+                    <CardTitle className="text-xl font-semibold text-white group-hover:text-de-accent-ink transition-colors">
                       {card.title}
                     </CardTitle>
                   </CardHeader>
@@ -349,11 +349,11 @@ export default function UCaaS() {
                 className="relative"
               >
                 <Card 
-                  className="h-full bg-white/[0.03] border-white/10 backdrop-blur-sm hover:border-purple-500/40 transition-all"
+                  className="h-full bg-white/[0.03] border-white/10 backdrop-blur-sm hover:border-de-hairline transition-all"
                   data-testid={`card-pricing-${tier.name.toLowerCase().replace(/\s+/g, '-')}`}
                 >
                   <CardHeader>
-                    <div className="text-sm text-violet-400 uppercase tracking-wider mb-1">
+                    <div className="text-sm text-de-accent-ink uppercase tracking-wider mb-1">
                       {tier.type === 'one-time' ? 'One-Time' : 'Monthly'}
                     </div>
                     <CardTitle className="text-2xl text-white">{tier.name}</CardTitle>
@@ -394,7 +394,7 @@ export default function UCaaS() {
             <div className="grid grid-cols-3 bg-white/5">
               <div className="p-4 font-semibold text-gray-400">Feature</div>
               <div className="p-4 font-semibold text-gray-400 text-center border-l border-white/10">DIY</div>
-              <div className="p-4 font-semibold text-violet-400 text-center border-l border-white/10 bg-violet-500/5">
+              <div className="p-4 font-semibold text-de-accent-ink text-center border-l border-white/10 bg-de-raised">
                 Digerati Experts UCaaS
               </div>
             </div>
@@ -406,7 +406,7 @@ export default function UCaaS() {
               >
                 <div className="p-4 text-white font-medium">{item.feature}</div>
                 <div className="p-4 text-gray-400 text-center border-l border-white/10">{item.diy}</div>
-                <div className="p-4 text-emerald-400 text-center border-l border-white/10 bg-violet-500/5 font-medium">
+                <div className="p-4 text-emerald-400 text-center border-l border-white/10 bg-de-raised font-medium">
                   {item.digerati}
                 </div>
               </div>
@@ -422,7 +422,7 @@ export default function UCaaS() {
           transition={{ duration: 0.5 }}
           className="relative rounded-2xl overflow-hidden"
         >
-          <div className="absolute inset-0 bg-gradient-to-r from-violet-600 via-purple-600 to-fuchsia-600" />
+          <div className="absolute inset-0 bg-de-raised" />
           
           <div className="absolute inset-0 opacity-30">
             <svg className="absolute w-full h-full" xmlns="http://www.w3.org/2000/svg">
@@ -436,7 +436,7 @@ export default function UCaaS() {
           </div>
           
           <div className="absolute -top-20 -right-20 w-64 h-64 bg-fuchsia-400/20 rounded-full blur-3xl" />
-          <div className="absolute -bottom-20 -left-20 w-64 h-64 bg-purple-400/20 rounded-full blur-3xl" />
+          <div className="absolute -bottom-20 -left-20 w-64 h-64 bg-de-raised rounded-full blur-3xl" />
           
           <div className="relative p-8 md:p-12 text-center">
             <h2 className="text-3xl md:text-4xl font-bold mb-4 text-white">
@@ -450,7 +450,7 @@ export default function UCaaS() {
                 href="/book" 
                 target="_blank"
                 rel="noopener noreferrer"
-                className="group inline-flex items-center justify-center bg-white text-purple-700 hover:bg-gray-100 px-8 py-4 rounded-xl font-semibold transition-all shadow-lg hover:shadow-xl hover:scale-105"
+                className="group inline-flex items-center justify-center bg-white text-de-accent hover:bg-gray-100 px-8 py-4 rounded-xl font-semibold transition-all shadow-lg hover:shadow-xl hover:scale-105"
                 data-testid="button-schedule-call"
               >
                 <ArrowRight className="mr-2 h-5 w-5 group-hover:translate-x-1 transition-transform" />
@@ -458,7 +458,7 @@ export default function UCaaS() {
               </a>
               <a 
                 href="tel:+13254809870"
-                className="group inline-flex items-center justify-center border-2 border-white bg-white/10 backdrop-blur-sm text-white hover:bg-white hover:text-purple-700 px-8 py-4 rounded-xl font-semibold transition-all"
+                className="group inline-flex items-center justify-center border-2 border-white bg-white/10 backdrop-blur-sm text-white hover:bg-white hover:text-de-accent px-8 py-4 rounded-xl font-semibold transition-all"
                 data-testid="button-call-now"
               >
                 <Phone className="mr-2 h-5 w-5" />

--- a/client/src/pages/services/UCaaS.tsx
+++ b/client/src/pages/services/UCaaS.tsx
@@ -435,7 +435,7 @@ export default function UCaaS() {
             </svg>
           </div>
           
-          <div className="absolute -top-20 -right-20 w-64 h-64 bg-fuchsia-400/20 rounded-full blur-3xl" />
+          <div className="absolute -top-20 -right-20 w-64 h-64 bg-de-accent/20 rounded-full blur-3xl" />
           <div className="absolute -bottom-20 -left-20 w-64 h-64 bg-de-raised rounded-full blur-3xl" />
           
           <div className="relative p-8 md:p-12 text-center">

--- a/client/src/pages/solutions/BackupDisasterRecovery.tsx
+++ b/client/src/pages/solutions/BackupDisasterRecovery.tsx
@@ -203,9 +203,9 @@ function FAQItem({ question, answer, isOpen, onToggle, index }: {
       >
         <span className="font-semibold text-white pr-4">{question}</span>
         {isOpen ? (
-          <ChevronUp className="w-5 h-5 text-violet-400 flex-shrink-0" />
+          <ChevronUp className="w-5 h-5 text-de-accent-ink flex-shrink-0" />
         ) : (
-          <ChevronDown className="w-5 h-5 text-violet-400 flex-shrink-0" />
+          <ChevronDown className="w-5 h-5 text-de-accent-ink flex-shrink-0" />
         )}
       </button>
       {isOpen && (
@@ -243,7 +243,7 @@ function RPOPickerComponent() {
           <select
             value={criticalSystems}
             onChange={(e) => setCriticalSystems(e.target.value)}
-            className="w-full bg-white/5 border border-white/20 rounded-lg px-4 py-3 text-white focus:border-violet-500 focus:outline-none"
+            className="w-full bg-white/5 border border-white/20 rounded-lg px-4 py-3 text-white focus:border-de-hairline focus:outline-none"
             data-testid="picker-systems"
           >
             <option value="1-5">1–5 systems</option>
@@ -257,7 +257,7 @@ function RPOPickerComponent() {
           <select
             value={targetRTO}
             onChange={(e) => setTargetRTO(e.target.value)}
-            className="w-full bg-white/5 border border-white/20 rounded-lg px-4 py-3 text-white focus:border-violet-500 focus:outline-none"
+            className="w-full bg-white/5 border border-white/20 rounded-lg px-4 py-3 text-white focus:border-de-hairline focus:outline-none"
             data-testid="picker-rto"
           >
             <option value="72h">72 hours</option>
@@ -272,7 +272,7 @@ function RPOPickerComponent() {
           <select
             value={targetRPO}
             onChange={(e) => setTargetRPO(e.target.value)}
-            className="w-full bg-white/5 border border-white/20 rounded-lg px-4 py-3 text-white focus:border-violet-500 focus:outline-none"
+            className="w-full bg-white/5 border border-white/20 rounded-lg px-4 py-3 text-white focus:border-de-hairline focus:outline-none"
             data-testid="picker-rpo"
           >
             <option value="24h">24 hours</option>
@@ -288,7 +288,7 @@ function RPOPickerComponent() {
             onClick={() => setWarmStandby(!warmStandby)}
             className={`w-full px-4 py-3 rounded-lg border transition-colors ${
               warmStandby 
-                ? 'bg-violet-600 border-violet-500 text-white' 
+                ? 'bg-de-accent border-de-hairline text-white' 
                 : 'bg-white/5 border-white/20 text-white/60'
             }`}
             data-testid="picker-standby"
@@ -298,7 +298,7 @@ function RPOPickerComponent() {
         </div>
       </div>
 
-      <div className="bg-gradient-to-r from-violet-600/20 to-purple-600/20 border border-violet-500/30 rounded-xl p-6">
+      <div className="bg-de-raised border border-de-hairline rounded-xl p-6">
         <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
           <div>
             <p className="text-white/60 text-sm mb-1">Recommended tier based on your selections:</p>
@@ -307,7 +307,7 @@ function RPOPickerComponent() {
           </div>
           <Button
             asChild
-            className="bg-white text-violet-700 hover:bg-violet-50 font-semibold"
+            className="bg-white text-de-accent hover:bg-de-paper-raised font-semibold"
             data-testid="btn-picker-quote"
           >
             <a href="/book">
@@ -357,7 +357,7 @@ export default function BackupDisasterRecovery() {
       <div className="space-y-24">
         {/* Hero Section */}
         <motion.section {...fadeInUp} className="relative">
-          <div className="absolute inset-0 bg-gradient-to-br from-violet-600/20 via-purple-600/10 to-transparent rounded-3xl pointer-events-none" />
+          <div className="absolute inset-0 bg-de-raised to-transparent rounded-3xl pointer-events-none" />
           <div className="relative bg-white/[0.02] border border-white/10 rounded-3xl p-8 md:p-12">
             <div className="max-w-4xl">
               <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-amber-500/20 border border-amber-500/30 text-amber-300 text-sm font-medium mb-6">
@@ -367,7 +367,7 @@ export default function BackupDisasterRecovery() {
               
               <h1 className="text-4xl md:text-5xl font-bold text-white mb-6 leading-tight">
                 Recover in hours—
-                <span className="bg-gradient-to-r from-violet-300 via-purple-300 to-violet-300 bg-clip-text text-transparent">
+                <span className="text-de-accent-ink">
                   not days
                 </span>
               </h1>
@@ -379,7 +379,7 @@ export default function BackupDisasterRecovery() {
                 <Button
                   asChild
                   size="lg"
-                  className="bg-white text-violet-700 hover:bg-violet-50 font-semibold shadow-lg"
+                  className="bg-white text-de-accent hover:bg-de-paper-raised font-semibold shadow-lg"
                   data-testid="btn-hero-assessment"
                 >
                   <a href="/book">
@@ -402,15 +402,15 @@ export default function BackupDisasterRecovery() {
 
               <div className="flex flex-wrap gap-4">
                 <div className="flex items-center gap-2 text-sm text-white/60">
-                  <Target className="w-4 h-4 text-violet-400" />
+                  <Target className="w-4 h-4 text-de-accent-ink" />
                   <span>RPO/RTO in writing</span>
                 </div>
                 <div className="flex items-center gap-2 text-sm text-white/60">
-                  <RefreshCw className="w-4 h-4 text-violet-400" />
+                  <RefreshCw className="w-4 h-4 text-de-accent-ink" />
                   <span>Scheduled restore testing</span>
                 </div>
                 <div className="flex items-center gap-2 text-sm text-white/60">
-                  <ClipboardCheck className="w-4 h-4 text-violet-400" />
+                  <ClipboardCheck className="w-4 h-4 text-de-accent-ink" />
                   <span>DR runbooks + tabletop exercises</span>
                 </div>
               </div>
@@ -424,7 +424,7 @@ export default function BackupDisasterRecovery() {
             {bcdrData.protectedSystems.map((system, index) => (
               <div key={index} className="flex items-center gap-3 text-white/70">
                 <div className="w-12 h-12 rounded-xl bg-white/5 border border-white/10 flex items-center justify-center">
-                  <system.icon className="w-6 h-6 text-violet-400" />
+                  <system.icon className="w-6 h-6 text-de-accent-ink" />
                 </div>
                 <span className="font-medium">{system.name}</span>
               </div>
@@ -438,21 +438,21 @@ export default function BackupDisasterRecovery() {
             <h2 className="text-3xl font-bold text-white mb-6 text-center">BCDR in 30 Seconds</h2>
             <div className="grid md:grid-cols-3 gap-8 max-w-4xl mx-auto">
               <div className="text-center">
-                <div className="w-16 h-16 rounded-full bg-gradient-to-br from-violet-600 to-purple-600 flex items-center justify-center mx-auto mb-4">
+                <div className="w-16 h-16 rounded-full bg-de-raised flex items-center justify-center mx-auto mb-4">
                   <HardDrive className="w-8 h-8 text-white" />
                 </div>
                 <h3 className="font-semibold text-white mb-2">Backup</h3>
                 <p className="text-white/60 text-sm">Copies of your data, stored securely, with immutable protection against ransomware</p>
               </div>
               <div className="text-center">
-                <div className="w-16 h-16 rounded-full bg-gradient-to-br from-purple-600 to-violet-600 flex items-center justify-center mx-auto mb-4">
+                <div className="w-16 h-16 rounded-full bg-de-raised flex items-center justify-center mx-auto mb-4">
                   <Timer className="w-8 h-8 text-white" />
                 </div>
                 <h3 className="font-semibold text-white mb-2">Recovery Targets</h3>
                 <p className="text-white/60 text-sm">Agreed RPO (data loss limit) and RTO (downtime limit) documented in your agreement</p>
               </div>
               <div className="text-center">
-                <div className="w-16 h-16 rounded-full bg-gradient-to-br from-violet-600 to-fuchsia-600 flex items-center justify-center mx-auto mb-4">
+                <div className="w-16 h-16 rounded-full bg-de-raised flex items-center justify-center mx-auto mb-4">
                   <ClipboardCheck className="w-8 h-8 text-white" />
                 </div>
                 <h3 className="font-semibold text-white mb-2">Tested Recovery</h3>
@@ -488,7 +488,7 @@ export default function BackupDisasterRecovery() {
                 className="bg-white/[0.03] border border-white/10 rounded-xl p-6 hover:bg-white/[0.05] transition-colors"
               >
                 <div className="flex items-start gap-4 mb-4">
-                  <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-violet-600 to-purple-600 flex items-center justify-center flex-shrink-0">
+                  <div className="w-12 h-12 rounded-xl bg-de-raised flex items-center justify-center flex-shrink-0">
                     <feature.icon className="w-6 h-6 text-white" />
                   </div>
                   <div>
@@ -506,9 +506,9 @@ export default function BackupDisasterRecovery() {
                       <span 
                         key={tier} 
                         className={`text-xs px-2 py-0.5 rounded ${
-                          tier === 'enterprise' ? 'bg-violet-600/30 text-violet-300' :
-                          tier === 'business' ? 'bg-purple-600/30 text-purple-300' :
-                          'bg-violet-600/30 text-violet-300'
+                          tier === 'enterprise' ? 'bg-de-raised text-de-accent-ink' :
+                          tier === 'business' ? 'bg-de-raised text-de-accent-ink' :
+                          'bg-de-raised text-de-accent-ink'
                         }`}
                       >
                         {tier.charAt(0).toUpperCase()}
@@ -562,7 +562,7 @@ export default function BackupDisasterRecovery() {
               >
                 <div className="p-8">
                   <h3 className="text-2xl font-bold text-white">{pkg.name}</h3>
-                  <p className="text-violet-300 text-sm mb-2">{pkg.subtitle}</p>
+                  <p className="text-de-accent-ink text-sm mb-2">{pkg.subtitle}</p>
                   <p className="text-white/60 text-sm mb-6">{pkg.best_for}</p>
                   
                   <div className="flex gap-4 mb-6">
@@ -587,7 +587,7 @@ export default function BackupDisasterRecovery() {
 
                   <div className="bg-white/5 rounded-lg p-3 mb-6 text-center">
                     <p className="text-xs text-white/50">Test Cadence</p>
-                    <p className="text-sm font-semibold text-violet-300">{pkg.test_cadence}</p>
+                    <p className="text-sm font-semibold text-de-accent-ink">{pkg.test_cadence}</p>
                   </div>
 
                   <div className="mb-6 text-center">
@@ -599,8 +599,8 @@ export default function BackupDisasterRecovery() {
                     asChild
                     className={`w-full ${
                       pkg.featured 
-                        ? 'bg-white text-violet-700 hover:bg-violet-50' 
-                        : 'bg-violet-600 text-white hover:bg-violet-500'
+                        ? 'bg-white text-de-accent hover:bg-de-paper-raised' 
+                        : 'bg-de-accent text-white hover:bg-de-accent'
                     }`}
                     data-testid={`btn-package-${pkg.sku}`}
                   >
@@ -634,10 +634,10 @@ export default function BackupDisasterRecovery() {
                 className="relative"
               >
                 <div className="bg-white/[0.03] border border-white/10 rounded-xl p-8 text-center h-full">
-                  <div className="w-16 h-16 rounded-full bg-gradient-to-br from-violet-600 to-purple-600 flex items-center justify-center mx-auto mb-6">
+                  <div className="w-16 h-16 rounded-full bg-de-raised flex items-center justify-center mx-auto mb-6">
                     <span className="text-2xl font-bold text-white">{step.step}</span>
                   </div>
-                  <step.icon className="w-8 h-8 text-violet-400 mx-auto mb-4" />
+                  <step.icon className="w-8 h-8 text-de-accent-ink mx-auto mb-4" />
                   <h3 className="text-xl font-semibold text-white mb-3">{step.title}</h3>
                   <p className="text-white/60">{step.description}</p>
                 </div>
@@ -674,26 +674,26 @@ export default function BackupDisasterRecovery() {
 
         {/* What Happens Next */}
         <motion.section {...fadeInUp}>
-          <div className="bg-gradient-to-br from-violet-600/20 via-purple-600/10 to-transparent rounded-2xl border border-white/10 p-8 md:p-12">
+          <div className="bg-de-raised to-transparent rounded-2xl border border-white/10 p-8 md:p-12">
             <h2 className="text-2xl font-bold text-white mb-6 text-center">What Happens After You Book?</h2>
             <div className="grid md:grid-cols-3 gap-6 max-w-4xl mx-auto">
               <div className="text-center">
-                <div className="w-12 h-12 rounded-full bg-violet-600/20 border border-violet-500/30 flex items-center justify-center mx-auto mb-4">
-                  <Users className="w-6 h-6 text-violet-400" />
+                <div className="w-12 h-12 rounded-full bg-de-raised border border-de-hairline flex items-center justify-center mx-auto mb-4">
+                  <Users className="w-6 h-6 text-de-accent-ink" />
                 </div>
                 <h3 className="font-semibold text-white mb-2">BCDR Assessment</h3>
                 <p className="text-white/60 text-sm">We inventory your systems, current backup state, and recovery requirements</p>
               </div>
               <div className="text-center">
-                <div className="w-12 h-12 rounded-full bg-violet-600/20 border border-violet-500/30 flex items-center justify-center mx-auto mb-4">
-                  <Target className="w-6 h-6 text-violet-400" />
+                <div className="w-12 h-12 rounded-full bg-de-raised border border-de-hairline flex items-center justify-center mx-auto mb-4">
+                  <Target className="w-6 h-6 text-de-accent-ink" />
                 </div>
                 <h3 className="font-semibold text-white mb-2">RPO/RTO Agreement</h3>
                 <p className="text-white/60 text-sm">We define realistic recovery targets and document them in your agreement</p>
               </div>
               <div className="text-center">
-                <div className="w-12 h-12 rounded-full bg-violet-600/20 border border-violet-500/30 flex items-center justify-center mx-auto mb-4">
-                  <Settings className="w-6 h-6 text-violet-400" />
+                <div className="w-12 h-12 rounded-full bg-de-raised border border-de-hairline flex items-center justify-center mx-auto mb-4">
+                  <Settings className="w-6 h-6 text-de-accent-ink" />
                 </div>
                 <h3 className="font-semibold text-white mb-2">Implementation</h3>
                 <p className="text-white/60 text-sm">We deploy backup agents, configure policies, and schedule your first restore test</p>
@@ -705,7 +705,7 @@ export default function BackupDisasterRecovery() {
         {/* Final CTA */}
         <motion.section {...fadeInUp}>
           <div className="relative rounded-2xl overflow-hidden">
-            <div className="absolute inset-0 bg-gradient-to-r from-violet-600 via-purple-600 to-violet-600 opacity-90" />
+            <div className="absolute inset-0 bg-de-raised opacity-90" />
             <div className="absolute inset-0 bg-[url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNjAiIGhlaWdodD0iNjAiIHZpZXdCb3g9IjAgMCA2MCA2MCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48ZyBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiPjxnIGZpbGw9IiNmZmZmZmYiIGZpbGwtb3BhY2l0eT0iMC4wNSI+PGNpcmNsZSBjeD0iMzAiIGN5PSIzMCIgcj0iMiIvPjwvZz48L2c+PC9zdmc+')] pointer-events-none" />
             <div className="relative py-16 px-8 text-center">
               <h2 className="text-3xl md:text-4xl font-bold text-white mb-4">
@@ -718,7 +718,7 @@ export default function BackupDisasterRecovery() {
                 <Button
                   asChild
                   size="lg"
-                  className="bg-white text-violet-700 hover:bg-violet-50 font-semibold shadow-lg"
+                  className="bg-white text-de-accent hover:bg-de-paper-raised font-semibold shadow-lg"
                   data-testid="btn-final-assessment"
                 >
                   <a href="/book">

--- a/client/src/pages/solutions/CoManagedIT.tsx
+++ b/client/src/pages/solutions/CoManagedIT.tsx
@@ -124,7 +124,7 @@ const outcomes = [
 
 function OwnershipBadge({ owner }: { owner: Ownership }) {
   const config = {
-    de: { bg: "bg-violet-500/20", text: "text-violet-300", border: "border-violet-500/30", label: "DE-owned" },
+    de: { bg: "bg-de-raised", text: "text-de-accent-ink", border: "border-de-hairline", label: "DE-owned" },
     client: { bg: "bg-amber-500/20", text: "text-amber-300", border: "border-amber-500/30", label: "Client-owned" },
     shared: { bg: "bg-emerald-500/20", text: "text-emerald-300", border: "border-emerald-500/30", label: "Shared" }
   };
@@ -181,9 +181,9 @@ function FAQItem({ question, answer, isOpen, onToggle, index }: {
       >
         <span className="font-semibold text-white pr-4">{question}</span>
         {isOpen ? (
-          <ChevronUp className="w-5 h-5 text-violet-400 flex-shrink-0" />
+          <ChevronUp className="w-5 h-5 text-de-accent-ink flex-shrink-0" />
         ) : (
-          <ChevronDown className="w-5 h-5 text-violet-400 flex-shrink-0" />
+          <ChevronDown className="w-5 h-5 text-de-accent-ink flex-shrink-0" />
         )}
       </button>
       {isOpen && (
@@ -200,7 +200,7 @@ function StickyCTA() {
     <div className="border-t border-white/10 bg-gray-950/80">
       <div className="max-w-7xl mx-auto px-4 py-4 flex flex-col sm:flex-row items-center justify-between gap-3">
         <div className="flex items-center gap-3">
-          <Users className="w-5 h-5 text-violet-400" />
+          <Users className="w-5 h-5 text-de-accent-ink" />
           <span className="text-white font-medium">Co-Managed IT</span>
           <span className="text-white/60 text-sm hidden sm:inline">Augment your team or manage a single kit</span>
         </div>
@@ -216,7 +216,7 @@ function StickyCTA() {
           <Button
             asChild
             size="sm"
-            className="bg-white text-violet-700 hover:bg-violet-50 font-semibold"
+            className="bg-white text-de-accent hover:bg-de-paper-raised font-semibold"
             data-testid="btn-sticky-consultation"
           >
             <a href="/book">
@@ -267,10 +267,10 @@ export default function CoManagedIT() {
           
           {/* Hero Section */}
           <motion.section {...fadeInUp} className="relative">
-            <div className="absolute inset-0 bg-gradient-to-br from-purple-600/20 via-violet-600/10 to-transparent rounded-3xl pointer-events-none" />
+            <div className="absolute inset-0 bg-de-raised to-transparent rounded-3xl pointer-events-none" />
             <div className="relative bg-white/[0.02] border border-white/10 rounded-3xl p-8 md:p-12">
               <div className="max-w-3xl">
-                <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-purple-500/20 border border-purple-500/30 text-purple-300 text-sm font-medium mb-6">
+                <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-de-raised border border-de-hairline text-de-accent-ink text-sm font-medium mb-6">
                   <Users className="w-4 h-4" />
                   Flexible engagement models
                 </div>
@@ -291,7 +291,7 @@ export default function CoManagedIT() {
                   <Button
                     asChild
                     size="lg"
-                    className="bg-white text-violet-700 hover:bg-violet-50 font-semibold shadow-lg"
+                    className="bg-white text-de-accent hover:bg-de-paper-raised font-semibold shadow-lg"
                     data-testid="btn-hero-consultation"
                   >
                     <a href="/book">
@@ -334,12 +334,12 @@ export default function CoManagedIT() {
               {/* Card A: Collaboration */}
               <div className="bg-white/[0.03] border border-white/10 rounded-2xl p-8 hover:bg-white/[0.05] transition-colors">
                 <div className="flex items-center gap-3 mb-4">
-                  <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-purple-600 to-violet-600 flex items-center justify-center">
+                  <div className="w-12 h-12 rounded-xl bg-de-raised flex items-center justify-center">
                     <Users className="w-6 h-6 text-white" />
                   </div>
                   <div>
                     <h3 className="text-xl font-bold text-white">Co-Managed Collaboration</h3>
-                    <p className="text-violet-300 text-sm">Joint effort with internal IT</p>
+                    <p className="text-de-accent-ink text-sm">Joint effort with internal IT</p>
                   </div>
                 </div>
                 <p className="text-white/70 mb-6">
@@ -365,7 +365,7 @@ export default function CoManagedIT() {
                 </ul>
                 <Button
                   asChild
-                  className="w-full bg-violet-600 text-white hover:bg-violet-500"
+                  className="w-full bg-de-accent text-white hover:bg-de-accent"
                   data-testid="btn-card-collaboration"
                 >
                   <a href="/book">
@@ -471,7 +471,7 @@ export default function CoManagedIT() {
                   onClick={() => setEngagementMode("collaboration")}
                   className={`px-6 py-2 rounded-lg text-sm font-medium transition-colors ${
                     engagementMode === "collaboration" 
-                      ? "bg-violet-600 text-white" 
+                      ? "bg-de-accent text-white" 
                       : "text-white/60 hover:text-white"
                   }`}
                   data-testid="btn-mode-collaboration"
@@ -494,7 +494,7 @@ export default function CoManagedIT() {
 
             {engagementMode === "collaboration" ? (
               <div className="bg-white/[0.02] border border-white/10 rounded-xl overflow-hidden">
-                <div className="bg-violet-600/20 border-b border-white/10 px-6 py-4">
+                <div className="bg-de-raised border-b border-white/10 px-6 py-4">
                   <h3 className="font-semibold text-white">Collaboration Co-Managed</h3>
                   <p className="text-white/60 text-sm">Joint effort with internal IT — clear ownership per domain</p>
                 </div>
@@ -546,7 +546,7 @@ export default function CoManagedIT() {
                 <thead>
                   <tr className="bg-white/5 border-b border-white/10">
                     <th className="text-left px-6 py-4 text-white font-semibold">Responsibility</th>
-                    <th className="text-center px-4 py-4 text-violet-300 font-semibold">DE</th>
+                    <th className="text-center px-4 py-4 text-de-accent-ink font-semibold">DE</th>
                     <th className="text-center px-4 py-4 text-amber-300 font-semibold">Client</th>
                   </tr>
                 </thead>
@@ -554,7 +554,7 @@ export default function CoManagedIT() {
                   {raciPreview.map((row, index) => (
                     <tr key={index} className="hover:bg-white/[0.02]">
                       <td className="px-6 py-3 text-white/80">{row.responsibility}</td>
-                      <td className="px-4 py-3 text-center text-violet-300 text-sm">{row.de}</td>
+                      <td className="px-4 py-3 text-center text-de-accent-ink text-sm">{row.de}</td>
                       <td className="px-4 py-3 text-center text-amber-300 text-sm">{row.client}</td>
                     </tr>
                   ))}
@@ -580,7 +580,7 @@ export default function CoManagedIT() {
             </div>
             <div className="grid md:grid-cols-3 gap-6">
               <div className="bg-white/[0.03] border border-white/10 rounded-xl p-6">
-                <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-violet-600 to-purple-600 flex items-center justify-center mb-4">
+                <div className="w-12 h-12 rounded-xl bg-de-raised flex items-center justify-center mb-4">
                   <Laptop className="w-6 h-6 text-white" />
                 </div>
                 <h3 className="text-lg font-semibold text-white mb-2">Secure Laptops</h3>
@@ -588,7 +588,7 @@ export default function CoManagedIT() {
                 <p className="text-amber-400 font-semibold">Starting at $495</p>
               </div>
               <div className="bg-white/[0.03] border border-white/10 rounded-xl p-6">
-                <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-violet-600 to-purple-600 flex items-center justify-center mb-4">
+                <div className="w-12 h-12 rounded-xl bg-de-raised flex items-center justify-center mb-4">
                   <Monitor className="w-6 h-6 text-white" />
                 </div>
                 <h3 className="text-lg font-semibold text-white mb-2">Workstations</h3>
@@ -596,7 +596,7 @@ export default function CoManagedIT() {
                 <p className="text-amber-400 font-semibold">Starting at $650</p>
               </div>
               <div className="bg-white/[0.03] border border-white/10 rounded-xl p-6">
-                <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-violet-600 to-purple-600 flex items-center justify-center mb-4">
+                <div className="w-12 h-12 rounded-xl bg-de-raised flex items-center justify-center mb-4">
                   <Network className="w-6 h-6 text-white" />
                 </div>
                 <h3 className="text-lg font-semibold text-white mb-2">Network Kits</h3>
@@ -629,7 +629,7 @@ export default function CoManagedIT() {
           {/* Final CTA */}
           <motion.section {...fadeInUp}>
             <div className="relative rounded-2xl overflow-hidden">
-              <div className="absolute inset-0 bg-gradient-to-r from-purple-600 via-violet-600 to-fuchsia-600 opacity-90" />
+              <div className="absolute inset-0 bg-de-raised opacity-90" />
               <div className="absolute inset-0 bg-[url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNjAiIGhlaWdodD0iNjAiIHZpZXdCb3g9IjAgMCA2MCA2MCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48ZyBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiPjxnIGZpbGw9IiNmZmZmZmYiIGZpbGwtb3BhY2l0eT0iMC4wNSI+PGNpcmNsZSBjeD0iMzAiIGN5PSIzMCIgcj0iMiIvPjwvZz48L2c+PC9zdmc+')] pointer-events-none" />
               <div className="relative py-16 px-8 text-center">
                 <h2 className="text-3xl md:text-4xl font-bold text-white mb-4">
@@ -642,7 +642,7 @@ export default function CoManagedIT() {
                   <Button
                     asChild
                     size="lg"
-                    className="bg-white text-violet-700 hover:bg-violet-50 font-semibold shadow-lg"
+                    className="bg-white text-de-accent hover:bg-de-paper-raised font-semibold shadow-lg"
                     data-testid="btn-final-consultation"
                   >
                     <a href="/book">

--- a/client/src/pages/solutions/ManagedWorkplace.tsx
+++ b/client/src/pages/solutions/ManagedWorkplace.tsx
@@ -161,7 +161,7 @@ function CompareCell({ value }: { value: boolean | string }) {
     return <Check className="w-5 h-5 text-emerald-400 mx-auto" />;
   }
   if (value === false) {
-    return <X className="w-5 h-5 text-white/30 mx-auto" />;
+    return <X className="w-5 h-5 text-white/55 mx-auto" />;
   }
   return <span className="text-sm text-white/80">{value}</span>;
 }
@@ -177,9 +177,9 @@ function FAQItem({ question, answer, isOpen, onToggle, index }: { question: stri
       >
         <span className="font-semibold text-white pr-4">{question}</span>
         {isOpen ? (
-          <ChevronUp className="w-5 h-5 text-violet-400 flex-shrink-0" />
+          <ChevronUp className="w-5 h-5 text-de-accent-ink flex-shrink-0" />
         ) : (
-          <ChevronDown className="w-5 h-5 text-violet-400 flex-shrink-0" />
+          <ChevronDown className="w-5 h-5 text-de-accent-ink flex-shrink-0" />
         )}
       </button>
       {isOpen && (
@@ -227,12 +227,12 @@ export default function ManagedWorkplace() {
       <div className="space-y-24">
         {/* Hero Section */}
         <motion.section {...fadeInUp} className="relative">
-          <div className="absolute inset-0 bg-gradient-to-br from-violet-600/20 via-purple-600/10 to-transparent rounded-3xl pointer-events-none" />
+          <div className="absolute inset-0 bg-de-raised to-transparent rounded-3xl pointer-events-none" />
           <div className="relative bg-white/[0.02] border border-white/10 rounded-3xl p-8 md:p-12">
             <div className="max-w-4xl">
               <h1 className="text-4xl md:text-5xl font-bold text-white mb-6 leading-tight">
                 Managed Workplace for{" "}
-                <span className="bg-gradient-to-r from-violet-300 via-purple-300 to-fuchsia-300 bg-clip-text text-transparent">
+                <span className="text-de-accent-ink">
                   security-first teams
                 </span>
               </h1>
@@ -244,7 +244,7 @@ export default function ManagedWorkplace() {
                 <Button
                   asChild
                   size="lg"
-                  className="bg-white text-violet-700 hover:bg-violet-50 font-semibold shadow-lg"
+                  className="bg-white text-de-accent hover:bg-de-paper-raised font-semibold shadow-lg"
                   data-testid="btn-hero-consultation"
                 >
                   <a href="/book">
@@ -256,15 +256,15 @@ export default function ManagedWorkplace() {
 
               <div className="flex flex-wrap gap-4">
                 <div className="flex items-center gap-2 text-sm text-white/60">
-                  <Shield className="w-4 h-4 text-violet-400" />
+                  <Shield className="w-4 h-4 text-de-accent-ink" />
                   <span>Zero-trust access policies</span>
                 </div>
                 <div className="flex items-center gap-2 text-sm text-white/60">
-                  <UserPlus className="w-4 h-4 text-violet-400" />
+                  <UserPlus className="w-4 h-4 text-de-accent-ink" />
                   <span>Onboarding automation</span>
                 </div>
                 <div className="flex items-center gap-2 text-sm text-white/60">
-                  <Laptop className="w-4 h-4 text-violet-400" />
+                  <Laptop className="w-4 h-4 text-de-accent-ink" />
                   <span>Standardized device baseline</span>
                 </div>
               </div>
@@ -289,7 +289,7 @@ export default function ManagedWorkplace() {
                 className="bg-white/[0.03] border border-white/10 rounded-xl p-6 hover:bg-white/[0.05] transition-colors"
               >
                 <div className="flex items-start gap-4">
-                  <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-violet-600 to-purple-600 flex items-center justify-center flex-shrink-0">
+                  <div className="w-12 h-12 rounded-xl bg-de-raised flex items-center justify-center flex-shrink-0">
                     <outcome.icon className="w-6 h-6 text-white" />
                   </div>
                   <div>
@@ -317,10 +317,10 @@ export default function ManagedWorkplace() {
                 className="relative"
               >
                 <div className="bg-white/[0.03] border border-white/10 rounded-xl p-8 text-center h-full">
-                  <div className="w-16 h-16 rounded-full bg-gradient-to-br from-violet-600 to-purple-600 flex items-center justify-center mx-auto mb-6">
+                  <div className="w-16 h-16 rounded-full bg-de-raised flex items-center justify-center mx-auto mb-6">
                     <span className="text-2xl font-bold text-white">{step.step}</span>
                   </div>
-                  <step.icon className="w-8 h-8 text-violet-400 mx-auto mb-4" />
+                  <step.icon className="w-8 h-8 text-de-accent-ink mx-auto mb-4" />
                   <h3 className="text-xl font-semibold text-white mb-3">{step.title}</h3>
                   <p className="text-white/60">{step.description}</p>
                 </div>
@@ -345,7 +345,7 @@ export default function ManagedWorkplace() {
                 onClick={() => setPricingMode('per_user')}
                 className={`px-4 py-2 rounded-full text-sm font-medium transition-colors ${
                   pricingMode === 'per_user' 
-                    ? 'bg-violet-600 text-white' 
+                    ? 'bg-de-accent text-white' 
                     : 'text-white/60 hover:text-white'
                 }`}
                 data-testid="btn-pricing-per-user"
@@ -356,7 +356,7 @@ export default function ManagedWorkplace() {
                 onClick={() => setPricingMode('monthly')}
                 className={`px-4 py-2 rounded-full text-sm font-medium transition-colors ${
                   pricingMode === 'monthly' 
-                    ? 'bg-violet-600 text-white' 
+                    ? 'bg-de-accent text-white' 
                     : 'text-white/60 hover:text-white'
                 }`}
                 data-testid="btn-pricing-monthly"
@@ -414,7 +414,7 @@ export default function ManagedWorkplace() {
                   <div className="bg-white/5 rounded-lg p-4 mb-6">
                     <p className="text-sm text-white/60 mb-2">Key Outcomes:</p>
                     {pkg.outcomes.map((outcome, i) => (
-                      <div key={i} className="flex items-center gap-2 text-sm text-violet-300">
+                      <div key={i} className="flex items-center gap-2 text-sm text-de-accent-ink">
                         <Sparkles className="w-4 h-4" />
                         {outcome}
                       </div>
@@ -425,8 +425,8 @@ export default function ManagedWorkplace() {
                     asChild
                     className={`w-full ${
                       pkg.featured 
-                        ? 'bg-white text-violet-700 hover:bg-violet-50' 
-                        : 'bg-violet-600 text-white hover:bg-violet-500'
+                        ? 'bg-white text-de-accent hover:bg-de-paper-raised' 
+                        : 'bg-de-accent text-white hover:bg-de-accent'
                     }`}
                     data-testid={`btn-package-${pkg.sku}`}
                   >
@@ -437,7 +437,7 @@ export default function ManagedWorkplace() {
                   </Button>
 
                   {pkg.not_included && pkg.not_included.length > 0 && (
-                    <p className="text-xs text-white/40 mt-4 text-center">
+                    <p className="text-xs text-white/55 mt-4 text-center">
                       <Info className="w-3 h-3 inline mr-1" />
                       Not included: {pkg.not_included.slice(0, 2).join(', ')}
                       {pkg.not_included.length > 2 && ` +${pkg.not_included.length - 2} more`}
@@ -462,7 +462,7 @@ export default function ManagedWorkplace() {
                 <tr className="border-b border-white/10">
                   <th className="text-left py-4 px-4 text-white/60 font-medium">Feature</th>
                   <th className="text-center py-4 px-4 text-white font-semibold">Essentials</th>
-                  <th className="text-center py-4 px-4 text-white font-semibold bg-violet-600/20">Business</th>
+                  <th className="text-center py-4 px-4 text-white font-semibold bg-de-raised">Business</th>
                   <th className="text-center py-4 px-4 text-white font-semibold">Enterprise</th>
                 </tr>
               </thead>
@@ -471,7 +471,7 @@ export default function ManagedWorkplace() {
                   <tr key={index} className="border-b border-white/5 hover:bg-white/[0.02]">
                     <td className="py-4 px-4 text-white/80 text-sm">{row.feature}</td>
                     <td className="py-4 px-4 text-center"><CompareCell value={row.essentials} /></td>
-                    <td className="py-4 px-4 text-center bg-violet-600/10"><CompareCell value={row.business} /></td>
+                    <td className="py-4 px-4 text-center bg-de-raised"><CompareCell value={row.business} /></td>
                     <td className="py-4 px-4 text-center"><CompareCell value={row.enterprise} /></td>
                   </tr>
                 ))}
@@ -482,7 +482,7 @@ export default function ManagedWorkplace() {
           <div className="text-center mt-6">
             <a 
               href="/ecosystem-pricing" 
-              className="text-violet-400 hover:text-violet-300 text-sm inline-flex items-center gap-1"
+              className="text-de-accent-ink hover:text-de-accent-ink text-sm inline-flex items-center gap-1"
               data-testid="link-full-matrix"
             >
               View full service matrix
@@ -504,7 +504,7 @@ export default function ManagedWorkplace() {
                 key={index}
                 {...fadeInUp}
                 transition={{ delay: index * 0.05 }}
-                className="bg-white/[0.03] border border-white/10 rounded-xl p-5 hover:border-violet-500/50 transition-colors"
+                className="bg-white/[0.03] border border-white/10 rounded-xl p-5 hover:border-de-hairline transition-colors"
               >
                 <h3 className="text-white font-semibold mb-2">{addon.name}</h3>
                 <p className="text-white/60 text-sm">{addon.description}</p>
@@ -536,26 +536,26 @@ export default function ManagedWorkplace() {
 
         {/* What Happens After You Book */}
         <motion.section {...fadeInUp}>
-          <div className="bg-gradient-to-br from-violet-600/20 via-purple-600/10 to-transparent rounded-2xl border border-white/10 p-8 md:p-12">
+          <div className="bg-de-raised to-transparent rounded-2xl border border-white/10 p-8 md:p-12">
             <h2 className="text-2xl font-bold text-white mb-6 text-center">What Happens After You Book?</h2>
             <div className="grid md:grid-cols-3 gap-6 max-w-4xl mx-auto">
               <div className="text-center">
-                <div className="w-12 h-12 rounded-full bg-violet-600/20 border border-violet-500/30 flex items-center justify-center mx-auto mb-4">
-                  <Phone className="w-6 h-6 text-violet-400" />
+                <div className="w-12 h-12 rounded-full bg-de-raised border border-de-hairline flex items-center justify-center mx-auto mb-4">
+                  <Phone className="w-6 h-6 text-de-accent-ink" />
                 </div>
                 <h3 className="font-semibold text-white mb-2">Discovery Call</h3>
                 <p className="text-white/60 text-sm">15–25 min call to understand your tools, team, and goals</p>
               </div>
               <div className="text-center">
-                <div className="w-12 h-12 rounded-full bg-violet-600/20 border border-violet-500/30 flex items-center justify-center mx-auto mb-4">
-                  <FileText className="w-6 h-6 text-violet-400" />
+                <div className="w-12 h-12 rounded-full bg-de-raised border border-de-hairline flex items-center justify-center mx-auto mb-4">
+                  <FileText className="w-6 h-6 text-de-accent-ink" />
                 </div>
                 <h3 className="font-semibold text-white mb-2">Access & Inventory</h3>
                 <p className="text-white/60 text-sm">We document your current state and create an action plan</p>
               </div>
               <div className="text-center">
-                <div className="w-12 h-12 rounded-full bg-violet-600/20 border border-violet-500/30 flex items-center justify-center mx-auto mb-4">
-                  <Building2 className="w-6 h-6 text-violet-400" />
+                <div className="w-12 h-12 rounded-full bg-de-raised border border-de-hairline flex items-center justify-center mx-auto mb-4">
+                  <Building2 className="w-6 h-6 text-de-accent-ink" />
                 </div>
                 <h3 className="font-semibold text-white mb-2">Onboarding Timeline</h3>
                 <p className="text-white/60 text-sm">Clear responsibilities and milestones for go-live</p>
@@ -567,7 +567,7 @@ export default function ManagedWorkplace() {
         {/* Final CTA */}
         <motion.section {...fadeInUp}>
           <div className="relative rounded-2xl overflow-hidden">
-            <div className="absolute inset-0 bg-gradient-to-r from-violet-600 via-purple-600 to-fuchsia-600 opacity-90" />
+            <div className="absolute inset-0 bg-de-raised opacity-90" />
             <div className="absolute inset-0 bg-[url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNjAiIGhlaWdodD0iNjAiIHZpZXdCb3g9IjAgMCA2MCA2MCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48ZyBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiPjxnIGZpbGw9IiNmZmZmZmYiIGZpbGwtb3BhY2l0eT0iMC4wNSI+PGNpcmNsZSBjeD0iMzAiIGN5PSIzMCIgcj0iMiIvPjwvZz48L2c+PC9zdmc+')] pointer-events-none" />
             <div className="relative py-16 px-8 text-center">
               <h2 className="text-3xl md:text-4xl font-bold text-white mb-4">
@@ -580,7 +580,7 @@ export default function ManagedWorkplace() {
                 <Button
                   asChild
                   size="lg"
-                  className="bg-white text-violet-700 hover:bg-violet-50 font-semibold shadow-lg"
+                  className="bg-white text-de-accent hover:bg-de-paper-raised font-semibold shadow-lg"
                   data-testid="btn-final-consultation"
                 >
                   <a href="/book">

--- a/client/src/pages/solutions/OfficePage.tsx
+++ b/client/src/pages/solutions/OfficePage.tsx
@@ -165,9 +165,9 @@ function StatusBadge({ status, tooltip }: { status: InclusionStatus; tooltip?: s
       icon: <Check className="w-3 h-3" />
     },
     "limited": { 
-      bg: "bg-violet-500/20", 
-      text: "text-violet-300", 
-      border: "border-violet-500/30",
+      bg: "bg-de-raised", 
+      text: "text-de-accent-ink", 
+      border: "border-de-hairline",
       label: "Included",
       icon: <Info className="w-3 h-3" />
     },
@@ -180,7 +180,7 @@ function StatusBadge({ status, tooltip }: { status: InclusionStatus; tooltip?: s
     },
     "not-included": { 
       bg: "bg-white/5", 
-      text: "text-white/40", 
+      text: "text-white/55", 
       border: "border-white/10",
       label: "—",
       icon: null
@@ -227,9 +227,9 @@ function FAQItem({ question, answer, isOpen, onToggle, index }: {
       >
         <span className="font-semibold text-white pr-4">{question}</span>
         {isOpen ? (
-          <ChevronUp className="w-5 h-5 text-violet-400 flex-shrink-0" />
+          <ChevronUp className="w-5 h-5 text-de-accent-ink flex-shrink-0" />
         ) : (
-          <ChevronDown className="w-5 h-5 text-violet-400 flex-shrink-0" />
+          <ChevronDown className="w-5 h-5 text-de-accent-ink flex-shrink-0" />
         )}
       </button>
       {isOpen && (
@@ -246,7 +246,7 @@ function StickyCTA() {
     <div className="border-t border-white/10 bg-gray-950/80">
       <div className="max-w-7xl mx-auto px-4 py-4 flex flex-col sm:flex-row items-center justify-between gap-3">
         <div className="flex items-center gap-3">
-          <Shield className="w-5 h-5 text-violet-400" />
+          <Shield className="w-5 h-5 text-de-accent-ink" />
           <span className="text-white font-medium">Office Package</span>
           <span className="text-white/60 text-sm hidden sm:inline">Complete IT for small offices (5–25 users)</span>
         </div>
@@ -324,10 +324,10 @@ export default function OfficePage() {
           
           {/* Hero Section */}
           <motion.section {...fadeInUp} className="relative">
-            <div className="absolute inset-0 bg-gradient-to-br from-violet-600/20 via-purple-600/10 to-transparent rounded-3xl pointer-events-none" />
+            <div className="absolute inset-0 bg-de-raised to-transparent rounded-3xl pointer-events-none" />
             <div className="relative bg-white/[0.02] border border-white/10 rounded-3xl p-8 md:p-12">
               <div className="max-w-3xl">
-                <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-violet-500/20 border border-violet-500/30 text-violet-300 text-sm font-medium mb-6">
+                <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-de-raised border border-de-hairline text-de-accent-ink text-sm font-medium mb-6">
                   <Shield className="w-4 h-4" />
                   Fit for small offices
                 </div>
@@ -348,7 +348,7 @@ export default function OfficePage() {
                   <Button
                     asChild
                     size="lg"
-                    className="bg-white text-violet-700 hover:bg-violet-50 font-semibold shadow-lg"
+                    className="bg-white text-de-accent hover:bg-de-paper-raised font-semibold shadow-lg"
                     data-testid="btn-hero-consultation"
                   >
                     <a href="/book">
@@ -369,8 +369,8 @@ export default function OfficePage() {
             <div className="grid md:grid-cols-2 gap-8">
               <div className="bg-white/[0.02] border border-white/10 rounded-xl p-6">
                 <div className="flex items-center gap-3 mb-4">
-                  <div className="w-10 h-10 rounded-lg bg-violet-600/20 flex items-center justify-center">
-                    <Users className="w-5 h-5 text-violet-400" />
+                  <div className="w-10 h-10 rounded-lg bg-de-raised flex items-center justify-center">
+                    <Users className="w-5 h-5 text-de-accent-ink" />
                   </div>
                   <h3 className="text-lg font-semibold text-white">Your Organization</h3>
                 </div>
@@ -448,8 +448,8 @@ export default function OfficePage() {
           {/* Package Card */}
           <motion.section {...fadeInUp} id="package" className="scroll-mt-32">
             <div className="max-w-lg mx-auto">
-              <div className="relative bg-gradient-to-b from-violet-600/20 to-transparent rounded-2xl border-2 border-violet-500 overflow-hidden">
-                <div className="absolute top-0 left-0 right-0 bg-violet-600 text-white text-center text-sm py-1.5 font-medium">
+              <div className="relative bg-de-raised to-transparent rounded-2xl border-2 border-de-hairline overflow-hidden">
+                <div className="absolute top-0 left-0 right-0 bg-de-accent text-white text-center text-sm py-1.5 font-medium">
                   Small-office operating model
                 </div>
                 <div className="p-8 pt-12">
@@ -505,7 +505,7 @@ export default function OfficePage() {
                     className="flex items-center justify-between px-6 py-4 hover:bg-white/[0.02]"
                   >
                     <span className="text-white/80">{row.label}</span>
-                    <span className="text-violet-300 font-medium">{row.value}</span>
+                    <span className="text-de-accent-ink font-medium">{row.value}</span>
                   </div>
                 ))}
               </div>
@@ -542,16 +542,16 @@ export default function OfficePage() {
                       data-testid={`category-toggle-${category.id}`}
                     >
                       <div className="flex items-center gap-3">
-                        <div className="w-8 h-8 rounded-lg bg-violet-600/20 flex items-center justify-center text-violet-400">
+                        <div className="w-8 h-8 rounded-lg bg-de-raised flex items-center justify-center text-de-accent-ink">
                           {category.icon}
                         </div>
                         <span className="font-semibold text-white">{category.title}</span>
-                        <span className="text-white/40 text-sm">({category.rows.length} items)</span>
+                        <span className="text-white/55 text-sm">({category.rows.length} items)</span>
                       </div>
                       {expandedCategories.includes(category.id) ? (
-                        <ChevronUp className="w-5 h-5 text-white/40" />
+                        <ChevronUp className="w-5 h-5 text-white/55" />
                       ) : (
-                        <ChevronDown className="w-5 h-5 text-white/40" />
+                        <ChevronDown className="w-5 h-5 text-white/55" />
                       )}
                     </button>
                     
@@ -587,12 +587,12 @@ export default function OfficePage() {
                 <div className="flex items-center gap-3">
                   <AlertTriangle className="w-5 h-5 text-amber-400" />
                   <span className="font-semibold text-white">What's Not Included in Office</span>
-                  <span className="text-white/40 text-sm">(prevents scope questions)</span>
+                  <span className="text-white/55 text-sm">(prevents scope questions)</span>
                 </div>
                 {showNotIncluded ? (
-                  <ChevronUp className="w-5 h-5 text-white/40" />
+                  <ChevronUp className="w-5 h-5 text-white/55" />
                 ) : (
-                  <ChevronDown className="w-5 h-5 text-white/40" />
+                  <ChevronDown className="w-5 h-5 text-white/55" />
                 )}
               </button>
               
@@ -600,7 +600,7 @@ export default function OfficePage() {
                 <div className="border-t border-white/10 p-6 space-y-4">
                   {notIncludedItems.map((item, index) => (
                     <div key={index} className="flex items-start gap-3">
-                      <X className="w-5 h-5 text-white/40 flex-shrink-0 mt-0.5" />
+                      <X className="w-5 h-5 text-white/55 flex-shrink-0 mt-0.5" />
                       <div>
                         <p className="text-white font-medium">{item.item}</p>
                         <p className="text-white/50 text-sm">{item.reason}</p>
@@ -637,7 +637,7 @@ export default function OfficePage() {
           {/* Final CTA */}
           <motion.section {...fadeInUp}>
             <div className="relative rounded-2xl overflow-hidden">
-              <div className="absolute inset-0 bg-gradient-to-r from-violet-600 via-purple-600 to-fuchsia-600 opacity-90" />
+              <div className="absolute inset-0 bg-de-raised opacity-90" />
               <div className="absolute inset-0 bg-[url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNjAiIGhlaWdodD0iNjAiIHZpZXdCb3g9IjAgMCA2MCA2MCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48ZyBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiPjxnIGZpbGw9IiNmZmZmZmYiIGZpbGwtb3BhY2l0eT0iMC4wNSI+PGNpcmNsZSBjeD0iMzAiIGN5PSIzMCIgcj0iMiIvPjwvZz48L2c+PC9zdmc+')] pointer-events-none" />
               <div className="relative py-16 px-8 text-center">
                 <h2 className="text-3xl md:text-4xl font-bold text-white mb-4">
@@ -650,7 +650,7 @@ export default function OfficePage() {
                   <Button
                     asChild
                     size="lg"
-                    className="bg-white text-violet-700 hover:bg-violet-50 font-semibold shadow-lg"
+                    className="bg-white text-de-accent hover:bg-de-paper-raised font-semibold shadow-lg"
                     data-testid="btn-final-consultation"
                   >
                     <a href="/book">

--- a/client/src/pages/solutions/ProActiveEcosystemPage.tsx
+++ b/client/src/pages/solutions/ProActiveEcosystemPage.tsx
@@ -105,7 +105,7 @@ export default function ProActiveEcosystemPage() {
                   <span className="font-semibold text-white">Enterprise</span> — adds unified posture reporting, deeper compliance reporting, custom BCDR architecture support, privileged access program elements, quarterly executive reviews. Starts at {formatUserPrice("enterprise")} ({formatPrice(pricing.enterprise.monthlyMin)}/mo minimum).
                 </li>
               </ul>
-              <p className="mt-4 text-xs text-white/40">{PRICING_SCOPE_NOTE}</p>
+              <p className="mt-4 text-xs text-white/55">{PRICING_SCOPE_NOTE}</p>
             </div>
             <div>
               <h2 className="font-heading text-2xl font-semibold text-white">How engagement works</h2>

--- a/client/src/pages/solutions/ProActiveEcosystemPage.tsx
+++ b/client/src/pages/solutions/ProActiveEcosystemPage.tsx
@@ -57,7 +57,7 @@ export default function ProActiveEcosystemPage() {
             </p>
             <div className="mt-8 flex flex-wrap gap-3">
               <Link href="/book">
-                <Button className="h-12 bg-gradient-to-r from-fuchsia-600 via-pink-600 to-rose-500 px-6 font-semibold text-white">
+                <Button className="h-12 bg-[#D3126A] px-6 font-semibold text-white">
                   {CTA.primary}
                   <ArrowRight className="ml-2 h-4 w-4" />
                 </Button>

--- a/client/src/pages/solutions/SolutionsIndex.tsx
+++ b/client/src/pages/solutions/SolutionsIndex.tsx
@@ -403,7 +403,7 @@ const SolutionsIndex = () => {
               <a href="/book">
                 <Button 
                   size="lg"
-                  className="h-14 px-8 text-lg font-semibold bg-de-magenta hover:bg-de-magenta text-white shadow-lg shadow-violet-500/25"
+                  className="h-14 px-8 text-lg font-semibold bg-de-magenta hover:bg-de-magenta text-white shadow-lg shadow-none"
                   data-testid="button-final-cta"
                 >
                   Schedule Free Consultation

--- a/client/src/pages/solutions/SolutionsIndex.tsx
+++ b/client/src/pages/solutions/SolutionsIndex.tsx
@@ -141,13 +141,13 @@ const SolutionsIndex = () => {
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5 }}
           >
-            <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-violet-500/10 border border-violet-500/20 mb-6">
-              <Shield className="w-4 h-4 text-violet-400" />
-              <span className="text-sm text-violet-300">Complete IT & Security Solutions</span>
+            <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-de-raised border border-de-hairline mb-6">
+              <Shield className="w-4 h-4 text-de-magenta-ink" />
+              <span className="text-sm text-de-magenta-ink">Complete IT & Security Solutions</span>
             </div>
             <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6">
               The ProActive{" "}
-              <span className="text-transparent bg-clip-text bg-gradient-to-r from-violet-300 via-violet-300 to-fuchsia-300">
+              <span className="text-de-magenta-ink">
                 Ecosystem
               </span>
             </h1>
@@ -216,7 +216,7 @@ const SolutionsIndex = () => {
               ))}
             </div>
             
-            <p className="text-center text-white/40 text-sm mt-6">
+            <p className="text-center text-white/55 text-sm mt-6">
               {getPricingFooterText()}. Final pricing tailored to your users, sites, and compliance needs.
             </p>
           </motion.section>
@@ -254,7 +254,7 @@ const SolutionsIndex = () => {
                 <motion.div
                   key={service.title}
                   variants={itemVariants}
-                  className="rounded-2xl border border-white/10 bg-[#151217] p-5 transition-all duration-300 hover:border-violet-500/30"
+                  className="rounded-2xl border border-white/10 bg-[#151217] p-5 transition-all duration-300 hover:border-de-hairline"
                   data-testid={`foundation-${index}`}
                 >
                   <div className="mb-4">
@@ -293,14 +293,14 @@ const SolutionsIndex = () => {
                 <motion.div
                   key={service.title}
                   variants={itemVariants}
-                  className="flex gap-4 rounded-2xl border border-white/10 bg-[#151217] p-5 transition-all duration-300 hover:border-violet-500/30"
+                  className="flex gap-4 rounded-2xl border border-white/10 bg-[#151217] p-5 transition-all duration-300 hover:border-de-hairline"
                   data-testid={`security-${index}`}
                 >
                   <IconWell icon={service.icon} size="md" surface="dark" />
                   <div className="flex-1">
                     <div className="flex items-center gap-2 mb-2">
                       <h3 className="text-white font-semibold">{service.title}</h3>
-                      <span className="px-2 py-0.5 text-xs bg-violet-500/20 text-violet-300 rounded">
+                      <span className="px-2 py-0.5 text-xs bg-de-raised text-de-magenta-ink rounded">
                         {service.tier}
                       </span>
                     </div>
@@ -336,14 +336,14 @@ const SolutionsIndex = () => {
                 <motion.div
                   key={service.title}
                   variants={itemVariants}
-                  className="flex gap-4 rounded-2xl border border-white/10 bg-[#151217] p-5 transition-all duration-300 hover:border-violet-500/30"
+                  className="flex gap-4 rounded-2xl border border-white/10 bg-[#151217] p-5 transition-all duration-300 hover:border-de-hairline"
                   data-testid={`compliance-${index}`}
                 >
                   <IconWell icon={service.icon} size="md" surface="dark" />
                   <div className="flex-1">
                     <div className="flex items-center gap-2 mb-2">
                       <h3 className="text-white font-semibold">{service.title}</h3>
-                      <span className="px-2 py-0.5 text-xs bg-violet-500/20 text-violet-300 rounded">
+                      <span className="px-2 py-0.5 text-xs bg-de-raised text-de-magenta-ink rounded">
                         {service.tier}
                       </span>
                     </div>
@@ -356,7 +356,7 @@ const SolutionsIndex = () => {
 
           {/* Why Choose Us */}
           <motion.section 
-            className="mb-20 rounded-2xl p-8 bg-gradient-to-br from-violet-900/20 to-violet-900/20 border border-violet-500/20"
+            className="mb-20 rounded-2xl p-8 bg-de-raised border border-de-hairline"
             initial={{ opacity: 0, y: 30 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
@@ -374,8 +374,8 @@ const SolutionsIndex = () => {
                 { icon: Award, value: "Security-first", label: "Operating model", description: "IT + cyber together" }
               ].map((stat, index) => (
                 <div key={index} className="text-center p-4">
-                  <div className="w-12 h-12 rounded-full bg-violet-500/20 flex items-center justify-center mx-auto mb-3">
-                    <stat.icon className="w-6 h-6 text-violet-400" />
+                  <div className="w-12 h-12 rounded-full bg-de-raised flex items-center justify-center mx-auto mb-3">
+                    <stat.icon className="w-6 h-6 text-de-magenta-ink" />
                   </div>
                   <div className="text-2xl font-bold text-white mb-1">{stat.value}</div>
                   <div className="text-white/80 font-medium text-sm">{stat.label}</div>
@@ -403,7 +403,7 @@ const SolutionsIndex = () => {
               <a href="/book">
                 <Button 
                   size="lg"
-                  className="h-14 px-8 text-lg font-semibold bg-violet-600 hover:bg-violet-500 text-white shadow-lg shadow-violet-500/25"
+                  className="h-14 px-8 text-lg font-semibold bg-de-magenta hover:bg-de-magenta text-white shadow-lg shadow-violet-500/25"
                   data-testid="button-final-cta"
                 >
                   Schedule Free Consultation

--- a/client/src/pages/solutions/StandaloneServices.tsx
+++ b/client/src/pages/solutions/StandaloneServices.tsx
@@ -159,7 +159,7 @@ export default function StandaloneServices() {
             </p>
             <div className="flex flex-col sm:flex-row items-stretch sm:items-center justify-center gap-3 mt-10">
               <a href={MEET_URL} target="_blank" rel="noopener noreferrer" data-testid="cta-hero-assessment">
-                <Button size="lg" className="w-full bg-de-raised hover: hover:to-fuchsia-500 text-white">
+                <Button size="lg" className="w-full bg-de-raised  text-white">
                   Start Cyber Risk Assessment
                   <ArrowRight className="w-4 h-4 ml-2" />
                 </Button>
@@ -337,7 +337,7 @@ export default function StandaloneServices() {
             </p>
             <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
               <a href={MEET_URL} target="_blank" rel="noopener noreferrer">
-                <Button size="lg" className="bg-de-raised hover: hover:to-fuchsia-500 text-white">
+                <Button size="lg" className="bg-de-raised  text-white">
                   Start Cyber Risk Assessment
                   <ArrowRight className="w-4 h-4 ml-2" />
                 </Button>

--- a/client/src/pages/solutions/StandaloneServices.tsx
+++ b/client/src/pages/solutions/StandaloneServices.tsx
@@ -148,7 +148,7 @@ export default function StandaloneServices() {
           >
             <h1 className="text-4xl md:text-6xl font-bold text-white mb-6 leading-tight" data-testid="heading-standalone-hero">
               Need One Critical IT or{" "}
-              <span className="bg-gradient-to-r from-cyan-400 via-violet-400 to-fuchsia-400 bg-clip-text text-transparent">
+              <span className="text-de-accent-ink">
                 Security Gap
               </span>{" "}
               Covered?
@@ -159,7 +159,7 @@ export default function StandaloneServices() {
             </p>
             <div className="flex flex-col sm:flex-row items-stretch sm:items-center justify-center gap-3 mt-10">
               <a href={MEET_URL} target="_blank" rel="noopener noreferrer" data-testid="cta-hero-assessment">
-                <Button size="lg" className="w-full bg-gradient-to-r from-violet-600 to-fuchsia-600 hover:from-violet-500 hover:to-fuchsia-500 text-white">
+                <Button size="lg" className="w-full bg-de-raised hover: hover:to-fuchsia-500 text-white">
                   Start Cyber Risk Assessment
                   <ArrowRight className="w-4 h-4 ml-2" />
                 </Button>
@@ -195,7 +195,7 @@ export default function StandaloneServices() {
                 </Button>
               </a>
             </div>
-            <div className="rounded-2xl border border-violet-500/30 bg-white/[0.03] p-7" data-testid="compare-ecosystem">
+            <div className="rounded-2xl border border-de-hairline bg-white/[0.03] p-7" data-testid="compare-ecosystem">
               <h2 className="text-xl font-bold text-white mb-4">ProActive Ecosystem</h2>
               <ul className="space-y-3 mb-6">
                 {[
@@ -204,7 +204,7 @@ export default function StandaloneServices() {
                   "Security-first technology management",
                 ].map((item) => (
                   <li key={item} className="flex items-start gap-3 text-white/70">
-                    <CheckCircle className="w-5 h-5 text-violet-400 mt-0.5 flex-shrink-0" />
+                    <CheckCircle className="w-5 h-5 text-de-accent-ink mt-0.5 flex-shrink-0" />
                     <span>{item}</span>
                   </li>
                 ))}
@@ -271,12 +271,12 @@ export default function StandaloneServices() {
                   viewport={{ once: true }}
                   variants={fadeIn}
                 >
-                  <span className="w-11 h-11 rounded-xl bg-violet-500/15 flex items-center justify-center mb-4">
-                    <service.icon className="w-5 h-5 text-violet-300" />
+                  <span className="w-11 h-11 rounded-xl bg-de-raised flex items-center justify-center mb-4">
+                    <service.icon className="w-5 h-5 text-de-accent-ink" />
                   </span>
                   <h3 className="font-semibold text-white mb-2">{service.title}</h3>
                   <p className="text-sm text-white/60 leading-relaxed mb-4 flex-1">{service.description}</p>
-                  <p className="text-xs text-white/40">{service.meta}</p>
+                  <p className="text-xs text-white/55">{service.meta}</p>
                 </motion.article>
               ))}
             </div>
@@ -295,10 +295,10 @@ export default function StandaloneServices() {
               {engagementSteps.map((step, index) => (
                 <li key={step.title} className="rounded-2xl border border-white/10 bg-white/[0.02] p-5">
                   <div className="flex items-center gap-3 mb-3">
-                    <span className="w-8 h-8 rounded-full bg-violet-500/20 text-violet-300 text-sm font-bold flex items-center justify-center">
+                    <span className="w-8 h-8 rounded-full bg-de-raised text-de-accent-ink text-sm font-bold flex items-center justify-center">
                       {index + 1}
                     </span>
-                    <step.icon className="w-5 h-5 text-white/40" />
+                    <step.icon className="w-5 h-5 text-white/55" />
                   </div>
                   <h3 className="font-semibold text-white text-sm mb-2">{step.title}</h3>
                   <p className="text-xs text-white/55 leading-relaxed">{step.description}</p>
@@ -327,7 +327,7 @@ export default function StandaloneServices() {
           </section>
 
           {/* Final CTA */}
-          <section className="text-center rounded-2xl border border-violet-500/30 bg-gradient-to-br from-violet-500/10 to-fuchsia-500/10 px-6 py-12">
+          <section className="text-center rounded-2xl border border-de-hairline bg-de-raised px-6 py-12">
             <h2 className="text-3xl font-bold text-white mb-3">
               Not Sure Whether You Need One Service or Full IT/Security Coverage?
             </h2>
@@ -337,7 +337,7 @@ export default function StandaloneServices() {
             </p>
             <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
               <a href={MEET_URL} target="_blank" rel="noopener noreferrer">
-                <Button size="lg" className="bg-gradient-to-r from-violet-600 to-fuchsia-600 hover:from-violet-500 hover:to-fuchsia-500 text-white">
+                <Button size="lg" className="bg-de-raised hover: hover:to-fuchsia-500 text-white">
                   Start Cyber Risk Assessment
                   <ArrowRight className="w-4 h-4 ml-2" />
                 </Button>

--- a/client/src/pages/store/Checkout.tsx
+++ b/client/src/pages/store/Checkout.tsx
@@ -229,7 +229,7 @@ const Checkout = () => {
               <div className="lg:col-span-3 space-y-8">
                 <div className="bg-white/5 border border-white/10 rounded-xl p-6" data-testid="section-billing-info">
                   <h2 className="text-xl font-semibold text-white mb-6 flex items-center gap-2">
-                    <FileText className="w-5 h-5 text-violet-400" />
+                    <FileText className="w-5 h-5 text-de-accent-ink" />
                     Billing Information
                   </h2>
 
@@ -243,7 +243,7 @@ const Checkout = () => {
                           id="name"
                           {...register("name")}
                           placeholder="John Smith"
-                          className="mt-1 bg-white/5 border-white/20 text-white placeholder:text-white/40 focus:border-violet-500"
+                          className="mt-1 bg-white/5 border-white/20 text-white placeholder:text-white/55 focus:border-de-hairline"
                           data-testid="input-name"
                         />
                         {errors.name && (
@@ -261,7 +261,7 @@ const Checkout = () => {
                           type="email"
                           {...register("email")}
                           placeholder="john@company.com"
-                          className="mt-1 bg-white/5 border-white/20 text-white placeholder:text-white/40 focus:border-violet-500"
+                          className="mt-1 bg-white/5 border-white/20 text-white placeholder:text-white/55 focus:border-de-hairline"
                           data-testid="input-email"
                         />
                         {errors.email && (
@@ -281,7 +281,7 @@ const Checkout = () => {
                           id="company"
                           {...register("company")}
                           placeholder="Acme Corp"
-                          className="mt-1 bg-white/5 border-white/20 text-white placeholder:text-white/40 focus:border-violet-500"
+                          className="mt-1 bg-white/5 border-white/20 text-white placeholder:text-white/55 focus:border-de-hairline"
                           data-testid="input-company"
                         />
                       </div>
@@ -294,7 +294,7 @@ const Checkout = () => {
                           type="tel"
                           {...register("phone")}
                           placeholder="(555) 123-4567"
-                          className="mt-1 bg-white/5 border-white/20 text-white placeholder:text-white/40 focus:border-violet-500"
+                          className="mt-1 bg-white/5 border-white/20 text-white placeholder:text-white/55 focus:border-de-hairline"
                           data-testid="input-phone"
                         />
                       </div>
@@ -304,7 +304,7 @@ const Checkout = () => {
 
                 <div className="bg-white/5 border border-white/10 rounded-xl p-6" data-testid="section-payment-method">
                   <h2 className="text-xl font-semibold text-white mb-6 flex items-center gap-2">
-                    <CreditCard className="w-5 h-5 text-violet-400" />
+                    <CreditCard className="w-5 h-5 text-de-accent-ink" />
                     Payment Method
                   </h2>
 
@@ -317,14 +317,14 @@ const Checkout = () => {
                       htmlFor="payment-zoho"
                       className={`flex items-center gap-4 p-4 rounded-lg border cursor-pointer transition-all ${
                         paymentMethod === "zoho"
-                          ? "border-violet-500 bg-violet-500/10"
+                          ? "border-de-hairline bg-de-raised"
                           : "border-white/20 hover:border-white/40"
                       }`}
                     >
                       <RadioGroupItem value="zoho" id="payment-zoho" data-testid="radio-zoho" />
                       <div className="flex-1">
                         <div className="flex items-center gap-2">
-                          <CreditCard className="w-5 h-5 text-violet-400" />
+                          <CreditCard className="w-5 h-5 text-de-accent-ink" />
                           <span className="font-medium text-white">Credit / Debit Card</span>
                         </div>
                         <p className="text-sm text-white/60 mt-1">
@@ -332,7 +332,7 @@ const Checkout = () => {
                         </p>
                       </div>
                       {paymentMethod === "zoho" && (
-                        <Check className="w-5 h-5 text-violet-400" />
+                        <Check className="w-5 h-5 text-de-accent-ink" />
                       )}
                     </label>
 
@@ -340,7 +340,7 @@ const Checkout = () => {
                       htmlFor="payment-quote"
                       className={`flex items-center gap-4 p-4 rounded-lg border cursor-pointer transition-all ${
                         paymentMethod === "quote_request"
-                          ? "border-violet-500 bg-violet-500/10"
+                          ? "border-de-hairline bg-de-raised"
                           : "border-white/20 hover:border-white/40"
                       }`}
                     >
@@ -355,7 +355,7 @@ const Checkout = () => {
                         </p>
                       </div>
                       {paymentMethod === "quote_request" && (
-                        <Check className="w-5 h-5 text-violet-400" />
+                        <Check className="w-5 h-5 text-de-accent-ink" />
                       )}
                     </label>
                   </RadioGroup>
@@ -365,7 +365,7 @@ const Checkout = () => {
               <div className="lg:col-span-2">
                 <div className="bg-white/5 border border-white/10 rounded-xl p-6 sticky top-28" data-testid="section-order-summary">
                   <h2 className="text-xl font-semibold text-white mb-6 flex items-center gap-2">
-                    <ShoppingCart className="w-5 h-5 text-violet-400" />
+                    <ShoppingCart className="w-5 h-5 text-de-accent-ink" />
                     Order Summary
                   </h2>
 
@@ -448,7 +448,7 @@ const Checkout = () => {
                     )}
                     <div className="flex justify-between text-lg font-semibold pt-2 border-t border-white/10">
                       <span className="text-white">Due Today</span>
-                      <span className="text-violet-400" data-testid="text-total-due">
+                      <span className="text-de-accent-ink" data-testid="text-total-due">
                         {formatCurrency(getCartTotal())}
                       </span>
                     </div>
@@ -458,7 +458,7 @@ const Checkout = () => {
                     type="submit"
                     form="checkout-form"
                     disabled={isSubmitting}
-                    className="w-full mt-6 bg-violet-600 hover:bg-violet-500 text-white py-6 text-lg font-semibold"
+                    className="w-full mt-6 bg-de-accent hover:bg-de-accent text-white py-6 text-lg font-semibold"
                     data-testid="button-submit-order"
                   >
                     {isSubmitting ? (
@@ -479,13 +479,13 @@ const Checkout = () => {
                     )}
                   </Button>
 
-                  <p className="text-center text-white/40 text-xs mt-4">
+                  <p className="text-center text-white/55 text-xs mt-4">
                     By completing this order, you agree to our{" "}
-                    <Link href="/legal/terms-of-use" className="text-violet-400 hover:underline">
+                    <Link href="/legal/terms-of-use" className="text-de-accent-ink hover:underline">
                       Terms of Service
                     </Link>{" "}
                     and{" "}
-                    <Link href="/legal/privacy-policy" className="text-violet-400 hover:underline">
+                    <Link href="/legal/privacy-policy" className="text-de-accent-ink hover:underline">
                       Privacy Policy
                     </Link>
                   </p>

--- a/client/src/pages/store/CoManagedStore.tsx
+++ b/client/src/pages/store/CoManagedStore.tsx
@@ -526,11 +526,11 @@ const CoManagedStore = () => {
           <div className="mb-4 flex items-center justify-between">
             {isLoggedIn && user ? (
               <div className="flex items-center gap-3">
-                <div className="flex items-center gap-2 rounded-lg border border-[#5034ff]/20 bg-[#5034ff]/10 px-3 py-2">
-                  <User className="h-4 w-4 text-[#a78bfa]" />
+                <div className="flex items-center gap-2 rounded-lg border border-de-accent/20 bg-de-accent/10 px-3 py-2">
+                  <User className="h-4 w-4 text-de-accent-ink" />
                   <span className="text-sm text-white" data-testid="text-user-greeting">
                     Welcome,{" "}
-                    <span className="font-semibold text-[#c4b5fd]">
+                    <span className="font-semibold text-de-accent-ink">
                       {user.fullName || user.username}
                     </span>
                   </span>
@@ -544,7 +544,7 @@ const CoManagedStore = () => {
                   variant="ghost"
                   size="sm"
                   onClick={logout}
-                  className="text-white/60 hover:bg-[#5034ff]/10 hover:text-white"
+                  className="text-white/60 hover:bg-de-accent/10 hover:text-white"
                   data-testid="button-store-logout"
                 >
                   <LogOut className="mr-1 h-4 w-4" />
@@ -556,7 +556,7 @@ const CoManagedStore = () => {
                 variant="outline"
                 size="sm"
                 onClick={loginRedirect}
-                className="h-11 border-none bg-[#5034ff] px-5 text-base text-white hover:bg-[#6548ff]"
+                className="h-11 border-none bg-de-accent px-5 text-base text-white hover:bg-[#6548ff]"
                 data-testid="button-store-login"
               >
                 <User className="mr-2 h-4 w-4" />
@@ -581,13 +581,13 @@ const CoManagedStore = () => {
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.45 }}
           >
-            <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-[#5034ff]/25 bg-[#5034ff]/10 px-4 py-2">
-              <Users className="h-4 w-4 text-[#a78bfa]" />
-              <span className="text-sm text-[#c4b5fd]">Guided IT Storefront</span>
+            <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-de-accent/25 bg-de-accent/10 px-4 py-2">
+              <Users className="h-4 w-4 text-de-accent-ink" />
+              <span className="text-sm text-de-accent-ink">Guided IT Storefront</span>
             </div>
             <h1 className="mb-4 text-4xl font-bold text-white md:text-5xl lg:text-6xl">
               Tell us what you&apos;re trying to{" "}
-              <span className="text-[#a78bfa]">accomplish.</span>
+              <span className="text-de-accent-ink">accomplish.</span>
             </h1>
             <p className="text-lg leading-relaxed text-white/70 md:text-xl">
               Shop by outcome, build a recommended stack with Ask Digerati, then buy from the live
@@ -595,7 +595,7 @@ const CoManagedStore = () => {
             </p>
             <div className="mt-6 flex flex-wrap gap-3">
               <Button
-                className="h-12 bg-[#5034ff] px-6 text-base text-white hover:bg-[#6548ff]"
+                className="h-12 bg-de-accent px-6 text-base text-white hover:bg-[#6548ff]"
                 onClick={() => setGuidedOpen(true)}
                 data-testid="button-build-solution"
               >
@@ -714,7 +714,7 @@ const CoManagedStore = () => {
                     variant={selectedCategory === "all" ? "default" : "outline"}
                     className={
                       selectedCategory === "all"
-                        ? "bg-[#5034ff] text-white hover:bg-[#6548ff]"
+                        ? "bg-de-accent text-white hover:bg-[#6548ff]"
                         : "border-white/15 bg-transparent text-white/80 hover:bg-white/5"
                     }
                     onClick={() => setSelectedCategory("all")}
@@ -732,7 +732,7 @@ const CoManagedStore = () => {
                         variant={selectedCategory === category ? "default" : "outline"}
                         className={
                           selectedCategory === category
-                            ? "bg-[#5034ff] text-white hover:bg-[#6548ff]"
+                            ? "bg-de-accent text-white hover:bg-[#6548ff]"
                             : "border-white/15 bg-transparent text-white/80 hover:bg-white/5"
                         }
                         onClick={() => setSelectedCategory(category)}
@@ -745,7 +745,7 @@ const CoManagedStore = () => {
                 </div>
 
                 {selectedCategory !== "all" && (
-                  <div className="mb-6 rounded-xl border border-[#5034ff]/20 bg-[#5034ff]/10 p-4">
+                  <div className="mb-6 rounded-xl border border-de-accent/20 bg-de-accent/10 p-4">
                     <h3 className="mb-1 font-semibold text-white">
                       {categoryLabels[selectedCategory]}
                     </h3>
@@ -793,11 +793,11 @@ const CoManagedStore = () => {
                     data-testid="catalog-empty-state"
                   >
                     <p className="text-lg text-white/50">No products match these filters.</p>
-                    <p className="mt-2 text-sm text-white/40">
+                    <p className="mt-2 text-sm text-white/55">
                       Showing 0 of {visibleBase.length} products
                     </p>
                     <Button
-                      className="mt-4 bg-[#5034ff] text-white hover:bg-[#6548ff]"
+                      className="mt-4 bg-de-accent text-white hover:bg-[#6548ff]"
                       onClick={clearAllFilters}
                       data-testid="button-empty-clear-filters"
                     >
@@ -831,8 +831,8 @@ const CoManagedStore = () => {
             <div className="grid gap-6 md:grid-cols-2">
               <div className="rounded-xl border border-white/10 bg-[#141414] p-6">
                 <div className="flex items-start gap-4">
-                  <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg border border-[#5034ff]/25 bg-[#5034ff]/15">
-                    <ShoppingCart className="h-5 w-5 text-[#a78bfa]" />
+                  <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg border border-de-accent/25 bg-de-accent/15">
+                    <ShoppingCart className="h-5 w-5 text-de-accent-ink" />
                   </div>
                   <div>
                     <h3 className="mb-2 font-semibold text-white">Checkout enabled</h3>
@@ -846,14 +846,14 @@ const CoManagedStore = () => {
 
               <div className="rounded-xl border border-white/10 bg-[#141414] p-6">
                 <div className="flex items-start gap-4">
-                  <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg border border-[#5034ff]/25 bg-[#5034ff]/15">
-                    <Lock className="h-5 w-5 text-[#a78bfa]" />
+                  <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg border border-de-accent/25 bg-de-accent/15">
+                    <Lock className="h-5 w-5 text-de-accent-ink" />
                   </div>
                   <div>
                     <h3 className="mb-2 font-semibold text-white">Client-only products</h3>
                     <p className="text-sm text-white/60">
                       Some products require an existing client relationship.{" "}
-                      <Link href={PORTAL_LOGIN} className="text-[#a78bfa] hover:text-[#c4b5fd]">
+                      <Link href={PORTAL_LOGIN} className="text-de-accent-ink hover:text-de-accent-ink">
                         Log in to your portal
                       </Link>{" "}
                       for exclusive pricing.
@@ -894,7 +894,7 @@ const CoManagedStore = () => {
               <Link href="/store/managed">
                 <Button
                   size="lg"
-                  className="h-12 bg-[#5034ff] px-6 text-white hover:bg-[#6548ff]"
+                  className="h-12 bg-de-accent px-6 text-white hover:bg-[#6548ff]"
                   data-testid="button-view-managed"
                 >
                   View Managed IT Packages

--- a/client/src/pages/store/ManagedStore.tsx
+++ b/client/src/pages/store/ManagedStore.tsx
@@ -56,13 +56,13 @@ const ManagedStore = () => {
         variants={itemVariants}
         className={`relative overflow-hidden rounded-2xl border transition-all duration-300 hover:-translate-y-1 cursor-pointer ${
           featured 
-            ? 'bg-violet-500/10 border-violet-500/40 shadow-[0_0_40px_rgba(139,92,246,0.2)]' 
-            : 'bg-white/[0.03] border-white/10 hover:border-violet-500/30'
+            ? 'bg-de-raised border-de-hairline shadow-[0_0_40px_rgba(139,92,246,0.2)]' 
+            : 'bg-white/[0.03] border-white/10 hover:border-de-hairline'
         }`}
         data-testid={`product-${product.id}`}
       >
       {featured && (
-        <div className="absolute -top-3 left-1/2 z-10 -translate-x-1/2 px-3 py-1 bg-violet-600 text-white text-xs font-bold rounded-full flex items-center gap-1">
+        <div className="absolute -top-3 left-1/2 z-10 -translate-x-1/2 px-3 py-1 bg-de-accent text-white text-xs font-bold rounded-full flex items-center gap-1">
           <Star className="w-3 h-3" />
           Most Popular
         </div>
@@ -77,7 +77,7 @@ const ManagedStore = () => {
 
       <div className="p-6">
       <div className="mb-4">
-        <span className="text-xs text-white/40 uppercase tracking-wider">{categoryLabels[product.category]}</span>
+        <span className="text-xs text-white/55 uppercase tracking-wider">{categoryLabels[product.category]}</span>
         {visual.vendor && (
           <span className="ml-2 text-xs text-white/50">{visual.vendor.name}</span>
         )}
@@ -86,7 +86,7 @@ const ManagedStore = () => {
 
       <div className="mb-4">
         {product.basePrice === 0 ? (
-          <span className="text-2xl font-bold text-violet-400">Custom Quote</span>
+          <span className="text-2xl font-bold text-de-accent-ink">Custom Quote</span>
         ) : (
           <>
             <span className="text-3xl font-black text-white">${product.basePrice}</span>
@@ -111,7 +111,7 @@ const ManagedStore = () => {
       <Button 
         className={`w-full ${
           featured 
-            ? 'bg-violet-600 hover:bg-violet-500 text-white' 
+            ? 'bg-de-accent hover:bg-de-accent text-white' 
             : 'bg-white/10 hover:bg-white/20 text-white border border-white/20'
         }`}
         onClick={(e) => {
@@ -154,13 +154,13 @@ const ManagedStore = () => {
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5 }}
           >
-            <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-violet-500/10 border border-violet-500/20 mb-6">
-              <Building className="w-4 h-4 text-violet-400" />
-              <span className="text-sm text-violet-300">Managed IT Services</span>
+            <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-de-raised border border-de-hairline mb-6">
+              <Building className="w-4 h-4 text-de-accent-ink" />
+              <span className="text-sm text-de-accent-ink">Managed IT Services</span>
             </div>
             <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6">
               Full-Service{" "}
-              <span className="text-transparent bg-clip-text bg-gradient-to-r from-violet-300 via-purple-300 to-fuchsia-300">
+              <span className="text-de-accent-ink">
                 Managed IT
               </span>
             </h1>
@@ -172,12 +172,12 @@ const ManagedStore = () => {
 
           {/* Contract Notice */}
           <motion.div 
-            className="mb-12 p-4 rounded-xl bg-violet-500/10 border border-violet-500/20 flex items-start gap-4"
+            className="mb-12 p-4 rounded-xl bg-de-raised border border-de-hairline flex items-start gap-4"
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5, delay: 0.1 }}
           >
-            <Lock className="w-5 h-5 text-violet-400 mt-0.5 flex-shrink-0" />
+            <Lock className="w-5 h-5 text-de-accent-ink mt-0.5 flex-shrink-0" />
             <div>
               <h3 className="text-white font-semibold mb-1">Contract-Based Services</h3>
               <p className="text-white/60 text-sm">
@@ -210,7 +210,7 @@ const ManagedStore = () => {
               ))}
             </div>
             
-            <p className="text-center text-white/40 text-sm mt-6">
+            <p className="text-center text-white/55 text-sm mt-6">
               {getPricingFooterText()}. Final pricing tailored to your users, sites, and compliance needs.
             </p>
           </motion.section>
@@ -239,7 +239,7 @@ const ManagedStore = () => {
 
           {/* Why Choose Managed */}
           <motion.section 
-            className="mb-20 rounded-2xl p-8 bg-gradient-to-br from-violet-900/20 to-purple-900/20 border border-violet-500/20"
+            className="mb-20 rounded-2xl p-8 bg-de-raised border border-de-hairline"
             initial={{ opacity: 0, y: 30 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
@@ -257,8 +257,8 @@ const ManagedStore = () => {
                 { icon: Award, value: "$50K+", label: "Avg. Savings", description: "Per client annually" }
               ].map((stat, index) => (
                 <div key={index} className="text-center p-4">
-                  <div className="w-12 h-12 rounded-full bg-violet-500/20 flex items-center justify-center mx-auto mb-3">
-                    <stat.icon className="w-6 h-6 text-violet-400" />
+                  <div className="w-12 h-12 rounded-full bg-de-raised flex items-center justify-center mx-auto mb-3">
+                    <stat.icon className="w-6 h-6 text-de-accent-ink" />
                   </div>
                   <div className="text-2xl font-bold text-white mb-1">{stat.value}</div>
                   <div className="text-white/80 font-medium text-sm">{stat.label}</div>
@@ -287,7 +287,7 @@ const ManagedStore = () => {
               <a href="/book">
                 <Button 
                   size="lg"
-                  className="h-14 px-8 text-lg font-semibold bg-violet-600 hover:bg-violet-500 text-white shadow-lg shadow-violet-500/25"
+                  className="h-14 px-8 text-lg font-semibold bg-de-accent hover:bg-de-accent text-white shadow-lg shadow-none"
                   data-testid="button-final-cta"
                 >
                   <Calendar className="w-5 h-5 mr-2" />
@@ -310,7 +310,7 @@ const ManagedStore = () => {
               <Link href="/store/co-managed">
                 <Button 
                   variant="link" 
-                  className="text-violet-400 hover:text-violet-300"
+                  className="text-de-accent-ink hover:text-de-accent-ink"
                   data-testid="button-browse-comanaged"
                 >
                   Looking for individual products? Browse Co-Managed Store

--- a/client/src/pages/store/OrderConfirmation.tsx
+++ b/client/src/pages/store/OrderConfirmation.tsx
@@ -98,7 +98,7 @@ const OrderConfirmation = () => {
     pending: { label: "Pending", color: "text-amber-400", bg: "bg-amber-400/10" },
     quote_requested: { label: "Quote Requested", color: "text-blue-400", bg: "bg-blue-400/10" },
     paid: { label: "Paid", color: "text-emerald-400", bg: "bg-emerald-400/10" },
-    processing: { label: "Processing", color: "text-violet-400", bg: "bg-violet-400/10" },
+    processing: { label: "Processing", color: "text-de-accent-ink", bg: "bg-de-raised" },
     completed: { label: "Completed", color: "text-emerald-400", bg: "bg-emerald-400/10" },
   };
 
@@ -110,7 +110,7 @@ const OrderConfirmation = () => {
         <MegaMenu />
         <main className="de-nav-clear pb-20">
           <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 flex flex-col items-center justify-center min-h-[50vh]">
-            <Loader2 className="w-12 h-12 text-violet-400 animate-spin mb-4" />
+            <Loader2 className="w-12 h-12 text-de-accent-ink animate-spin mb-4" />
             <p className="text-white/60">Loading order details...</p>
           </div>
         </main>
@@ -131,7 +131,7 @@ const OrderConfirmation = () => {
               We couldn't find your order. Please check your email for confirmation or contact support.
             </p>
             <Link href="/store">
-              <Button className="bg-violet-600 hover:bg-violet-500 text-white" data-testid="button-back-to-store">
+              <Button className="bg-de-accent hover:bg-de-accent text-white" data-testid="button-back-to-store">
                 <ShoppingBag className="w-4 h-4 mr-2" />
                 Continue Shopping
               </Button>
@@ -159,8 +159,8 @@ const OrderConfirmation = () => {
             transition={{ duration: 0.5 }}
             className="text-center mb-12"
           >
-            <div className="inline-flex items-center justify-center w-20 h-20 rounded-full bg-violet-500/20 mb-6">
-              <CheckCircle className="w-10 h-10 text-violet-400" />
+            <div className="inline-flex items-center justify-center w-20 h-20 rounded-full bg-de-raised mb-6">
+              <CheckCircle className="w-10 h-10 text-de-accent-ink" />
             </div>
 
             <h1 className="text-3xl md:text-4xl font-bold text-white mb-4" data-testid="text-confirmation-title">
@@ -257,7 +257,7 @@ const OrderConfirmation = () => {
               </div>
               <div className="flex justify-between text-lg font-semibold pt-2 border-t border-white/10">
                 <span className="text-white">Total</span>
-                <span className="text-violet-400" data-testid="text-order-total">
+                <span className="text-de-accent-ink" data-testid="text-order-total">
                   {formatCurrency(parseFloat(order?.total || "0"))}
                 </span>
               </div>
@@ -268,18 +268,18 @@ const OrderConfirmation = () => {
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5, delay: 0.2 }}
-            className="bg-gradient-to-r from-violet-500/10 to-purple-500/10 border border-violet-500/20 rounded-xl p-6 md:p-8 mb-8"
+            className="bg-de-raised border border-de-hairline rounded-xl p-6 md:p-8 mb-8"
             data-testid="section-next-steps"
           >
             <h2 className="text-xl font-semibold text-white mb-6 flex items-center gap-2">
-              <FileText className="w-5 h-5 text-violet-400" />
+              <FileText className="w-5 h-5 text-de-accent-ink" />
               What's Next?
             </h2>
 
             <div className="grid md:grid-cols-3 gap-6">
               <div className="flex gap-4">
-                <div className="flex-shrink-0 w-10 h-10 rounded-full bg-violet-500/20 flex items-center justify-center">
-                  <Mail className="w-5 h-5 text-violet-400" />
+                <div className="flex-shrink-0 w-10 h-10 rounded-full bg-de-raised flex items-center justify-center">
+                  <Mail className="w-5 h-5 text-de-accent-ink" />
                 </div>
                 <div>
                   <p className="text-white font-medium mb-1">Confirmation Email</p>
@@ -292,8 +292,8 @@ const OrderConfirmation = () => {
               </div>
 
               <div className="flex gap-4">
-                <div className="flex-shrink-0 w-10 h-10 rounded-full bg-violet-500/20 flex items-center justify-center">
-                  <Clock className="w-5 h-5 text-violet-400" />
+                <div className="flex-shrink-0 w-10 h-10 rounded-full bg-de-raised flex items-center justify-center">
+                  <Clock className="w-5 h-5 text-de-accent-ink" />
                 </div>
                 <div>
                   <p className="text-white font-medium mb-1">
@@ -308,8 +308,8 @@ const OrderConfirmation = () => {
               </div>
 
               <div className="flex gap-4">
-                <div className="flex-shrink-0 w-10 h-10 rounded-full bg-violet-500/20 flex items-center justify-center">
-                  <Package className="w-5 h-5 text-violet-400" />
+                <div className="flex-shrink-0 w-10 h-10 rounded-full bg-de-raised flex items-center justify-center">
+                  <Package className="w-5 h-5 text-de-accent-ink" />
                 </div>
                 <div>
                   <p className="text-white font-medium mb-1">Get Started</p>
@@ -342,7 +342,7 @@ const OrderConfirmation = () => {
 
             <Link href="/portal/dashboard">
               <Button
-                className="bg-violet-600 hover:bg-violet-500 text-white"
+                className="bg-de-accent hover:bg-de-accent text-white"
                 data-testid="button-go-to-portal"
               >
                 Go to Client Portal
@@ -361,14 +361,14 @@ const OrderConfirmation = () => {
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <a
                 href="tel:+13254809870"
-                className="inline-flex items-center gap-2 text-violet-400 hover:text-violet-300 transition-colors"
+                className="inline-flex items-center gap-2 text-de-accent-ink hover:text-de-accent-ink transition-colors"
                 data-testid="link-phone-support"
               >
                 <Phone className="w-4 h-4" />
                 325-480-9870
               </a>
               <Link href="/support/submit-ticket">
-                <span className="inline-flex items-center gap-2 text-violet-400 hover:text-violet-300 transition-colors cursor-pointer" data-testid="link-submit-ticket">
+                <span className="inline-flex items-center gap-2 text-de-accent-ink hover:text-de-accent-ink transition-colors cursor-pointer" data-testid="link-submit-ticket">
                   <MessageSquare className="w-4 h-4" />
                   Submit a Ticket
                 </span>

--- a/client/src/pages/store/ProductDetail.tsx
+++ b/client/src/pages/store/ProductDetail.tsx
@@ -93,7 +93,7 @@ const ProductDetail = () => {
             <h1 className="mb-4 text-3xl font-bold text-white">Product Not Found</h1>
             <p className="mb-8 text-white/60">The product you're looking for doesn't exist.</p>
             <Link href="/store">
-              <Button className="bg-[#5034ff] text-white hover:bg-[#6548ff]">
+              <Button className="bg-de-accent text-white hover:bg-[#6548ff]">
                 <ArrowLeft className="mr-2 h-4 w-4" />
                 Back to Store
               </Button>
@@ -179,11 +179,11 @@ const ProductDetail = () => {
           <div className="mb-4 flex items-center justify-between">
             {isLoggedIn && user ? (
               <div className="flex items-center gap-3">
-                <div className="flex items-center gap-2 rounded-lg border border-[#5034ff]/20 bg-[#5034ff]/10 px-3 py-2">
-                  <User className="h-4 w-4 text-[#a78bfa]" />
+                <div className="flex items-center gap-2 rounded-lg border border-de-accent/20 bg-de-accent/10 px-3 py-2">
+                  <User className="h-4 w-4 text-de-accent-ink" />
                   <span className="text-sm text-white" data-testid="text-user-greeting">
                     Welcome,{" "}
-                    <span className="font-semibold text-[#c4b5fd]">
+                    <span className="font-semibold text-de-accent-ink">
                       {user.fullName || user.username}
                     </span>
                   </span>
@@ -197,7 +197,7 @@ const ProductDetail = () => {
                   variant="ghost"
                   size="sm"
                   onClick={logout}
-                  className="text-white/60 hover:bg-[#5034ff]/10 hover:text-white"
+                  className="text-white/60 hover:bg-de-accent/10 hover:text-white"
                   data-testid="button-store-logout"
                 >
                   <LogOut className="mr-1 h-4 w-4" />
@@ -209,7 +209,7 @@ const ProductDetail = () => {
                 variant="outline"
                 size="sm"
                 onClick={loginRedirect}
-                className="border-none bg-[#5034ff] text-white hover:bg-[#6548ff]"
+                className="border-none bg-de-accent text-white hover:bg-[#6548ff]"
                 data-testid="button-store-login"
               >
                 <User className="mr-2 h-4 w-4" />
@@ -259,7 +259,7 @@ const ProductDetail = () => {
                 categoryBadge={categoryLabels[product.category]}
               />
               {visual.vendor && (
-                <p className="mt-3 text-sm text-white/45">
+                <p className="mt-3 text-sm text-white/55">
                   Powered with <span className="text-white/70">{visual.vendor.name}</span> in the DE
                   stack
                 </p>
@@ -272,7 +272,7 @@ const ProductDetail = () => {
               transition={{ duration: 0.5, delay: 0.1 }}
             >
               <span
-                className="mb-2 block font-mono text-sm text-white/40"
+                className="mb-2 block font-mono text-sm text-white/55"
                 data-testid="product-sku"
               >
                 SKU: {product.sku}
@@ -308,10 +308,10 @@ const ProductDetail = () => {
 
               {(includedHint || relationships?.includedIn) && (
                 <div
-                  className="mb-6 flex items-start gap-3 rounded-xl border border-[#5034ff]/25 bg-[#5034ff]/10 px-4 py-3"
+                  className="mb-6 flex items-start gap-3 rounded-xl border border-de-accent/25 bg-de-accent/10 px-4 py-3"
                   data-testid="product-included-in"
                 >
-                  <Layers className="mt-0.5 h-5 w-5 flex-shrink-0 text-[#a78bfa]" />
+                  <Layers className="mt-0.5 h-5 w-5 flex-shrink-0 text-de-accent-ink" />
                   <div>
                     <p className="text-sm font-medium text-white">How it fits</p>
                     <p className="mt-0.5 text-sm text-white/65">
@@ -329,19 +329,19 @@ const ProductDetail = () => {
                   <div className="space-y-2">
                     <div className="flex flex-wrap items-center gap-3">
                       <span
-                        className="text-3xl font-bold text-[#a78bfa]"
+                        className="text-3xl font-bold text-de-accent-ink"
                         data-testid="product-price"
                       >
                         ${productPricing.price.toFixed(2)}
                       </span>
-                      <span className="text-xl text-white/40 line-through">
+                      <span className="text-xl text-white/55 line-through">
                         ${product.basePrice.toFixed(2)}
                       </span>
                       {product.pricingUnit && (
                         <span className="text-sm text-white/50">per {product.pricingUnit}</span>
                       )}
                     </div>
-                    <div className="flex items-center gap-2 text-[#a78bfa]">
+                    <div className="flex items-center gap-2 text-de-accent-ink">
                       <Tag className="h-4 w-4" />
                       <span className="text-sm font-medium" data-testid="discount-badge">
                         {productPricing.discountPercent}% client discount applied
@@ -351,7 +351,7 @@ const ProductDetail = () => {
                 ) : (
                   <div>
                     <span
-                      className="text-3xl font-bold text-[#a78bfa]"
+                      className="text-3xl font-bold text-de-accent-ink"
                       data-testid="product-price"
                     >
                       {formatPrice(product)}
@@ -365,7 +365,7 @@ const ProductDetail = () => {
                           variant="link"
                           size="sm"
                           onClick={loginRedirect}
-                          className="h-auto p-0 text-[#a78bfa] hover:text-[#c4b5fd]"
+                          className="h-auto p-0 text-de-accent-ink hover:text-de-accent-ink"
                           data-testid="button-login-for-pricing"
                         >
                           <User className="mr-1 h-3 w-3" />
@@ -382,7 +382,7 @@ const ProductDetail = () => {
                 <ul className="space-y-3">
                   {product.features.map((feature, idx) => (
                     <li key={idx} className="flex items-start gap-3" data-testid={`feature-${idx}`}>
-                      <Check className="mt-0.5 h-5 w-5 flex-shrink-0 text-[#a78bfa]" />
+                      <Check className="mt-0.5 h-5 w-5 flex-shrink-0 text-de-accent-ink" />
                       <span className="text-white/70">{feature}</span>
                     </li>
                   ))}
@@ -397,7 +397,7 @@ const ProductDetail = () => {
                   </p>
                   <a href="/book" target="_blank" rel="noopener noreferrer">
                     <Button
-                      className="w-full bg-[#5034ff] py-6 text-lg text-white hover:bg-[#6548ff]"
+                      className="w-full bg-de-accent py-6 text-lg text-white hover:bg-[#6548ff]"
                       data-testid="button-schedule-consultant"
                     >
                       <Calendar className="mr-2 h-5 w-5" />
@@ -425,7 +425,7 @@ const ProductDetail = () => {
                           size="icon"
                           onClick={() => handleQuantityChange(-1)}
                           disabled={quantity <= minQty}
-                          className="border-[#5034ff]/30 bg-[#5034ff]/10 text-white hover:bg-[#5034ff]/20"
+                          className="border-de-accent/30 bg-de-accent/10 text-white hover:bg-de-accent/20"
                           data-testid="button-decrease-qty"
                         >
                           <Minus className="h-4 w-4" />
@@ -440,14 +440,14 @@ const ProductDetail = () => {
                           variant="outline"
                           size="icon"
                           onClick={() => handleQuantityChange(1)}
-                          className="border-[#5034ff]/30 bg-[#5034ff]/10 text-white hover:bg-[#5034ff]/20"
+                          className="border-de-accent/30 bg-de-accent/10 text-white hover:bg-de-accent/20"
                           data-testid="button-increase-qty"
                         >
                           <Plus className="h-4 w-4" />
                         </Button>
                       </div>
                       {minQty > 1 && (
-                        <span className="text-xs text-white/40">Min: {minQty}</span>
+                        <span className="text-xs text-white/55">Min: {minQty}</span>
                       )}
                     </div>
                   )}
@@ -455,7 +455,7 @@ const ProductDetail = () => {
                   {product.isClientOnly && !isLoggedIn ? (
                     <div className="space-y-3">
                       <Button
-                        className="w-full bg-[#5034ff] py-6 text-lg text-white hover:bg-[#6548ff]"
+                        className="w-full bg-de-accent py-6 text-lg text-white hover:bg-[#6548ff]"
                         onClick={loginRedirect}
                         data-testid="button-login-to-purchase"
                       >
@@ -470,7 +470,7 @@ const ProductDetail = () => {
                   ) : configurable ? (
                     <div className="space-y-3">
                       <Button
-                        className="w-full bg-[#5034ff] py-6 text-lg text-white hover:bg-[#6548ff]"
+                        className="w-full bg-de-accent py-6 text-lg text-white hover:bg-[#6548ff]"
                         onClick={() => setConfigureOpen(true)}
                         data-testid="button-configure"
                       >
@@ -490,14 +490,14 @@ const ProductDetail = () => {
                   ) : (
                     <>
                       <Button
-                        className="w-full bg-[#5034ff] py-6 text-lg text-white hover:bg-[#6548ff]"
+                        className="w-full bg-de-accent py-6 text-lg text-white hover:bg-[#6548ff]"
                         onClick={handleAddToCart}
                         data-testid="button-add-to-cart"
                       >
                         <ShoppingCart className="mr-2 h-5 w-5" />
                         Add to Cart - ${(productPricing.price * quantity).toFixed(2)}
                         {productPricing.hasDiscount && (
-                          <span className="ml-2 text-sm text-[#c4b5fd]">
+                          <span className="ml-2 text-sm text-de-accent-ink">
                             (You save $
                             {(
                               (product.basePrice - productPricing.price) *
@@ -508,7 +508,7 @@ const ProductDetail = () => {
                         )}
                       </Button>
                       {product.isClientOnly && (
-                        <p className="flex items-center justify-center gap-1 text-center text-sm text-[#a78bfa]/80">
+                        <p className="flex items-center justify-center gap-1 text-center text-sm text-de-accent-ink/80">
                           <Check className="h-4 w-4" />
                           Client-only product - You have access
                         </p>
@@ -553,7 +553,7 @@ const ProductDetail = () => {
               data-testid="product-relationships"
             >
               <div className="mb-6 flex items-center gap-2">
-                <Sparkles className="h-5 w-5 text-[#a78bfa]" />
+                <Sparkles className="h-5 w-5 text-de-accent-ink" />
                 <h2 className="text-2xl font-bold text-white">Solution relationships</h2>
               </div>
               <div className="grid gap-6 lg:grid-cols-2">
@@ -568,14 +568,14 @@ const ProductDetail = () => {
                           <Link href={`/store/product/${related.sku}`}>
                             <span className="group flex items-center justify-between gap-3 rounded-lg border border-transparent px-2 py-2 transition-colors hover:border-white/10 hover:bg-white/[0.03]">
                               <span>
-                                <span className="block font-medium text-white group-hover:text-[#c4b5fd]">
+                                <span className="block font-medium text-white group-hover:text-de-accent-ink">
                                   {related.name}
                                 </span>
-                                <span className="block text-sm text-white/45 line-clamp-1">
+                                <span className="block text-sm text-white/55 line-clamp-1">
                                   {getOutcomeLead(related)}
                                 </span>
                               </span>
-                              <ArrowRight className="h-4 w-4 flex-shrink-0 text-white/30 group-hover:text-[#a78bfa]" />
+                              <ArrowRight className="h-4 w-4 flex-shrink-0 text-white/55 group-hover:text-de-accent-ink" />
                             </span>
                           </Link>
                         </li>
@@ -594,14 +594,14 @@ const ProductDetail = () => {
                           <Link href={`/store/product/${related.sku}`}>
                             <span className="group flex items-center justify-between gap-3 rounded-lg border border-transparent px-2 py-2 transition-colors hover:border-white/10 hover:bg-white/[0.03]">
                               <span>
-                                <span className="block font-medium text-white group-hover:text-[#c4b5fd]">
+                                <span className="block font-medium text-white group-hover:text-de-accent-ink">
                                   {related.name}
                                 </span>
-                                <span className="block text-sm text-white/45">
+                                <span className="block text-sm text-white/55">
                                   {formatPrice(related)}
                                 </span>
                               </span>
-                              <ArrowRight className="h-4 w-4 flex-shrink-0 text-white/30 group-hover:text-[#a78bfa]" />
+                              <ArrowRight className="h-4 w-4 flex-shrink-0 text-white/55 group-hover:text-de-accent-ink" />
                             </span>
                           </Link>
                         </li>
@@ -625,7 +625,7 @@ const ProductDetail = () => {
                 {relatedProducts.map((related) => (
                   <Link key={related.id} href={`/store/product/${related.sku}`}>
                     <div
-                      className="group h-full cursor-pointer overflow-hidden rounded-xl border border-white/10 bg-white/[0.03] transition-all duration-300 hover:border-[#5034ff]/30"
+                      className="group h-full cursor-pointer overflow-hidden rounded-xl border border-white/10 bg-white/[0.03] transition-all duration-300 hover:border-de-accent/30"
                       data-testid={`related-${related.id}`}
                     >
                       <ProductMedia
@@ -635,7 +635,7 @@ const ProductDetail = () => {
                       />
                       <div className="p-5">
                         <h3
-                          className="mb-2 line-clamp-1 font-semibold text-white transition-colors group-hover:text-[#c4b5fd]"
+                          className="mb-2 line-clamp-1 font-semibold text-white transition-colors group-hover:text-de-accent-ink"
                           title={related.name}
                         >
                           {related.name}
@@ -644,10 +644,10 @@ const ProductDetail = () => {
                           {getOutcomeLead(related)}
                         </p>
                         <div className="flex items-center justify-between">
-                          <span className="font-semibold text-[#a78bfa]">
+                          <span className="font-semibold text-de-accent-ink">
                             {formatPrice(related)}
                           </span>
-                          <ArrowRight className="h-4 w-4 text-white/30 transition-colors group-hover:text-[#a78bfa]" />
+                          <ArrowRight className="h-4 w-4 text-white/55 transition-colors group-hover:text-de-accent-ink" />
                         </div>
                       </div>
                     </div>
@@ -667,18 +667,18 @@ const ProductDetail = () => {
           <div className="mx-auto flex max-w-7xl items-center gap-3">
             <div className="min-w-0 flex-1">
               <p className="truncate text-sm font-medium text-white">{product.name}</p>
-              <p className="text-sm text-[#a78bfa]">{formatPrice(product)}</p>
+              <p className="text-sm text-de-accent-ink">{formatPrice(product)}</p>
             </div>
             {configurable ? (
               <Button
-                className="bg-[#5034ff] text-white hover:bg-[#6548ff]"
+                className="bg-de-accent text-white hover:bg-[#6548ff]"
                 onClick={() => setConfigureOpen(true)}
               >
                 Configure
               </Button>
             ) : (
               <Button
-                className="bg-[#5034ff] text-white hover:bg-[#6548ff]"
+                className="bg-de-accent text-white hover:bg-[#6548ff]"
                 onClick={handleAddToCart}
               >
                 Add

--- a/client/src/pages/store/QuoteConfirmation.tsx
+++ b/client/src/pages/store/QuoteConfirmation.tsx
@@ -58,7 +58,7 @@ const QuoteConfirmation = () => {
         <MegaMenu />
         <main className="de-nav-clear pb-20">
           <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-            <Loader2 className="w-12 h-12 text-violet-400 animate-spin mx-auto" />
+            <Loader2 className="w-12 h-12 text-de-accent-ink animate-spin mx-auto" />
             <p className="text-white/60 mt-4">Loading quote details...</p>
           </div>
         </main>
@@ -78,7 +78,7 @@ const QuoteConfirmation = () => {
               animate={{ opacity: 1, y: 0 }}
               className="bg-white/5 border border-white/10 rounded-xl p-12"
             >
-              <FileText className="w-16 h-16 text-white/40 mx-auto mb-6" />
+              <FileText className="w-16 h-16 text-white/55 mx-auto mb-6" />
               <h1 className="text-2xl font-bold text-white mb-4" data-testid="text-error-title">
                 Quote Not Found
               </h1>
@@ -86,7 +86,7 @@ const QuoteConfirmation = () => {
                 We couldn't find the quote request you're looking for.
               </p>
               <Link href="/store">
-                <Button className="bg-violet-600 hover:bg-violet-500 text-white" data-testid="button-back-to-store">
+                <Button className="bg-de-accent hover:bg-de-accent text-white" data-testid="button-back-to-store">
                   Back to Store
                 </Button>
               </Link>
@@ -130,7 +130,7 @@ const QuoteConfirmation = () => {
             <div className="bg-white/5 border border-white/10 rounded-xl p-8 mb-8" data-testid="section-quote-details">
               <div className="text-center mb-8">
                 <p className="text-white/60 text-sm uppercase tracking-wide mb-2">Quote Request Number</p>
-                <p className="text-3xl font-mono font-bold text-violet-400" data-testid="text-quote-number">
+                <p className="text-3xl font-mono font-bold text-de-accent-ink" data-testid="text-quote-number">
                   {quoteRequest.quoteNumber}
                 </p>
               </div>
@@ -138,7 +138,7 @@ const QuoteConfirmation = () => {
               <div className="grid md:grid-cols-2 gap-6 mb-8">
                 <div className="bg-white/5 rounded-lg p-4">
                   <div className="flex items-center gap-3 mb-2">
-                    <Mail className="w-5 h-5 text-violet-400" />
+                    <Mail className="w-5 h-5 text-de-accent-ink" />
                     <span className="text-white font-medium">Email</span>
                   </div>
                   <p className="text-white/70 ml-8" data-testid="text-contact-email">
@@ -148,7 +148,7 @@ const QuoteConfirmation = () => {
 
                 <div className="bg-white/5 rounded-lg p-4">
                   <div className="flex items-center gap-3 mb-2">
-                    <Calendar className="w-5 h-5 text-violet-400" />
+                    <Calendar className="w-5 h-5 text-de-accent-ink" />
                     <span className="text-white font-medium">Submitted</span>
                   </div>
                   <p className="text-white/70 ml-8" data-testid="text-submitted-date">
@@ -172,16 +172,16 @@ const QuoteConfirmation = () => {
               )}
             </div>
 
-            <div className="bg-gradient-to-r from-violet-500/10 to-purple-500/10 border border-violet-500/30 rounded-xl p-8 mb-8" data-testid="section-next-steps">
+            <div className="bg-de-raised border border-de-hairline rounded-xl p-8 mb-8" data-testid="section-next-steps">
               <h2 className="text-xl font-semibold text-white mb-6 flex items-center gap-2">
-                <Clock className="w-5 h-5 text-violet-400" />
+                <Clock className="w-5 h-5 text-de-accent-ink" />
                 What Happens Next
               </h2>
 
               <div className="space-y-6">
                 <div className="flex gap-4">
-                  <div className="flex-shrink-0 w-8 h-8 bg-violet-500/20 rounded-full flex items-center justify-center">
-                    <span className="text-violet-400 font-bold text-sm">1</span>
+                  <div className="flex-shrink-0 w-8 h-8 bg-de-raised rounded-full flex items-center justify-center">
+                    <span className="text-de-accent-ink font-bold text-sm">1</span>
                   </div>
                   <div>
                     <h3 className="text-white font-medium mb-1">Review</h3>
@@ -192,8 +192,8 @@ const QuoteConfirmation = () => {
                 </div>
 
                 <div className="flex gap-4">
-                  <div className="flex-shrink-0 w-8 h-8 bg-violet-500/20 rounded-full flex items-center justify-center">
-                    <span className="text-violet-400 font-bold text-sm">2</span>
+                  <div className="flex-shrink-0 w-8 h-8 bg-de-raised rounded-full flex items-center justify-center">
+                    <span className="text-de-accent-ink font-bold text-sm">2</span>
                   </div>
                   <div>
                     <h3 className="text-white font-medium mb-1">Consultation</h3>
@@ -204,8 +204,8 @@ const QuoteConfirmation = () => {
                 </div>
 
                 <div className="flex gap-4">
-                  <div className="flex-shrink-0 w-8 h-8 bg-violet-500/20 rounded-full flex items-center justify-center">
-                    <span className="text-violet-400 font-bold text-sm">3</span>
+                  <div className="flex-shrink-0 w-8 h-8 bg-de-raised rounded-full flex items-center justify-center">
+                    <span className="text-de-accent-ink font-bold text-sm">3</span>
                   </div>
                   <div>
                     <h3 className="text-white font-medium mb-1">Custom Quote</h3>
@@ -222,7 +222,7 @@ const QuoteConfirmation = () => {
               <div className="flex flex-col md:flex-row gap-4">
                 <a
                   href="tel:+13254809870"
-                  className="flex items-center gap-3 text-white/70 hover:text-violet-400 transition-colors"
+                  className="flex items-center gap-3 text-white/70 hover:text-de-accent-ink transition-colors"
                   data-testid="link-phone"
                 >
                   <Phone className="w-5 h-5" />
@@ -230,7 +230,7 @@ const QuoteConfirmation = () => {
                 </a>
                 <a
                   href="mailto:sales@digerati-experts.com"
-                  className="flex items-center gap-3 text-white/70 hover:text-violet-400 transition-colors"
+                  className="flex items-center gap-3 text-white/70 hover:text-de-accent-ink transition-colors"
                   data-testid="link-email"
                 >
                   <Mail className="w-5 h-5" />
@@ -252,7 +252,7 @@ const QuoteConfirmation = () => {
               </Link>
               <Link href="/store">
                 <Button
-                  className="bg-violet-600 hover:bg-violet-500 text-white"
+                  className="bg-de-accent hover:bg-de-accent text-white"
                   data-testid="button-continue-browsing"
                 >
                   Continue Browsing

--- a/client/src/pages/store/QuoteRequest.tsx
+++ b/client/src/pages/store/QuoteRequest.tsx
@@ -166,7 +166,7 @@ const QuoteRequest = () => {
               transition={{ duration: 0.5 }}
               className="bg-white/5 border border-white/10 rounded-xl p-12"
             >
-              <Package className="w-16 h-16 text-white/40 mx-auto mb-6" />
+              <Package className="w-16 h-16 text-white/55 mx-auto mb-6" />
               <h1 className="text-2xl font-bold text-white mb-4" data-testid="text-empty-cart-title">
                 No Items to Quote
               </h1>
@@ -174,7 +174,7 @@ const QuoteRequest = () => {
                 Add items to your cart before requesting a quote.
               </p>
               <Link href="/store">
-                <Button className="bg-violet-600 hover:bg-violet-500 text-white" data-testid="button-browse-store">
+                <Button className="bg-de-accent hover:bg-de-accent text-white" data-testid="button-browse-store">
                   Browse Store
                 </Button>
               </Link>
@@ -229,7 +229,7 @@ const QuoteRequest = () => {
               <div className="lg:col-span-3 space-y-8">
                 <div className="bg-white/5 border border-white/10 rounded-xl p-6" data-testid="section-contact-info">
                   <h2 className="text-xl font-semibold text-white mb-6 flex items-center gap-2">
-                    <FileText className="w-5 h-5 text-violet-400" />
+                    <FileText className="w-5 h-5 text-de-accent-ink" />
                     Contact Information
                   </h2>
 
@@ -243,7 +243,7 @@ const QuoteRequest = () => {
                           id="name"
                           {...register("name")}
                           placeholder="John Smith"
-                          className="mt-1 bg-white/5 border-white/20 text-white placeholder:text-white/40 focus:border-violet-500"
+                          className="mt-1 bg-white/5 border-white/20 text-white placeholder:text-white/55 focus:border-de-hairline"
                           data-testid="input-name"
                         />
                         {errors.name && (
@@ -261,7 +261,7 @@ const QuoteRequest = () => {
                           type="email"
                           {...register("email")}
                           placeholder="john@company.com"
-                          className="mt-1 bg-white/5 border-white/20 text-white placeholder:text-white/40 focus:border-violet-500"
+                          className="mt-1 bg-white/5 border-white/20 text-white placeholder:text-white/55 focus:border-de-hairline"
                           data-testid="input-email"
                         />
                         {errors.email && (
@@ -282,7 +282,7 @@ const QuoteRequest = () => {
                           type="tel"
                           {...register("phone")}
                           placeholder="(555) 123-4567"
-                          className="mt-1 bg-white/5 border-white/20 text-white placeholder:text-white/40 focus:border-violet-500"
+                          className="mt-1 bg-white/5 border-white/20 text-white placeholder:text-white/55 focus:border-de-hairline"
                           data-testid="input-phone"
                         />
                       </div>
@@ -294,7 +294,7 @@ const QuoteRequest = () => {
                           id="company"
                           {...register("company")}
                           placeholder="Acme Corp"
-                          className="mt-1 bg-white/5 border-white/20 text-white placeholder:text-white/40 focus:border-violet-500"
+                          className="mt-1 bg-white/5 border-white/20 text-white placeholder:text-white/55 focus:border-de-hairline"
                           data-testid="input-company"
                         />
                       </div>
@@ -309,33 +309,33 @@ const QuoteRequest = () => {
                         {...register("message")}
                         placeholder="Tell us about your specific requirements or questions..."
                         rows={4}
-                        className="mt-1 bg-white/5 border-white/20 text-white placeholder:text-white/40 focus:border-violet-500 resize-none"
+                        className="mt-1 bg-white/5 border-white/20 text-white placeholder:text-white/55 focus:border-de-hairline resize-none"
                         data-testid="input-message"
                       />
                     </div>
                   </form>
                 </div>
 
-                <div className="bg-violet-500/10 border border-violet-500/30 rounded-xl p-6" data-testid="section-quote-info">
+                <div className="bg-de-raised border border-de-hairline rounded-xl p-6" data-testid="section-quote-info">
                   <h3 className="text-lg font-semibold text-white mb-3 flex items-center gap-2">
-                    <CheckCircle className="w-5 h-5 text-violet-400" />
+                    <CheckCircle className="w-5 h-5 text-de-accent-ink" />
                     What to Expect
                   </h3>
                   <ul className="space-y-2 text-white/70 text-sm">
                     <li className="flex items-start gap-2">
-                      <span className="text-violet-400">•</span>
+                      <span className="text-de-accent-ink">•</span>
                       A Digerati Experts consultant will review your request
                     </li>
                     <li className="flex items-start gap-2">
-                      <span className="text-violet-400">•</span>
+                      <span className="text-de-accent-ink">•</span>
                       You'll receive a detailed quote within 1 business day
                     </li>
                     <li className="flex items-start gap-2">
-                      <span className="text-violet-400">•</span>
+                      <span className="text-de-accent-ink">•</span>
                       Custom pricing based on your specific needs
                     </li>
                     <li className="flex items-start gap-2">
-                      <span className="text-violet-400">•</span>
+                      <span className="text-de-accent-ink">•</span>
                       No obligation - review the quote at your convenience
                     </li>
                   </ul>
@@ -345,7 +345,7 @@ const QuoteRequest = () => {
               <div className="lg:col-span-2">
                 <div className="bg-white/5 border border-white/10 rounded-xl p-6 sticky top-28" data-testid="section-items-summary">
                   <h2 className="text-xl font-semibold text-white mb-6 flex items-center gap-2">
-                    <MessageSquare className="w-5 h-5 text-violet-400" />
+                    <MessageSquare className="w-5 h-5 text-de-accent-ink" />
                     Items to Quote
                   </h2>
 
@@ -408,7 +408,7 @@ const QuoteRequest = () => {
                   <div className="border-t border-white/20 pt-4 space-y-2 mb-6">
                     <div className="flex justify-between text-lg font-semibold">
                       <span className="text-white">Estimated Total</span>
-                      <span className="text-violet-400" data-testid="text-estimated-total">
+                      <span className="text-de-accent-ink" data-testid="text-estimated-total">
                         {formatCurrency(getCartTotal())}
                       </span>
                     </div>
@@ -421,7 +421,7 @@ const QuoteRequest = () => {
                     type="submit"
                     form="quote-request-form"
                     disabled={isSubmitting}
-                    className="w-full bg-violet-600 hover:bg-violet-500 text-white py-6 text-lg font-semibold"
+                    className="w-full bg-de-accent hover:bg-de-accent text-white py-6 text-lg font-semibold"
                     data-testid="button-submit-quote"
                   >
                     {isSubmitting ? (

--- a/client/src/pages/store/StoreLanding.tsx
+++ b/client/src/pages/store/StoreLanding.tsx
@@ -144,16 +144,16 @@ const StoreLanding = () => {
           <div className="mb-4 flex items-center justify-between">
             {isLoggedIn && user ? (
               <div className="flex items-center gap-3">
-                <div className="flex items-center gap-2 rounded-lg border border-[#5034ff]/20 bg-[#5034ff]/10 px-3 py-2">
-                  <User className="h-4 w-4 text-[#a78bfa]" />
+                <div className="flex items-center gap-2 rounded-lg border border-de-accent/20 bg-de-accent/10 px-3 py-2">
+                  <User className="h-4 w-4 text-de-accent-ink" />
                   <span className="text-sm text-white" data-testid="text-user-greeting">
                     Welcome,{" "}
-                    <span className="font-semibold text-[#c4b5fd]">
+                    <span className="font-semibold text-de-accent-ink">
                       {user.fullName || user.username}
                     </span>
                   </span>
                   {clientType !== "public" && (
-                    <span className="ml-2 rounded-full bg-[#5034ff]/20 px-2 py-0.5 text-xs font-medium text-[#c4b5fd]">
+                    <span className="ml-2 rounded-full bg-de-accent/20 px-2 py-0.5 text-xs font-medium text-de-accent-ink">
                       {clientType === "managed" ? "Managed Client" : "Co-Managed Client"}
                     </span>
                   )}
@@ -162,7 +162,7 @@ const StoreLanding = () => {
                   variant="ghost"
                   size="sm"
                   onClick={logout}
-                  className="text-white/60 hover:bg-[#5034ff]/10 hover:text-white"
+                  className="text-white/60 hover:bg-de-accent/10 hover:text-white"
                   data-testid="button-store-logout"
                 >
                   <LogOut className="mr-1 h-4 w-4" />
@@ -174,7 +174,7 @@ const StoreLanding = () => {
                 <Button
                   variant="outline"
                   size="sm"
-                  className="h-11 border-none bg-[#5034ff] px-5 text-base text-white hover:bg-[#6548ff]"
+                  className="h-11 border-none bg-de-accent px-5 text-base text-white hover:bg-[#6548ff]"
                   data-testid="button-store-login"
                 >
                   <User className="mr-2 h-4 w-4" />
@@ -193,13 +193,13 @@ const StoreLanding = () => {
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.5 }}
               >
-                <div className="mb-6 inline-flex items-center gap-2 rounded-full border border-[#5034ff]/25 bg-[#5034ff]/10 px-4 py-2">
-                  <Package className="h-4 w-4 text-[#a78bfa]" />
-                  <span className="text-sm text-[#c4b5fd]">IT Services & Solutions</span>
+                <div className="mb-6 inline-flex items-center gap-2 rounded-full border border-de-accent/25 bg-de-accent/10 px-4 py-2">
+                  <Package className="h-4 w-4 text-de-accent-ink" />
+                  <span className="text-sm text-de-accent-ink">IT Services & Solutions</span>
                 </div>
                 <h1 className="mb-4 text-4xl font-bold text-white md:text-5xl lg:text-6xl xl:text-7xl">
                   Tell us what you&apos;re trying to{" "}
-                  <span className="text-[#a78bfa]">accomplish</span>
+                  <span className="text-de-accent-ink">accomplish</span>
                 </h1>
                 <p className="max-w-3xl text-xl leading-relaxed text-white/70 md:text-2xl">
                   Guided storefront for managed packages and à la carte services — shop by outcome,
@@ -207,7 +207,7 @@ const StoreLanding = () => {
                 </p>
                 <div className="mt-7 flex flex-wrap gap-3">
                   <Button
-                    className="h-12 bg-[#5034ff] px-6 text-base text-white hover:bg-[#6548ff]"
+                    className="h-12 bg-de-accent px-6 text-base text-white hover:bg-[#6548ff]"
                     onClick={() => setGuidedOpen(true)}
                     data-testid="button-build-solution"
                   >
@@ -266,12 +266,12 @@ const StoreLanding = () => {
             <div className="grid gap-8 md:grid-cols-2">
               <motion.div
                 variants={itemVariants}
-                className="group relative overflow-hidden rounded-2xl border border-[#5034ff]/30 bg-[#141414] p-9 transition-all duration-300 hover:-translate-y-1"
+                className="group relative overflow-hidden rounded-2xl border border-de-accent/30 bg-[#141414] p-9 transition-all duration-300 hover:-translate-y-1"
                 data-testid="card-managed-clients"
               >
                 <div className="relative z-10">
-                  <div className="mb-6 flex h-16 w-16 items-center justify-center rounded-xl border border-[#5034ff]/30 bg-[#5034ff]/15">
-                    <Building className="h-8 w-8 text-[#a78bfa]" />
+                  <div className="mb-6 flex h-16 w-16 items-center justify-center rounded-xl border border-de-accent/30 bg-de-accent/15">
+                    <Building className="h-8 w-8 text-de-accent-ink" />
                   </div>
                   <h2 className="mb-3 text-2xl font-bold text-white md:text-3xl">Managed Clients</h2>
                   <p className="mb-4 text-base leading-relaxed text-white/65 md:text-lg">
@@ -279,7 +279,7 @@ const StoreLanding = () => {
                     ProActive Ecosystem plans include everything you need in one predictable monthly
                     subscription.
                   </p>
-                  <div className="mb-6 flex items-center gap-2 text-base text-[#c4b5fd]">
+                  <div className="mb-6 flex items-center gap-2 text-base text-de-accent-ink">
                     <Lock className="h-4 w-4" />
                     <span>Contract-based services · Schedule a consultation</span>
                   </div>
@@ -289,7 +289,7 @@ const StoreLanding = () => {
                     </span>
                     <Link href="/store/managed">
                       <Button
-                        className="h-11 bg-[#5034ff] px-5 text-base text-white hover:bg-[#6548ff]"
+                        className="h-11 bg-de-accent px-5 text-base text-white hover:bg-[#6548ff]"
                         data-testid="button-view-managed"
                       >
                         View Packages
@@ -302,12 +302,12 @@ const StoreLanding = () => {
 
               <motion.div
                 variants={itemVariants}
-                className="group relative overflow-hidden rounded-2xl border border-white/10 bg-[#141414] p-9 transition-all duration-300 hover:-translate-y-1 hover:border-[#5034ff]/30"
+                className="group relative overflow-hidden rounded-2xl border border-white/10 bg-[#141414] p-9 transition-all duration-300 hover:-translate-y-1 hover:border-de-accent/30"
                 data-testid="card-comanaged-clients"
               >
                 <div className="relative z-10">
-                  <div className="mb-6 flex h-16 w-16 items-center justify-center rounded-xl border border-[#5034ff]/30 bg-[#5034ff]/15">
-                    <Users className="h-8 w-8 text-[#a78bfa]" />
+                  <div className="mb-6 flex h-16 w-16 items-center justify-center rounded-xl border border-de-accent/30 bg-de-accent/15">
+                    <Users className="h-8 w-8 text-de-accent-ink" />
                   </div>
                   <h2 className="mb-3 text-2xl font-bold text-white md:text-3xl">Co-Managed Clients</h2>
                   <p className="mb-4 text-base leading-relaxed text-white/65 md:text-lg">
@@ -324,7 +324,7 @@ const StoreLanding = () => {
                     </span>
                     <Link href="/store/co-managed">
                       <Button
-                        className="h-11 border-none bg-[#5034ff] px-5 text-base text-white hover:bg-[#6548ff]"
+                        className="h-11 border-none bg-de-accent px-5 text-base text-white hover:bg-[#6548ff]"
                         data-testid="button-view-comanaged"
                       >
                         Browse Products
@@ -388,16 +388,16 @@ const StoreLanding = () => {
                   <motion.div key={category} variants={itemVariants}>
                     <Link href={`/store/co-managed?category=${category}`}>
                       <div
-                        className="group h-full cursor-pointer rounded-xl border border-white/10 bg-[#141414] p-4 text-center transition-all duration-300 hover:border-[#5034ff]/30 hover:bg-[#171717]"
+                        className="group h-full cursor-pointer rounded-xl border border-white/10 bg-[#141414] p-4 text-center transition-all duration-300 hover:border-de-accent/30 hover:bg-[#171717]"
                         data-testid={`category-${category}`}
                       >
-                        <div className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-lg border border-white/10 bg-white/[0.04] transition-colors group-hover:border-[#5034ff]/30 group-hover:bg-[#5034ff]/15">
-                          <Icon className="h-5 w-5 text-[#a78bfa]" />
+                        <div className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-lg border border-white/10 bg-white/[0.04] transition-colors group-hover:border-de-accent/30 group-hover:bg-de-accent/15">
+                          <Icon className="h-5 w-5 text-de-accent-ink" />
                         </div>
                         <h3 className="mb-1 text-sm font-medium text-white">
                           {categoryLabels[category]}
                         </h3>
-                        <p className="text-xs text-white/40">{productCount} items</p>
+                        <p className="text-xs text-white/55">{productCount} items</p>
                       </div>
                     </Link>
                   </motion.div>
@@ -474,7 +474,7 @@ const StoreLanding = () => {
               <a href="/book">
                 <Button
                   size="lg"
-                  className="h-12 bg-[#5034ff] px-6 text-white hover:bg-[#6548ff]"
+                  className="h-12 bg-de-accent px-6 text-white hover:bg-[#6548ff]"
                   data-testid="button-schedule-consult"
                 >
                   Schedule Free Consultation

--- a/client/src/pages/support/KnowledgeBase.tsx
+++ b/client/src/pages/support/KnowledgeBase.tsx
@@ -144,7 +144,7 @@ export default function KnowledgeBase() {
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <a 
               href="/support/submit-ticket" 
-              className="inline-flex items-center justify-center bg-white text-de-accent hover:bg-de-paper-raised px-8 py-3 rounded-lg font-semibold transition-all hover:shadow-lg"
+              className="inline-flex items-center justify-center bg-white text-[#0e7490] hover:bg-de-paper-raised px-8 py-3 rounded-lg font-semibold transition-all hover:shadow-lg"
               data-testid="button-submit-ticket"
             >
               Submit Support Ticket

--- a/client/src/pages/support/KnowledgeBase.tsx
+++ b/client/src/pages/support/KnowledgeBase.tsx
@@ -54,15 +54,15 @@ export default function KnowledgeBase() {
         {/* Enhanced Search Bar */}
         <div className="max-w-2xl mx-auto w-full">
           <div className="relative group">
-            <div className="absolute inset-0 bg-gradient-to-r from-purple-400 to-blue-400 rounded-xl blur opacity-0 group-hover:opacity-20 transition-all" />
-            <div className="relative flex items-center bg-white/10 backdrop-blur-sm rounded-xl border border-white/20 group-hover:border-purple-400/50 transition-all">
+            <div className="absolute inset-0 bg-de-raised rounded-xl blur opacity-0 group-hover:opacity-20 transition-all" />
+            <div className="relative flex items-center bg-white/10 backdrop-blur-sm rounded-xl border border-white/20 group-hover:border-de-hairline transition-all">
               <Search className="absolute left-4 h-5 w-5 text-gray-400" />
               <Input
                 type="text"
                 placeholder="Search knowledge base..."
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
-                className="pl-12 pr-4 py-3 text-lg border-0 bg-transparent text-white placeholder:text-gray-500"
+                className="pl-12 pr-4 py-3 text-lg border-0 bg-transparent text-white placeholder:text-white/70"
                 data-testid="input-search-kb"
               />
             </div>
@@ -85,11 +85,11 @@ export default function KnowledgeBase() {
                 <div className="grid md:grid-cols-2 gap-4">
                   {cat.articles.map((article, i) => (
                     <div key={i} className="group cursor-pointer">
-                      <Card className="h-full bg-white/5 backdrop-blur-sm border border-white/10 hover:border-purple-400/50 transition-all">
+                      <Card className="h-full bg-white/5 backdrop-blur-sm border border-white/10 hover:border-de-hairline transition-all">
                         <CardHeader>
                           <div className="flex items-start justify-between mb-2">
-                            <CardTitle className="text-lg text-white group-hover:text-purple-400 transition-colors">{article.title}</CardTitle>
-                            <Eye className="h-4 w-4 text-gray-400 group-hover:text-purple-400" />
+                            <CardTitle className="text-lg text-white group-hover:text-de-accent-ink transition-colors">{article.title}</CardTitle>
+                            <Eye className="h-4 w-4 text-gray-400 group-hover:text-de-accent-ink" />
                           </div>
                         </CardHeader>
                         <CardContent>
@@ -113,13 +113,13 @@ export default function KnowledgeBase() {
           <div className="grid md:grid-cols-3 gap-6">
             {[
               { icon: Video, title: "Video Tutorials", desc: "Step-by-step guides", color: "from-red-500 to-pink-500", cta: "Watch Videos" },
-              { icon: FileText, title: "Documentation", desc: "Technical references", color: "from-blue-500 to-indigo-500", cta: "View Docs" },
+              { icon: FileText, title: "Documentation", desc: "Technical references", color: "from-blue-500 ", cta: "View Docs" },
               { icon: Zap, title: "Quick Tips", desc: "Best practices", color: "from-amber-500 to-orange-500", cta: "Read Tips" }
             ].map((resource, idx) => {
               const Icon = resource.icon;
               return (
                 <div key={idx} className="group">
-                  <Card className="h-full bg-white/5 backdrop-blur-sm border border-white/10 group-hover:border-purple-400/50 transition-all">
+                  <Card className="h-full bg-white/5 backdrop-blur-sm border border-white/10 group-hover:border-de-hairline transition-all">
                     <CardContent className="pt-6">
                       <div className={`w-12 h-12 rounded-lg bg-gradient-to-r ${resource.color} text-white flex items-center justify-center mb-4 group-hover:scale-110 transition-transform`}>
                         <Icon className="h-6 w-6" />
@@ -138,13 +138,13 @@ export default function KnowledgeBase() {
         </div>
 
         {/* CTA */}
-        <div className="bg-gradient-to-r from-purple-600 to-blue-600 rounded-xl p-8 text-center text-white">
+        <div className="bg-de-raised rounded-xl p-8 text-center text-white">
           <h2 className="text-3xl font-bold mb-4">Still Need Help?</h2>
-          <p className="text-lg mb-6 text-purple-100">Our MSP support team is ready to assist 24/7.</p>
+          <p className="text-lg mb-6 text-white/80">Our MSP support team is ready to assist 24/7.</p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <a 
               href="/support/submit-ticket" 
-              className="inline-flex items-center justify-center bg-white text-purple-700 hover:bg-purple-50 px-8 py-3 rounded-lg font-semibold transition-all hover:shadow-lg"
+              className="inline-flex items-center justify-center bg-white text-de-accent hover:bg-de-paper-raised px-8 py-3 rounded-lg font-semibold transition-all hover:shadow-lg"
               data-testid="button-submit-ticket"
             >
               Submit Support Ticket

--- a/client/src/pages/support/RemoteSupport.tsx
+++ b/client/src/pages/support/RemoteSupport.tsx
@@ -6,7 +6,7 @@ export default function RemoteSupport() {
   const features = [
     { icon: Clock, title: "Instant Connection", color: "from-blue-500 to-cyan-500", points: ["Connect in under 2 minutes", "No software required", "Windows, Mac, Linux"] },
     { icon: Shield, title: "Secure & Encrypted", color: "from-green-500 to-emerald-500", points: ["End-to-end encryption", "Session recording", "HIPAA-aligned session controls"] },
-    { icon: RefreshCw, title: "Screen Sharing", color: "from-purple-500 to-indigo-500", points: ["Full control capability", "Multi-monitor support", "File transfer included"] },
+    { icon: RefreshCw, title: "Screen Sharing", color: " ", points: ["Full control capability", "Multi-monitor support", "File transfer included"] },
     { icon: Zap, title: "24/7 Availability", color: "from-amber-500 to-orange-500", points: ["Round-the-clock support", "15-min response time", "Senior engineer escalation"] }
   ];
 
@@ -14,7 +14,7 @@ export default function RemoteSupport() {
     <PageTemplate
       title="Remote Support"
       subtitle="Instant, secure remote assistance from our expert MSP technicians"
-      gradientColors="from-blue-600 via-indigo-600 to-violet-600"
+      gradientColors="from-blue-600  "
     >
       <div className="space-y-16">
         {/* How It Works */}
@@ -70,7 +70,7 @@ export default function RemoteSupport() {
                 )}
                 <Card className="text-center bg-white/5 backdrop-blur-sm border border-white/10">
                   <CardContent className="pt-6">
-                    <div className="w-12 h-12 rounded-full bg-gradient-to-r from-blue-500 to-indigo-500 text-white flex items-center justify-center font-bold mx-auto mb-4">
+                    <div className="w-12 h-12 rounded-full bg-de-raised text-white flex items-center justify-center font-bold mx-auto mb-4">
                       {process.step}
                     </div>
                     <h4 className="font-semibold text-lg mb-2 text-white">{process.title}</h4>
@@ -84,7 +84,7 @@ export default function RemoteSupport() {
         </div>
 
         {/* MSP Statistics */}
-        <div className="grid md:grid-cols-4 gap-6 bg-gradient-to-r from-blue-600 to-indigo-600 rounded-xl p-8 text-white">
+        <div className="grid md:grid-cols-4 gap-6 bg-de-raised rounded-xl p-8 text-white">
           <div className="text-center">
             <p className="text-4xl font-bold mb-2">2 mins</p>
             <p className="text-blue-100">Avg Connection Time</p>
@@ -104,7 +104,7 @@ export default function RemoteSupport() {
         </div>
 
         {/* Zoho Assist CTA — restored from 61f25fc */}
-        <div className="bg-gradient-to-r from-blue-600 to-indigo-600 rounded-xl p-8 text-center text-white">
+        <div className="bg-de-raised rounded-xl p-8 text-center text-white">
           <h2 className="text-3xl font-bold mb-4">Need Immediate Help?</h2>
           <p className="text-lg mb-6 text-blue-100">
             Join a secure Zoho Assist session with our MSP technicians, or open a ticket if you need us to reach out.

--- a/client/src/pages/support/SubmitTicket.tsx
+++ b/client/src/pages/support/SubmitTicket.tsx
@@ -109,7 +109,7 @@ export default function SubmitTicket() {
                       placeholder="John Smith"
                       required
                       data-testid="input-name"
-                      className="bg-white/10 border-white/20 text-white placeholder:text-gray-500"
+                      className="bg-white/10 border-white/20 text-white placeholder:text-white/70"
                     />
                   </div>
                   <div>
@@ -122,7 +122,7 @@ export default function SubmitTicket() {
                       placeholder="john@company.com"
                       required
                       data-testid="input-email"
-                      className="bg-white/10 border-white/20 text-white placeholder:text-gray-500"
+                      className="bg-white/10 border-white/20 text-white placeholder:text-white/70"
                     />
                   </div>
                 </div>
@@ -138,7 +138,7 @@ export default function SubmitTicket() {
                       placeholder="(480) 000-0000"
                       required
                       data-testid="input-phone"
-                      className="bg-white/10 border-white/20 text-white placeholder:text-gray-500"
+                      className="bg-white/10 border-white/20 text-white placeholder:text-white/70"
                     />
                   </div>
                   <div>
@@ -166,7 +166,7 @@ export default function SubmitTicket() {
                     placeholder="Brief description of your issue"
                     required
                     data-testid="input-subject"
-                    className="bg-white/10 border-white/20 text-white placeholder:text-gray-500"
+                    className="bg-white/10 border-white/20 text-white placeholder:text-white/70"
                   />
                 </div>
 
@@ -180,7 +180,7 @@ export default function SubmitTicket() {
                     rows={8}
                     required
                     data-testid="textarea-description"
-                    className="bg-white/10 border-white/20 text-white placeholder:text-gray-500"
+                    className="bg-white/10 border-white/20 text-white placeholder:text-white/70"
                   />
                 </div>
 
@@ -188,7 +188,7 @@ export default function SubmitTicket() {
                   type="submit"
                   size="lg"
                   disabled={isSubmitting}
-                  className="w-full bg-gradient-to-r from-purple-600 to-blue-600 text-white"
+                  className="w-full bg-de-raised text-white"
                   data-testid="button-submit-ticket"
                 >
                   {isSubmitting ? (
@@ -208,12 +208,12 @@ export default function SubmitTicket() {
         <div className="space-y-6">
           <Card className="bg-white/5 backdrop-blur-sm border border-white/10">
             <CardHeader>
-              <Clock className="h-10 w-10 text-purple-400 mb-2" />
+              <Clock className="h-10 w-10 text-de-accent-ink mb-2" />
               <CardTitle className="text-white">Response Times</CardTitle>
             </CardHeader>
             <CardContent className="space-y-3">
               <div>
-                <p className="font-semibold text-purple-400">Critical Issues</p>
+                <p className="font-semibold text-de-accent-ink">Critical Issues</p>
                 <p className="text-sm text-gray-400">Immediate response</p>
               </div>
               <div>
@@ -229,7 +229,7 @@ export default function SubmitTicket() {
 
           <Card className="bg-white/5 backdrop-blur-sm border border-white/10">
             <CardHeader>
-              <Phone className="h-10 w-10 text-purple-400 mb-2" />
+              <Phone className="h-10 w-10 text-de-accent-ink mb-2" />
               <CardTitle className="text-white">Need Immediate Help?</CardTitle>
             </CardHeader>
             <CardContent>
@@ -238,7 +238,7 @@ export default function SubmitTicket() {
               </p>
               <a
                 href="tel:+13254809870"
-                className="text-2xl font-bold text-purple-400 hover:text-purple-300"
+                className="text-2xl font-bold text-de-accent-ink hover:text-de-accent-ink"
               >
                 325-480-9870
               </a>

--- a/client/src/pages/support/TicketConfirmation.tsx
+++ b/client/src/pages/support/TicketConfirmation.tsx
@@ -28,7 +28,7 @@ export default function TicketConfirmation() {
         </p>
         <a
           href="tel:+13254809870"
-          className="inline-flex items-center gap-2 text-2xl font-bold text-purple-300 hover:text-purple-200"
+          className="inline-flex items-center gap-2 text-2xl font-bold text-de-accent-ink hover:text-de-accent-ink"
         >
           <Phone className="h-6 w-6" />
           325-480-9870
@@ -37,7 +37,7 @@ export default function TicketConfirmation() {
           <Button onClick={() => setLocation("/support/knowledge-base")} variant="outline">
             Browse Knowledge Base
           </Button>
-          <Button onClick={() => setLocation("/")} className="bg-violet-600 hover:bg-violet-500">
+          <Button onClick={() => setLocation("/")} className="bg-de-accent hover:bg-de-accent">
             Back to Home
             <ArrowRight className="ml-2 h-4 w-4" />
           </Button>

--- a/client/src/pages/trust/Accessibility.tsx
+++ b/client/src/pages/trust/Accessibility.tsx
@@ -58,14 +58,14 @@ export default function Accessibility() {
 
         {/* Conformance Status */}
         <motion.div 
-          className="bg-white/5 backdrop-blur-sm border-l-4 border-violet-500 border border-white/10 rounded-xl p-8"
+          className="bg-white/5 backdrop-blur-sm border-l-4 border-de-hairline border border-white/10 rounded-xl p-8"
           initial={prefersReducedMotion ? {} : { opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.5 }}
         >
           <div className="flex items-center gap-3 mb-6">
-            <div className="w-10 h-10 rounded-lg bg-gradient-to-br from-violet-500 to-purple-600 flex items-center justify-center">
+            <div className="w-10 h-10 rounded-lg bg-de-raised border border-de-hairline flex items-center justify-center">
               <CheckCircle className="w-5 h-5 text-white" />
             </div>
             <h2 className="text-2xl font-bold text-white">Conformance Status</h2>
@@ -89,7 +89,7 @@ export default function Accessibility() {
                   viewport={{ once: true }}
                   transition={{ delay: idx * 0.1, duration: 0.3 }}
                 >
-                  <div className={`w-10 h-10 rounded-lg bg-gradient-to-br ${user.color} flex items-center justify-center mb-2`}>
+                  <div className={`w-10 h-10 rounded-lg border border-de-hairline bg-de-bg flex items-center justify-center mb-2`}>
                     <Icon className="w-5 h-5 text-white" />
                   </div>
                   <span className="text-sm text-gray-300">{user.text}</span>
@@ -107,11 +107,11 @@ export default function Accessibility() {
           viewport={{ once: true }}
           transition={{ duration: 0.5 }}
         >
-          <div className="absolute top-0 right-0 w-64 h-64 bg-gradient-to-bl from-purple-500/20 to-transparent rounded-full blur-3xl" />
+          <div className="absolute top-0 right-0 w-64 h-64 bg-de-raised to-transparent rounded-full blur-3xl" />
           
           <div className="relative">
             <div className="flex items-center gap-3 mb-8">
-              <div className="w-12 h-12 rounded-lg bg-gradient-to-br from-violet-600 to-purple-600 flex items-center justify-center">
+              <div className="w-12 h-12 rounded-lg bg-de-raised border border-de-hairline flex items-center justify-center">
                 <Eye className="w-6 h-6 text-white" />
               </div>
               <h2 className="text-3xl font-bold text-white">Accessibility Features</h2>
@@ -148,9 +148,9 @@ export default function Accessibility() {
             {assistiveTech.map((tech, idx) => {
               const Icon = tech.icon;
               return (
-                <Card key={idx} className="group bg-white/5 backdrop-blur-sm border border-white/10 hover:border-purple-500/50 hover:shadow-xl transition-all duration-300 text-center">
+                <Card key={idx} className="group bg-white/5 backdrop-blur-sm border border-white/10 hover:border-de-hairline hover:shadow-xl transition-all duration-300 text-center">
                   <CardContent className="pt-6">
-                    <div className="w-14 h-14 rounded-xl bg-gradient-to-br from-violet-500 to-purple-600 flex items-center justify-center mx-auto mb-4 group-hover:scale-110 transition-transform">
+                    <div className="w-14 h-14 rounded-xl bg-de-raised border border-de-hairline flex items-center justify-center mx-auto mb-4 group-hover:scale-110 transition-transform">
                       <Icon className="h-7 w-7 text-white" />
                     </div>
                     <p className="text-gray-300 text-sm">{tech.name}</p>
@@ -203,15 +203,15 @@ export default function Accessibility() {
           </p>
           <div className="grid md:grid-cols-3 gap-4">
             <div className="flex items-center gap-3 p-4 bg-white/5 backdrop-blur-sm rounded-xl border border-white/10">
-              <Mail className="w-5 h-5 text-purple-400" />
+              <Mail className="w-5 h-5 text-de-magenta-ink" />
               <span className="text-gray-300">accessibility@digeratiexperts.com</span>
             </div>
             <div className="flex items-center gap-3 p-4 bg-white/5 backdrop-blur-sm rounded-xl border border-white/10">
-              <Phone className="w-5 h-5 text-purple-400" />
+              <Phone className="w-5 h-5 text-de-magenta-ink" />
               <span className="text-gray-300">325-480-9870</span>
             </div>
             <div className="flex items-center gap-3 p-4 bg-white/5 backdrop-blur-sm rounded-xl border border-white/10">
-              <MapPin className="w-5 h-5 text-purple-400" />
+              <MapPin className="w-5 h-5 text-de-magenta-ink" />
               <span className="text-gray-300 text-sm">3165 S Alma School Rd Suite 29, Chandler, AZ 85248</span>
             </div>
           </div>
@@ -228,7 +228,7 @@ export default function Accessibility() {
           viewport={{ once: true }}
           transition={{ duration: 0.5 }}
         >
-          <div className="absolute inset-0 bg-gradient-to-r from-violet-600 via-purple-600 to-fuchsia-600" />
+          <div className="absolute inset-0 bg-de-surface" />
           <div className="absolute inset-0 opacity-20">
             <svg className="w-full h-full" xmlns="http://www.w3.org/2000/svg">
               <defs>
@@ -247,7 +247,7 @@ export default function Accessibility() {
             </p>
             <a 
               href="mailto:accessibility@digeratiexperts.com?subject=Accessibility Feedback"
-              className="group inline-flex items-center justify-center bg-white text-purple-700 hover:bg-purple-50 px-8 py-4 rounded-xl font-semibold transition-all shadow-lg hover:shadow-xl hover:scale-105"
+              className="group inline-flex items-center justify-center bg-white text-de-magenta hover:bg-de-paper-raised px-8 py-4 rounded-xl font-semibold transition-all shadow-lg hover:shadow-xl hover:scale-105"
               data-testid="button-report-accessibility"
             >
               <Mail className="mr-2 h-5 w-5" />

--- a/client/src/pages/trust/Accessibility.tsx
+++ b/client/src/pages/trust/Accessibility.tsx
@@ -25,10 +25,10 @@ export default function Accessibility() {
   ];
 
   const supportedUsers = [
-    { icon: Eye, text: "Blind or have low vision", color: "from-violet-500 to-purple-600" },
-    { icon: Ear, text: "Deaf or have hearing loss", color: "from-purple-500 to-fuchsia-600" },
+    { icon: Eye, text: "Blind or have low vision", color: " " },
+    { icon: Ear, text: "Deaf or have hearing loss", color: " to-fuchsia-600" },
     { icon: Hand, text: "Living with mobility impairments", color: "from-fuchsia-500 to-pink-600" },
-    { icon: Brain, text: "Living with cognitive disabilities", color: "from-purple-600 to-violet-600" }
+    { icon: Brain, text: "Living with cognitive disabilities", color: " " }
   ];
 
   return (

--- a/client/src/pages/trust/TrustCenter.tsx
+++ b/client/src/pages/trust/TrustCenter.tsx
@@ -69,11 +69,11 @@ export default function TrustCenter() {
                   viewport={{ once: true }}
                   transition={{ delay: idx * 0.1, duration: 0.5 }}
                 >
-                  <Card className="group h-full bg-white/5 backdrop-blur-sm border border-white/10 hover:border-purple-500/50 hover:shadow-xl transition-all duration-300 overflow-hidden">
-                    <div className={`absolute top-0 right-0 w-24 h-24 bg-gradient-to-bl ${item.gradient} opacity-10 rounded-bl-full`} />
+                  <Card className="group h-full bg-white/5 backdrop-blur-sm border border-white/10 hover:border-de-hairline hover:shadow-xl transition-all duration-300 overflow-hidden">
+                    <div className={`absolute top-0 right-0 w-24 h-24 bg-de-magenta opacity-[0.06] rounded-bl-full`} />
                     <CardHeader>
-                      <div className={`w-14 h-14 rounded-xl bg-gradient-to-br ${item.gradient} flex items-center justify-center mb-4`}>
-                        <Icon className="h-7 w-7 text-white" />
+                      <div className={`w-14 h-14 rounded-xl border border-de-hairline bg-de-bg flex items-center justify-center mb-4`}>
+                        <Icon className="h-7 w-7 text-de-magenta" />
                       </div>
                       <CardTitle className="text-xl text-white">{item.title}</CardTitle>
                     </CardHeader>
@@ -103,11 +103,11 @@ export default function TrustCenter() {
           viewport={{ once: true }}
           transition={{ duration: 0.5 }}
         >
-          <div className="absolute top-0 right-0 w-64 h-64 bg-gradient-to-bl from-purple-500/20 to-transparent rounded-full blur-3xl" />
+          <div className="absolute top-0 right-0 w-64 h-64 bg-de-raised to-transparent rounded-full blur-3xl" />
           
           <div className="relative">
             <div className="flex items-center gap-3 mb-8">
-              <div className="w-12 h-12 rounded-lg bg-gradient-to-br from-violet-600 to-purple-600 flex items-center justify-center">
+              <div className="w-12 h-12 rounded-lg bg-de-raised border border-de-hairline flex items-center justify-center">
                 <Lock className="w-6 h-6 text-white" />
               </div>
               <h2 className="text-3xl font-bold text-white">Our Security Practices</h2>
@@ -116,7 +116,7 @@ export default function TrustCenter() {
             <div className="grid md:grid-cols-2 gap-8">
               <div>
                 <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">
-                  <Shield className="w-5 h-5 text-violet-400" />
+                  <Shield className="w-5 h-5 text-de-magenta-ink" />
                   Technical Controls
                 </h3>
                 <div className="space-y-3">
@@ -137,7 +137,7 @@ export default function TrustCenter() {
               </div>
               <div>
                 <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">
-                  <FileCheck className="w-5 h-5 text-violet-400" />
+                  <FileCheck className="w-5 h-5 text-de-magenta-ink" />
                   Administrative Controls
                 </h3>
                 <div className="space-y-3">
@@ -162,14 +162,14 @@ export default function TrustCenter() {
 
         {/* Infrastructure Security */}
         <motion.div 
-          className="bg-white/5 backdrop-blur-sm border-l-4 border-violet-500 border border-white/10 rounded-xl p-8"
+          className="bg-white/5 backdrop-blur-sm border-l-4 border-de-hairline border border-white/10 rounded-xl p-8"
           initial={prefersReducedMotion ? {} : { opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.5 }}
         >
           <div className="flex items-center gap-3 mb-6">
-            <div className="w-10 h-10 rounded-lg bg-gradient-to-br from-violet-600 to-purple-600 flex items-center justify-center">
+            <div className="w-10 h-10 rounded-lg bg-de-raised border border-de-hairline flex items-center justify-center">
               <Server className="w-5 h-5 text-white" />
             </div>
             <h2 className="text-2xl font-bold text-white">Infrastructure Security</h2>
@@ -192,14 +192,14 @@ export default function TrustCenter() {
 
         {/* Privacy & Data Protection */}
         <motion.div 
-          className="bg-white/5 backdrop-blur-sm border-l-4 border-purple-500 border border-white/10 rounded-xl p-8"
+          className="bg-white/5 backdrop-blur-sm border-l-4 border-de-hairline border border-white/10 rounded-xl p-8"
           initial={prefersReducedMotion ? {} : { opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.5 }}
         >
           <div className="flex items-center gap-3 mb-6">
-            <div className="w-10 h-10 rounded-lg bg-gradient-to-br from-violet-600 to-purple-600 flex items-center justify-center">
+            <div className="w-10 h-10 rounded-lg bg-de-raised border border-de-hairline flex items-center justify-center">
               <Eye className="w-5 h-5 text-white" />
             </div>
             <h2 className="text-2xl font-bold text-white">Privacy & Data Protection</h2>
@@ -228,7 +228,7 @@ export default function TrustCenter() {
           viewport={{ once: true }}
           transition={{ duration: 0.5 }}
         >
-          <div className="absolute inset-0 bg-gradient-to-r from-violet-600 via-purple-600 to-fuchsia-600" />
+          <div className="absolute inset-0 bg-de-surface" />
           <div className="absolute inset-0 opacity-20">
             <svg className="w-full h-full" xmlns="http://www.w3.org/2000/svg">
               <defs>
@@ -248,7 +248,7 @@ export default function TrustCenter() {
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <a 
                 href="mailto:security@digeratiexperts.com?subject=Security Documentation Request"
-                className="group inline-flex items-center justify-center bg-white text-purple-700 hover:bg-purple-50 px-8 py-4 rounded-xl font-semibold transition-all shadow-lg hover:shadow-xl hover:scale-105"
+                className="group inline-flex items-center justify-center bg-white text-de-magenta hover:bg-de-paper-raised px-8 py-4 rounded-xl font-semibold transition-all shadow-lg hover:shadow-xl hover:scale-105"
                 data-testid="button-request-docs"
               >
                 <Mail className="mr-2 h-5 w-5" />
@@ -256,7 +256,7 @@ export default function TrustCenter() {
               </a>
               <a 
                 href="tel:+13254809870"
-                className="inline-flex items-center justify-center border-2 border-white bg-white/10 backdrop-blur-sm text-white hover:bg-white hover:text-purple-700 px-8 py-4 rounded-xl font-semibold transition-all"
+                className="inline-flex items-center justify-center border-2 border-white bg-white/10 backdrop-blur-sm text-white hover:bg-white hover:text-de-magenta px-8 py-4 rounded-xl font-semibold transition-all"
                 data-testid="button-call-trust"
               >
                 <Phone className="mr-2 h-5 w-5" />

--- a/client/src/pages/trust/TrustCenter.tsx
+++ b/client/src/pages/trust/TrustCenter.tsx
@@ -7,10 +7,10 @@ export default function TrustCenter() {
   const prefersReducedMotion = useReducedMotion() ?? false;
   
   const complianceSupport = [
-    { icon: FileCheck, title: "HIPAA-aligned security and compliance support", desc: "Business Associate Agreements available for healthcare clients. Framework alignment — not a HIPAA certification.", gradient: "from-purple-500 to-fuchsia-600" },
-    { icon: Award, title: "SOC 2 readiness and control alignment", desc: "Control mapping, evidence support, and readiness work for customer SOC 2 programs. Digerati is not SOC 2 Type II certified.", gradient: "from-violet-500 to-purple-600" },
+    { icon: FileCheck, title: "HIPAA-aligned security and compliance support", desc: "Business Associate Agreements available for healthcare clients. Framework alignment — not a HIPAA certification.", gradient: " to-fuchsia-600" },
+    { icon: Award, title: "SOC 2 readiness and control alignment", desc: "Control mapping, evidence support, and readiness work for customer SOC 2 programs. Digerati is not SOC 2 Type II certified.", gradient: " " },
     { icon: Lock, title: "Cyber insurance readiness", desc: "Controls and documentation insurers commonly request during underwriting and renewals.", gradient: "from-fuchsia-500 to-pink-600" },
-    { icon: Shield, title: "Security and compliance reporting", desc: "Questionnaires, control evidence, and reporting support for vendor reviews and audits.", gradient: "from-violet-600 to-purple-600" },
+    { icon: Shield, title: "Security and compliance reporting", desc: "Questionnaires, control evidence, and reporting support for vendor reviews and audits.", gradient: " " },
   ];
 
   const technicalControls = [

--- a/client/src/pages/trust/VulnerabilityDisclosure.tsx
+++ b/client/src/pages/trust/VulnerabilityDisclosure.tsx
@@ -16,10 +16,10 @@ export default function VulnerabilityDisclosure() {
   ];
 
   const commitments = [
-    { icon: Clock, title: "Acknowledgment", desc: "We'll acknowledge your report within 48 hours", color: "from-violet-500 to-purple-600" },
-    { icon: FileText, title: "Updates", desc: "We'll provide regular updates on our investigation and remediation", color: "from-purple-500 to-fuchsia-600" },
+    { icon: Clock, title: "Acknowledgment", desc: "We'll acknowledge your report within 48 hours", color: " " },
+    { icon: FileText, title: "Updates", desc: "We'll provide regular updates on our investigation and remediation", color: " to-fuchsia-600" },
     { icon: CheckCircle, title: "Credit", desc: "We'll publicly acknowledge researchers (with permission) after remediation", color: "from-fuchsia-500 to-pink-600" },
-    { icon: ShieldCheck, title: "No Legal Action", desc: "We won't pursue legal action against researchers who follow this policy", color: "from-purple-600 to-violet-600" }
+    { icon: ShieldCheck, title: "No Legal Action", desc: "We won't pursue legal action against researchers who follow this policy", color: " " }
   ];
 
   const timeline = [

--- a/client/src/pages/trust/VulnerabilityDisclosure.tsx
+++ b/client/src/pages/trust/VulnerabilityDisclosure.tsx
@@ -53,14 +53,14 @@ export default function VulnerabilityDisclosure() {
 
         {/* How to Report */}
         <motion.div 
-          className="bg-white/5 backdrop-blur-sm border-l-4 border-violet-500 border border-white/10 rounded-xl p-8"
+          className="bg-white/5 backdrop-blur-sm border-l-4 border-de-hairline border border-white/10 rounded-xl p-8"
           initial={prefersReducedMotion ? {} : { opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.5 }}
         >
           <div className="flex items-center gap-3 mb-6">
-            <div className="w-10 h-10 rounded-lg bg-gradient-to-br from-violet-500 to-purple-600 flex items-center justify-center">
+            <div className="w-10 h-10 rounded-lg bg-de-raised border border-de-hairline flex items-center justify-center">
               <Mail className="w-5 h-5 text-white" />
             </div>
             <h2 className="text-2xl font-bold text-white">How to Report a Vulnerability</h2>
@@ -76,14 +76,14 @@ export default function VulnerabilityDisclosure() {
 
         {/* Information to Include */}
         <motion.div 
-          className="bg-white/5 backdrop-blur-sm border-l-4 border-violet-500 border border-white/10 rounded-xl p-8"
+          className="bg-white/5 backdrop-blur-sm border-l-4 border-de-hairline border border-white/10 rounded-xl p-8"
           initial={prefersReducedMotion ? {} : { opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.5 }}
         >
           <div className="flex items-center gap-3 mb-6">
-            <div className="w-10 h-10 rounded-lg bg-gradient-to-br from-violet-500 to-purple-600 flex items-center justify-center">
+            <div className="w-10 h-10 rounded-lg bg-de-raised border border-de-hairline flex items-center justify-center">
               <FileText className="w-5 h-5 text-white" />
             </div>
             <h2 className="text-2xl font-bold text-white">Information to Include</h2>
@@ -128,11 +128,11 @@ export default function VulnerabilityDisclosure() {
                   viewport={{ once: true }}
                   transition={{ delay: idx * 0.1, duration: 0.5 }}
                 >
-                  <Card className="group h-full bg-white/5 backdrop-blur-sm border border-white/10 hover:border-purple-500/50 hover:shadow-xl transition-all duration-300">
+                  <Card className="group h-full bg-white/5 backdrop-blur-sm border border-white/10 hover:border-de-hairline hover:shadow-xl transition-all duration-300">
                     <CardContent className="pt-6">
                       <div className="flex gap-4">
-                        <div className={`w-12 h-12 rounded-xl bg-gradient-to-br ${item.color} flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform`}>
-                          <Icon className="h-6 w-6 text-white" />
+                        <div className={`w-12 h-12 rounded-xl border border-de-hairline bg-de-bg flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform`}>
+                          <Icon className="h-6 w-6 text-de-magenta" />
                         </div>
                         <div>
                           <h3 className="font-bold text-white mb-1">{item.title}</h3>
@@ -189,7 +189,7 @@ export default function VulnerabilityDisclosure() {
             transition={{ duration: 0.5 }}
           >
             <h3 className="text-xl font-bold text-white mb-4 flex items-center gap-2">
-              <AlertCircle className="w-5 h-5 text-violet-400" />
+              <AlertCircle className="w-5 h-5 text-de-magenta-ink" />
               Rules of Engagement
             </h3>
             <ul className="space-y-2 text-sm">
@@ -201,7 +201,7 @@ export default function VulnerabilityDisclosure() {
                 "Make a good faith effort to avoid privacy violations and destruction of data"
               ].map((rule, idx) => (
                 <li key={idx} className="flex items-start gap-2 text-gray-300">
-                  <AlertCircle className="w-4 h-4 text-violet-400 flex-shrink-0 mt-0.5" />
+                  <AlertCircle className="w-4 h-4 text-de-magenta-ink flex-shrink-0 mt-0.5" />
                   <span>{rule}</span>
                 </li>
               ))}
@@ -217,13 +217,13 @@ export default function VulnerabilityDisclosure() {
             transition={{ duration: 0.5, delay: 0.1 }}
           >
             <h3 className="text-xl font-bold text-white mb-4 flex items-center gap-2">
-              <Clock className="w-5 h-5 text-violet-400" />
+              <Clock className="w-5 h-5 text-de-magenta-ink" />
               Response Timeline
             </h3>
             <div className="space-y-4">
               {timeline.map((item, idx) => (
                 <div key={idx} className="flex gap-4">
-                  <Badge className="bg-gradient-to-r from-violet-500 to-purple-600 text-white border-0 px-3 flex-shrink-0">
+                  <Badge className="bg-de-raised text-white border-0 px-3 flex-shrink-0">
                     {item.time}
                   </Badge>
                   <span className="text-gray-300 text-sm">{item.desc}</span>
@@ -241,7 +241,7 @@ export default function VulnerabilityDisclosure() {
           viewport={{ once: true }}
           transition={{ duration: 0.5 }}
         >
-          <div className="absolute inset-0 bg-gradient-to-r from-violet-600 via-purple-600 to-fuchsia-600" />
+          <div className="absolute inset-0 bg-de-surface" />
           <div className="absolute inset-0 opacity-20">
             <svg className="w-full h-full" xmlns="http://www.w3.org/2000/svg">
               <defs>
@@ -260,7 +260,7 @@ export default function VulnerabilityDisclosure() {
             </p>
             <a 
               href="mailto:security@digeratiexperts.com?subject=Security Vulnerability Report"
-              className="group inline-flex items-center justify-center bg-white text-purple-700 hover:bg-purple-50 px-8 py-4 rounded-xl font-semibold transition-all shadow-lg hover:shadow-xl hover:scale-105"
+              className="group inline-flex items-center justify-center bg-white text-de-magenta hover:bg-de-paper-raised px-8 py-4 rounded-xl font-semibold transition-all shadow-lg hover:shadow-xl hover:scale-105"
               data-testid="button-report-vulnerability"
             >
               <Mail className="mr-2 h-5 w-5" />

--- a/docs/BRAND-SWEEP-NEXT.md
+++ b/docs/BRAND-SWEEP-NEXT.md
@@ -1,0 +1,34 @@
+# Brand sweep — next pass
+
+**Date:** 2026-08-16  
+**Settled on:** `cursor/homepage-retire-leftover-purple-chrome-3080` / PR #20  
+**Do not start** another full-site rewrite. Start from the named flags below.
+
+The audit (`scripts/brand-audit.mjs`) is a regression detector, not a requirement to force every route to zero flags.
+
+## Already settled — do not re-litigate
+
+- Marketing field stays the charcoal ladder. Primary CTA fill is solid `#D3126A`.
+- Page families keep one topical hue: store → electric, support → cyan, resources → amber, everything else inherits magenta.
+- Store category pills stay pill-only and use 14 distinct hues. Teal / lime / yellow replaced the three that had collapsed onto violet; `professional_services` moved to pink so teal could stay. Guard: `client/src/components/store/categoryAccent.test.ts`.
+- Portal, login, and signup are out of scope unless DE asks for a separate portal UI pass.
+- Dead `client/src/pages/Homepage.tsx` and the legacy sections it imports are not routed (`/` uses `DigeratiHomepage`). Sweeping them is diff noise.
+- Intentional exceptions live in `EXCEPTIONS` inside `scripts/brand-audit.mjs`: store category pills, vendor marks, hero lighting, semantic status/charts, official city chips.
+
+## Named leftovers
+
+| Item | Where | Why it is parked | Next move |
+|------|--------|------------------|-----------|
+| Magenta as text on paper (~3.6:1) | `ComplianceCertifications.tsx` outline buttons; `SecurityUpdates.tsx` source / severity labels | `#D3126A` as a **fill** on dark is fine. As **text on paper** it fails AA. | Add a darker paper-ink token. Do not darken the CTA fill. |
+| Quote wizard 1.14:1 on slate-900 | `/quote-wizard` | Almost certainly a backdrop-measurement miss in the audit, not a purple regression. | Confirm in the browser, then fix `behind()` in `brand-audit.mjs` if the form is actually readable. |
+| `#5034ff` “Sign Up” | `/de-ecosystem-matrix-offical`, `/official-network-planner` | Official-tool pages, not the marketing/store system. | DE decides whether those tools join the accent system. |
+| Yellow star glyphs | `/thank-you-success-page` | Rating affordance, not brand chrome. | Leave unless DE wants a different rating treatment. |
+| Legacy unused purple | `Homepage.tsx` + `HeroSection`, `PricingSection`, `ServicesSection`, `BlogSection`, `FooterSection`, `CallToActionSection`, `ContactSection` | Not reachable. | Delete only if DE approves removing dead code; do not restyle in place. |
+| Portal palette | `/portal/*` | Explicitly excluded from this sweep. | Separate portal UI audit if DE asks. |
+
+## Optional later
+
+1. Paper-ink token for magenta-on-white text.
+2. Quote-wizard contrast investigation (audit vs rendered).
+3. Official-tool hue decision (`#5034ff` vs electric vs magenta).
+4. Portal UI pass — only if requested.

--- a/package-lock.json
+++ b/package-lock.json
@@ -124,6 +124,7 @@
         "autoprefixer": "^10.4.20",
         "drizzle-kit": "^0.31.4",
         "esbuild": "^0.25.0",
+        "playwright": "^1.62.1",
         "postcss": "^8.4.47",
         "tailwindcss": "^3.4.17",
         "tsx": "^4.20.5",
@@ -11959,6 +11960,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plist": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:watch": "vitest",
     "smoke:public": "node scripts/public-route-smoke.mjs",
     "db:push": "drizzle-kit push",
-    "test:advisor": "tsx --test server/services/msp-advisor/**/*.test.ts",
+    "test:advisor": "tsx --test server/services/msp-advisor/*.test.ts",
     "eval:advisor": "tsx server/services/msp-advisor/eval/score.ts"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "autoprefixer": "^10.4.20",
     "drizzle-kit": "^0.31.4",
     "esbuild": "^0.25.0",
+    "playwright": "^1.62.1",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.17",
     "tsx": "^4.20.5",

--- a/scripts/brand-audit.mjs
+++ b/scripts/brand-audit.mjs
@@ -34,11 +34,59 @@ const routes = argOf("--routes", "")
   : routesFromApp();
 
 /**
+ * Intentional exceptions.
+ *
+ * This script is a regression detector, not the design authority. Plenty of
+ * colour on this site is doing a job — status, taxonomy, vendor identity — and
+ * forcing every route to zero flags would destroy it. Anything listed here is
+ * a deliberate decision; everything else that trips is a regression.
+ *
+ * Each entry needs a reason. If you cannot write one, it is not an exception.
+ */
+const EXCEPTIONS = [
+  {
+    match: (hit) => /\bde-store-category\b/.test(hit.cls),
+    why: "Store category pills colour-code 14 product categories for wayfinding. Hue is reinforcement only — the pill also prints its label. See categoryAccent in StoreProductCard.tsx.",
+  },
+  {
+    match: (hit) => /\bde-vendor-mark\b/.test(hit.cls),
+    why: "Vendor branding has to render in the vendor's own colours.",
+  },
+  {
+    match: (hit) => hit.kind === "gradient" && /\bde-process-band\b/.test(hit.cls),
+    why: "Homepage process band uses violet as lighting over a charcoal slab, which the accent-pop rule permits. It is not a fill.",
+  },
+  {
+    match: (hit) => hit.kind === "gradient" && /\bde-hero-glow\b/.test(hit.cls),
+    why: "Hero atmosphere. Violet as lighting, explicitly allowed; the field underneath stays black.",
+  },
+  {
+    match: (hit) => /\bde-status\b/.test(hit.cls) || /\bde-chart\b/.test(hit.cls),
+    why: "Semantic status and chart series colours encode meaning. Flattening them to magenta would hide the signal.",
+  },
+  {
+    match: (hit) => /\bcity-btn\b/.test(hit.cls),
+    why: "Arizona city chips use each city's official colour, not the brand palette.",
+  },
+];
+
+/** Routes the sweep deliberately does not own. */
+const OUT_OF_SCOPE = [/^\/portal(\/|$)/, /^\/login$/, /^\/signup$/];
+
+/**
  * Runs in the page. Violet is legal as *lighting* (low-alpha glows) but not as
  * a fill, so the fill check ignores anything below the alpha floor.
  */
 function collect(alphaFloor) {
-  const isPurple = (r, g, b) => b > 90 && b > r + 40 && b > g + 40;
+  /**
+   * Violet and indigo specifically, not "anything blue-ish".
+   *
+   * Purple sits where blue leads, red trails it, and green is pushed well
+   * below both. Requiring `r > g` is what separates violet from a true blue
+   * such as the Store's electric accent (low red, mid green), and requiring
+   * `b > r` is what keeps brand magenta out of the net.
+   */
+  const isPurple = (r, g, b) => b > 90 && b > r && r - g >= 10 && b - g >= 60;
   const rgb = (s) => {
     const m = s.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*([\d.]+))?/);
     return m ? { r: +m[1], g: +m[2], b: +m[3], a: m[4] === undefined ? 1 : +m[4] } : null;
@@ -180,8 +228,7 @@ function collect(alphaFloor) {
   const doc = document.documentElement;
   return {
     checked,
-    purple: purple.length,
-    purpleSample: [...new Set(purple.map((p) => `${p.kind}:${p.cls}`))].slice(0, 3),
+    purpleHits: purple,
     contrast: uniqueContrast.length,
     contrastSample: uniqueContrast.sort((a, b) => a.ratio - b.ratio).slice(0, 3),
     overflow: doc.scrollWidth > doc.clientWidth,
@@ -215,14 +262,33 @@ for (const route of routes) {
     });
     await page.waitForTimeout(500);
     const data = await page.evaluate(collect, 0.12);
-    results.push({ route, ...data, errors: errors.length, errorSample: errors.slice(0, 2) });
+
+    const excused = [];
+    const flagged = [];
+    for (const hit of data.purpleHits) {
+      const exception = EXCEPTIONS.find((e) => e.match(hit));
+      (exception ? excused : flagged).push(exception ? { ...hit, why: exception.why } : hit);
+    }
+    data.purple = flagged.length;
+    data.purpleSample = [...new Set(flagged.map((p) => `${p.kind}:${p.cls}`))].slice(0, 3);
+    data.excused = excused.length;
+    delete data.purpleHits;
+
+    results.push({
+      route,
+      outOfScope: OUT_OF_SCOPE.some((re) => re.test(route)),
+      ...data,
+      errors: errors.length,
+      errorSample: errors.slice(0, 2),
+    });
   } catch (err) {
     results.push({ route, failed: String(err).slice(0, 90), errors: errors.length });
   }
 }
 await browser.close();
 
-const bad = results.filter(
+const inScope = results.filter((r) => !r.outOfScope);
+const bad = inScope.filter(
   (r) => r.failed || r.errors > 0 || r.purple > 0 || r.contrast > 0 || r.overflow,
 );
 
@@ -245,5 +311,11 @@ for (const r of bad) {
   for (const p of r.purpleSample || []) console.log(`      ${p}`);
   for (const e of r.errorSample || []) console.log(`      ${e}`);
 }
-console.log(`\n${results.length - bad.length}/${results.length} clean\n`);
+const excused = inScope.reduce((total, r) => total + (r.excused || 0), 0);
+const skipped = results.length - inScope.length;
+
+console.log(`\n${inScope.length - bad.length}/${inScope.length} in-scope routes clean`);
+if (excused) console.log(`${excused} intentional exception(s) allowed — see EXCEPTIONS in this file`);
+if (skipped) console.log(`${skipped} route(s) out of scope (portal / auth)`);
+console.log();
 process.exit(bad.length ? 1 : 0);

--- a/scripts/brand-audit.mjs
+++ b/scripts/brand-audit.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+/**
+ * Renders every public route and reports brand + accessibility debt.
+ *
+ * Written as a repeatable harness rather than a one-off because the sweep it
+ * guards touches ~80 pages: a scripted edit needs a check that actually loads
+ * the page, since class-name greps cannot see computed gradients, inherited
+ * backgrounds, or text that ends up invisible.
+ *
+ *   node scripts/brand-audit.mjs [--base http://localhost:8080] [--routes a,b]
+ *
+ * Exit code is 1 when any route reports a defect, so CI can gate on it.
+ */
+import { chromium } from "playwright";
+import { readFileSync, writeFileSync } from "node:fs";
+
+const args = process.argv.slice(2);
+const argOf = (name, fallback) => {
+  const i = args.indexOf(name);
+  return i === -1 ? fallback : args[i + 1];
+};
+
+const BASE = argOf("--base", "http://localhost:8080");
+const VIEWPORT = { width: Number(argOf("--width", 1440)), height: 900 };
+
+function routesFromApp() {
+  const src = readFileSync(new URL("../client/src/App.tsx", import.meta.url), "utf8");
+  const found = [...src.matchAll(/<Route\s+path="([^"]+)"/g)].map((m) => m[1]);
+  return [...new Set(found)].filter((r) => !r.includes(":") && !r.includes("*")).sort();
+}
+
+const routes = argOf("--routes", "")
+  ? argOf("--routes", "").split(",").map((s) => s.trim()).filter(Boolean)
+  : routesFromApp();
+
+/**
+ * Runs in the page. Violet is legal as *lighting* (low-alpha glows) but not as
+ * a fill, so the fill check ignores anything below the alpha floor.
+ */
+function collect(alphaFloor) {
+  const isPurple = (r, g, b) => b > 90 && b > r + 40 && b > g + 40;
+  const rgb = (s) => {
+    const m = s.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*([\d.]+))?/);
+    return m ? { r: +m[1], g: +m[2], b: +m[3], a: m[4] === undefined ? 1 : +m[4] } : null;
+  };
+
+  const purple = [];
+  for (const el of document.querySelectorAll("*")) {
+    const box = el.getBoundingClientRect();
+    if (box.height < 8 || box.width < 8) continue;
+    const cs = getComputedStyle(el);
+
+    const fill = rgb(cs.backgroundColor);
+    if (fill && fill.a > alphaFloor && isPurple(fill.r, fill.g, fill.b)) {
+      purple.push({ kind: "fill", cls: String(el.className).slice(0, 60) });
+      continue;
+    }
+    if (cs.backgroundImage && cs.backgroundImage !== "none") {
+      for (const stop of cs.backgroundImage.matchAll(/rgba?\((\d+), (\d+), (\d+)(?:, ([\d.]+))?\)/g)) {
+        const a = stop[4] === undefined ? 1 : +stop[4];
+        if (a > alphaFloor && isPurple(+stop[1], +stop[2], +stop[3])) {
+          purple.push({ kind: "gradient", cls: String(el.className).slice(0, 60) });
+          break;
+        }
+      }
+    }
+  }
+
+  const lum = (r, g, b) => {
+    const f = (v) => {
+      v /= 255;
+      return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+    };
+    return 0.2126 * f(r) + 0.7152 * f(g) + 0.0722 * f(b);
+  };
+  // Text over an image or gradient scrim cannot be scored from a background
+  // colour walk, so it is skipped rather than reported as a false failure.
+  const overScrim = (el) => {
+    let n = el;
+    for (let i = 0; i < 4 && n; i++) {
+      if (getComputedStyle(n).backgroundImage.includes("gradient")) return true;
+      n = n.parentElement;
+    }
+    return false;
+  };
+  // Averages a gradient's stops so a gradient-painted field counts as a real
+  // backdrop. Without this the walk falls through to a white <body> and reports
+  // white-on-dark text as 1:1.
+  const gradientAvg = (image) => {
+    const stops = [...image.matchAll(/rgba?\((\d+), (\d+), (\d+)(?:, ([\d.]+))?\)/g)].map((m) => ({
+      r: +m[1], g: +m[2], b: +m[3], a: m[4] === undefined ? 1 : +m[4],
+    }));
+    const solid = stops.filter((s) => s.a > 0.05);
+    if (!solid.length) return null;
+    const n = solid.length;
+    return {
+      r: solid.reduce((t, s) => t + s.r, 0) / n,
+      g: solid.reduce((t, s) => t + s.g, 0) / n,
+      b: solid.reduce((t, s) => t + s.b, 0) / n,
+      a: solid.reduce((t, s) => t + s.a, 0) / n,
+    };
+  };
+
+  // Composite every translucent layer on the way up. Skipping them (rather than
+  // blending) reports white-on-dark card text as 1:1, which is a false failure.
+  const behind = (el) => {
+    const layers = [];
+    let n = el;
+    while (n) {
+      const cs = getComputedStyle(n);
+      const c = rgb(cs.backgroundColor);
+      if (c && c.a > 0.001) {
+        layers.push(c);
+        if (c.a > 0.99) break;
+      }
+      if (cs.backgroundImage && cs.backgroundImage.includes("gradient(")) {
+        const g = gradientAvg(cs.backgroundImage);
+        if (g) {
+          layers.push(g);
+          if (g.a > 0.9) break;
+        }
+      }
+      n = n.parentElement;
+    }
+    let out = { r: 5, g: 3, b: 18 };
+    for (let i = layers.length - 1; i >= 0; i--) {
+      const l = layers[i];
+      out = {
+        r: l.r * l.a + out.r * (1 - l.a),
+        g: l.g * l.a + out.g * (1 - l.a),
+        b: l.b * l.a + out.b * (1 - l.a),
+      };
+    }
+    return { ...out, a: 1 };
+  };
+
+  const contrast = [];
+  let checked = 0;
+  for (const el of document.querySelectorAll("p,h1,h2,h3,h4,h5,span,a,li,label,button,div")) {
+    const text = [...el.childNodes].filter((n) => n.nodeType === 3 && n.textContent.trim().length > 2);
+    if (!text.length) continue;
+    const cs = getComputedStyle(el);
+    if (cs.visibility === "hidden" || cs.display === "none" || +cs.opacity < 0.1) continue;
+    const box = el.getBoundingClientRect();
+    if (box.width < 4 || box.height < 4) continue;
+    if (overScrim(el)) continue;
+    const fg = rgb(cs.color);
+    if (!fg) continue;
+    checked++;
+    const bg = behind(el);
+    const flat = {
+      r: fg.r * fg.a + bg.r * (1 - fg.a),
+      g: fg.g * fg.a + bg.g * (1 - fg.a),
+      b: fg.b * fg.a + bg.b * (1 - fg.a),
+    };
+    const l1 = lum(flat.r, flat.g, flat.b);
+    const l2 = lum(bg.r, bg.g, bg.b);
+    const ratio = (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
+    const px = parseFloat(cs.fontSize);
+    const weight = parseInt(cs.fontWeight) || 400;
+    const need = px >= 24 || (px >= 18.66 && weight >= 700) ? 3 : 4.5;
+    if (ratio < need) {
+      contrast.push({
+        text: text[0].textContent.trim().slice(0, 30),
+        color: cs.color,
+        ratio: +ratio.toFixed(2),
+        need,
+      });
+    }
+  }
+
+  const seen = new Set();
+  const uniqueContrast = contrast.filter((c) => {
+    const key = c.text + c.color;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+
+  const doc = document.documentElement;
+  return {
+    checked,
+    purple: purple.length,
+    purpleSample: [...new Set(purple.map((p) => `${p.kind}:${p.cls}`))].slice(0, 3),
+    contrast: uniqueContrast.length,
+    contrastSample: uniqueContrast.sort((a, b) => a.ratio - b.ratio).slice(0, 3),
+    overflow: doc.scrollWidth > doc.clientWidth,
+  };
+}
+
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: VIEWPORT });
+
+const results = [];
+for (const route of routes) {
+  const errors = [];
+  page.removeAllListeners("pageerror");
+  page.on("pageerror", (e) => errors.push(String(e).slice(0, 90)));
+
+  try {
+    await page.goto(BASE + route, { waitUntil: "domcontentloaded", timeout: 30000 });
+    await page.waitForTimeout(1500);
+    const consent = page.locator("button:has-text('Accept All')");
+    if (await consent.count()) {
+      await consent.first().click().catch(() => {});
+      await page.waitForTimeout(200);
+    }
+    // Scroll so viewport-triggered reveals actually paint before measuring.
+    await page.evaluate(async () => {
+      for (let y = 0; y < document.body.scrollHeight; y += 500) {
+        window.scrollTo(0, y);
+        await new Promise((r) => setTimeout(r, 18));
+      }
+      window.scrollTo(0, 0);
+    });
+    await page.waitForTimeout(500);
+    const data = await page.evaluate(collect, 0.12);
+    results.push({ route, ...data, errors: errors.length, errorSample: errors.slice(0, 2) });
+  } catch (err) {
+    results.push({ route, failed: String(err).slice(0, 90), errors: errors.length });
+  }
+}
+await browser.close();
+
+const bad = results.filter(
+  (r) => r.failed || r.errors > 0 || r.purple > 0 || r.contrast > 0 || r.overflow,
+);
+
+const reportPath = argOf("--out", "/tmp/brand-audit.json");
+writeFileSync(reportPath, JSON.stringify({ base: BASE, viewport: VIEWPORT, results }, null, 2));
+
+console.log(`\nAudited ${results.length} routes at ${VIEWPORT.width}px\n`);
+for (const r of bad) {
+  if (r.failed) {
+    console.log(`✗ ${r.route}  LOAD FAILED  ${r.failed}`);
+    continue;
+  }
+  const bits = [];
+  if (r.errors) bits.push(`js:${r.errors}`);
+  if (r.purple) bits.push(`purple:${r.purple}`);
+  if (r.contrast) bits.push(`contrast:${r.contrast}`);
+  if (r.overflow) bits.push("overflow");
+  console.log(`✗ ${r.route.padEnd(44)} ${bits.join("  ")}`);
+  for (const c of r.contrastSample || []) console.log(`      ${c.ratio}:1 (needs ${c.need})  "${c.text}"  ${c.color}`);
+  for (const p of r.purpleSample || []) console.log(`      ${p}`);
+  for (const e of r.errorSample || []) console.log(`      ${e}`);
+}
+console.log(`\n${results.length - bad.length}/${results.length} clean\n`);
+process.exit(bad.length ? 1 : 0);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -53,6 +53,8 @@ module.exports = {
         de: {
           magenta: "var(--de-magenta)",
           "magenta-ink": "var(--de-magenta-ink)",
+          accent: "rgb(var(--de-accent-rgb) / <alpha-value>)",
+          "accent-ink": "rgb(var(--de-accent-ink-rgb) / <alpha-value>)",
           bg: "var(--de-bg)",
           surface: "var(--de-surface)",
           raised: "var(--de-raised)",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -51,6 +51,8 @@ module.exports = {
           foreground: "hsl(var(--card-foreground))",
         },
         de: {
+          magenta: "var(--de-magenta)",
+          "magenta-ink": "var(--de-magenta-ink)",
           bg: "var(--de-bg)",
           surface: "var(--de-surface)",
           raised: "var(--de-raised)",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,10 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["client/src/**/*.test.ts", "server/**/*.test.ts", "shared/**/*.test.ts", "scripts/**/*.test.ts"],
+    // msp-advisor is written against the node:test runner and is executed by
+    // `npm run test:advisor`. Collecting it here makes Vitest fail the suite
+    // with "No test suite found".
+    exclude: ["**/node_modules/**", "**/dist/**", "server/services/msp-advisor/**"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Finishes the accent-pop sweep on public marketing pages and gives the store its own flavor without redesigning it.

## What changed

- **Homepage leftovers** from earlier on this PR: solid `#D3126A` CTAs, WCAG AA contrast, honest newsletter cadence label, `prefers-reduced-motion` on the assessment form.
- **Store keeps its commerce layout.** `/store/*` now owns an electric-blue page accent. Category pills stay pill-only and use 14 distinct hues — teal / lime / yellow replace the three that had collapsed onto violet (`professional_services` moved to pink so teal could be used exactly as requested). Legacy `#5034ff` catalog tints now follow `var(--de-accent)`.
- **Page families keep one hue:** store → electric, support → cyan, resources → amber, everything else inherits magenta. Portal is excluded.
- **Shared primitives** no longer carry purple focus rings or gradient fills.
- **Service / industry / blog / location heroes** are charcoal slabs instead of violet or magenta-to-fuchsia washes.
- **`scripts/brand-audit.mjs`** is a regression detector, not a “127/127 clean” mandate. Intentional exceptions: store category pills, vendor marks, hero lighting, semantic status/charts, official city colours. Portal/auth routes are out of scope.

## Functionality preserved

- Store catalog, filters, compare, cart, checkout, and merchandising rails are unchanged except for hue.
- No portal, login, or signup chrome was touched.
- Dead `Homepage.tsx` + legacy sections were left alone (not routed).
- No content, CTAs, nav items, or stats were removed.

## Tests

- `npm test` — 56/56, including the new category-accent uniqueness guard
- `npm run test:advisor` — 33/33
- `npm run build` — succeeds
- `npm run check` — still reports the pre-existing TypeScript debt tracked by issue #12 (CI treats this as informational)
- Full rendered audit: 127 routes. 44 portal/auth out of scope. After the leftover-wash pass, the previously purple service/industry/location/store cluster is clean.

## Next pass (parked, not in this PR)

Named leftovers live in `docs/BRAND-SWEEP-NEXT.md` so the next session does not start another full-site rewrite:

- Magenta `#D3126A` as text on paper (~3.6:1) — needs a darker paper-ink token
- `/quote-wizard` 1.14:1 — likely an audit backdrop miss
- Official-tool `#5034ff` on `/de-ecosystem-matrix-offical` and `/official-network-planner`
- Unused legacy homepage sections (not routed)
- Portal stays excluded unless DE asks

## Human inputs still required

None for this sweep. A later, separate pass would be needed if DE wants the portal — or those two official-tool pages — on the same palette.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55eac13a-e87f-4a00-9c34-f63bb77c3080&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

