### PR TITLE
Raise sitewide type so marketing copy is readable at 100%

### DIFF
--- a/client/src/components/BlogAudioPlayer.tsx
+++ b/client/src/components/BlogAudioPlayer.tsx
@@ -438,7 +438,7 @@ export function BlogAudioPlayer({
             style={{ width: `${progress}%` }}
           />
         </div>
-        <span className="text-[10px] text-white/55 tabular-nums w-8 text-right">
+        <span className="text-xs text-white/55 tabular-nums w-8 text-right">
           {progress}%
         </span>
       </div>
@@ -454,7 +454,7 @@ export function BlogAudioPlayer({
             stop();
           }
         }}
-        className="hidden sm:block bg-transparent text-[11px] text-white/50 border-none outline-none cursor-pointer hover:text-white/70"
+        className="hidden sm:block bg-transparent text-sm text-white/50 border-none outline-none cursor-pointer hover:text-white/70"
         data-testid="select-audio-rate"
         title="Playback speed"
         aria-label="Playback speed"
@@ -486,7 +486,7 @@ export function BlogAudioPlayer({
             setMode("openai");
           }
         }}
-        className="hidden md:block bg-transparent text-[11px] text-white/50 border-none outline-none cursor-pointer hover:text-white/70 max-w-[120px]"
+        className="hidden md:block bg-transparent text-sm text-white/50 border-none outline-none cursor-pointer hover:text-white/70 max-w-[120px]"
         data-testid="select-audio-voice"
         title={
           mode === "browser"
@@ -506,7 +506,7 @@ export function BlogAudioPlayer({
       </select>
 
       {error && !isPlaying && !isPaused && (
-        <span className="text-[10px] text-amber-300/90 hidden sm:inline">
+        <span className="text-xs text-amber-300/90 hidden sm:inline">
           {error}
         </span>
       )}

--- a/client/src/components/BookingModal.tsx
+++ b/client/src/components/BookingModal.tsx
@@ -144,7 +144,7 @@ export function BookingModal() {
 
               <div className="grid min-h-0 flex-1 overflow-y-auto lg:grid-cols-[minmax(17rem,0.9fr)_minmax(0,1.15fr)]">
                 <aside className="border-b border-de-hairline bg-de-raised px-5 py-6 md:px-7 md:py-8 lg:border-b-0 lg:border-r">
-                  <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[#D3126A]">
+                  <p className="text-sm font-semibold uppercase tracking-[0.16em] text-[#D3126A]">
                     Cyber Risk Assessment
                   </p>
                   <h2

--- a/client/src/components/CookieConsentBanner.tsx
+++ b/client/src/components/CookieConsentBanner.tsx
@@ -197,7 +197,7 @@ export function CookieConsentBanner() {
                   </Link>
                   .
                 </p>
-                <p className="md:hidden text-[13px] font-medium leading-snug text-gray-200 flex-1 min-w-0">
+                <p className="md:hidden text-sm font-medium leading-snug text-gray-200 flex-1 min-w-0">
                   We use cookies.{" "}
                   <Link
                     href="/legal/privacy-policy"

--- a/client/src/components/ExitIntentPopup.tsx
+++ b/client/src/components/ExitIntentPopup.tsx
@@ -257,7 +257,7 @@ export function ExitIntentPopup({ delay = 30000 }: ExitIntentPopupProps) {
                 <div className="bg-[var(--de-paper)] px-5 pb-6 pt-5 md:px-8 md:pb-8 md:pt-6">
                   {!isSuccess ? (
                     <>
-                      <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[#D3126A]">
+                      <p className="text-sm font-semibold uppercase tracking-[0.16em] text-[#D3126A]">
                         Cyber Risk Assessment
                       </p>
                       <h2

--- a/client/src/components/HomepageOnPageNav.tsx
+++ b/client/src/components/HomepageOnPageNav.tsx
@@ -83,7 +83,7 @@ export function HomepageOnPageNav() {
                     event.preventDefault();
                     goTo(index);
                   }}
-                  className={`relative inline-flex min-h-9 w-full items-center justify-center px-1 py-1.5 text-xs font-semibold tracking-wide whitespace-nowrap transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-de-accent focus-visible:ring-inset sm:px-2 sm:text-sm lg:min-h-8 lg:w-auto lg:px-3.5 lg:text-[13px] ${
+                  className={`relative inline-flex min-h-9 w-full items-center justify-center px-1 py-1.5 text-xs font-semibold tracking-wide whitespace-nowrap transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-de-accent focus-visible:ring-inset sm:px-2 sm:text-sm lg:min-h-8 lg:w-auto lg:px-3.5 ${
                     isActive
                       ? "text-white"
                       : "text-white/55 hover:text-white/90"

--- a/client/src/components/HomepageOnPageNav.tsx
+++ b/client/src/components/HomepageOnPageNav.tsx
@@ -83,7 +83,7 @@ export function HomepageOnPageNav() {
                     event.preventDefault();
                     goTo(index);
                   }}
-                  className={`relative inline-flex min-h-9 w-full items-center justify-center px-1 py-1.5 text-[10px] font-semibold tracking-wide whitespace-nowrap transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-de-accent focus-visible:ring-inset sm:px-2 sm:text-[11px] lg:min-h-8 lg:w-auto lg:px-3.5 lg:text-[13px] ${
+                  className={`relative inline-flex min-h-9 w-full items-center justify-center px-1 py-1.5 text-xs font-semibold tracking-wide whitespace-nowrap transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-de-accent focus-visible:ring-inset sm:px-2 sm:text-sm lg:min-h-8 lg:w-auto lg:px-3.5 lg:text-[13px] ${
                     isActive
                       ? "text-white"
                       : "text-white/55 hover:text-white/90"

--- a/client/src/components/MegaMenu.tsx
+++ b/client/src/components/MegaMenu.tsx
@@ -877,7 +877,7 @@ export function MegaMenu() {
                                               )}
                                             </div>
                                             {subItem.description && (
-                                              <p className="text-[13px] text-white/70 group-hover/item:text-gray-400 mt-1 transition-colors leading-snug line-clamp-2">
+                                              <p className="text-sm text-white/70 group-hover/item:text-gray-400 mt-1 transition-colors leading-snug line-clamp-2">
                                                 {subItem.description}
                                               </p>
                                             )}

--- a/client/src/components/MegaMenu.tsx
+++ b/client/src/components/MegaMenu.tsx
@@ -87,7 +87,7 @@ const DiagonalLinesBadge = ({ children, variant }: { children: React.ReactNode; 
     : 'bg-de-raised text-de-accent-ink border border-de-hairline';
     
   return (
-    <span className={`relative text-[10px] px-1.5 py-0.5 rounded font-medium overflow-hidden ${baseClasses}`}>
+    <span className={`relative text-xs px-1.5 py-0.5 rounded font-medium overflow-hidden ${baseClasses}`}>
       <span 
         className="absolute inset-0 pointer-events-none opacity-[0.05]"
         style={{
@@ -142,7 +142,7 @@ function MenuFeaturedRail({
         </div>
       ) : null}
       <div className="flex flex-1 flex-col p-5">
-        <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[#D3126A]">{eyebrow}</p>
+        <p className="text-sm font-semibold uppercase tracking-[0.16em] text-[#D3126A]">{eyebrow}</p>
         <h4 className="mt-2 font-heading text-lg font-semibold leading-snug text-white md:text-xl">{title}</h4>
         <p className="mt-2 flex-1 text-sm leading-relaxed text-white/70">{body}</p>
         <Link
@@ -1081,7 +1081,7 @@ export function MegaMenu() {
 
               {scrollContext && (
                 <div className="mb-5">
-                  <p className="mb-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-[#D3126A]">
+                  <p className="mb-2 text-sm font-semibold uppercase tracking-[0.16em] text-[#D3126A]">
                     On this page
                   </p>
                   <div className="flex flex-wrap gap-2">
@@ -1143,7 +1143,7 @@ export function MegaMenu() {
                         <div className="mt-2 ml-1 space-y-1 rounded-xl border border-de-hairline bg-de-raised p-3">
                           {item.sections.map((section) => (
                             <div key={section.title} className="mb-4 last:mb-0">
-                              <h4 className="mb-3 px-2 pt-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-[#D3126A]">
+                              <h4 className="mb-3 px-2 pt-1 text-sm font-semibold uppercase tracking-[0.16em] text-[#D3126A]">
                                 {section.title}
                               </h4>
                               <div className="space-y-1">

--- a/client/src/components/ServiceCapabilityMatrix.tsx
+++ b/client/src/components/ServiceCapabilityMatrix.tsx
@@ -182,7 +182,7 @@ export function ServiceCapabilityMatrix({
     }
     if (value === "Add-on" || value === "Optional") {
       return (
-        <span className={`px-2 py-0.5 rounded-full text-[11px] font-medium ${
+        <span className={`px-2 py-0.5 rounded-full text-sm font-medium ${
           isHighlighted 
             ? 'bg-de-raised text-de-accent-ink border border-de-hairline' 
             : 'bg-amber-500/15 text-amber-400 border border-amber-500/20'
@@ -192,7 +192,7 @@ export function ServiceCapabilityMatrix({
       );
     }
     return (
-      <span className={`px-2 py-0.5 rounded-full text-[11px] font-medium ${
+      <span className={`px-2 py-0.5 rounded-full text-sm font-medium ${
         isHighlighted 
           ? 'bg-de-raised text-de-accent-ink border border-de-hairline' 
           : 'bg-white/5 text-white/70 border border-white/10'
@@ -232,9 +232,9 @@ export function ServiceCapabilityMatrix({
             }`}>
               {tier.name}
             </div>
-            <div className="text-[10px] text-white/50">{tier.price}</div>
+            <div className="text-xs text-white/50">{tier.price}</div>
             {highlightTier === tier.id && (
-              <div className="text-[9px] text-de-accent-ink mt-0.5">Recommended</div>
+              <div className="text-xs text-de-accent-ink mt-0.5">Recommended</div>
             )}
           </div>
         ))}

--- a/client/src/components/SiteBottomBar.tsx
+++ b/client/src/components/SiteBottomBar.tsx
@@ -23,7 +23,7 @@ function AskDELauncherButton() {
       aria-label="Open DE Desk"
       aria-expanded={false}
     >
-      <span className="relative flex h-8 w-8 items-center justify-center rounded-full bg-[#D3126A] text-[11px] font-bold tracking-tight">
+      <span className="relative flex h-8 w-8 items-center justify-center rounded-full bg-[#D3126A] text-sm font-bold tracking-tight">
         DE
         <span className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full border-2 border-[#0a0a0a] bg-emerald-400" />
       </span>

--- a/client/src/components/VirtualMspAdvisor.tsx
+++ b/client/src/components/VirtualMspAdvisor.tsx
@@ -501,7 +501,7 @@ export function VirtualMspAdvisor() {
               <Send size={16} />
             </Button>
           </form>
-          <div className="px-3 pb-2 bg-white text-[10px] text-slate-400 text-center">
+          <div className="px-3 pb-2 bg-white text-xs text-slate-400 text-center">
             Not a general chatbot · Digerati Experts · 325-480-9870
           </div>
         </div>

--- a/client/src/components/ZohoBookingWidget.tsx
+++ b/client/src/components/ZohoBookingWidget.tsx
@@ -115,7 +115,7 @@ function BookingFallback({ className = "" }: { className?: string }) {
       className={`flex h-full min-h-[22rem] flex-col justify-center rounded-xl border border-de-hairline bg-de-raised p-6 md:p-8 ${className}`}
       data-testid="booking-fallback"
     >
-      <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[#D3126A]">
+      <p className="text-sm font-semibold uppercase tracking-[0.16em] text-[#D3126A]">
         Next step
       </p>
       <h3 className="mt-2 font-heading text-xl font-semibold tracking-[-0.02em] text-white md:text-2xl">

--- a/client/src/components/store/CoverageScorePanel.tsx
+++ b/client/src/components/store/CoverageScorePanel.tsx
@@ -36,7 +36,7 @@ export function CoverageScorePanel({
             {score.total}
             <span className="text-sm font-medium text-white/55"> / 100</span>
           </span>
-          <p className="text-[11px] text-white/55" data-testid="text-coverage-areas">
+          <p className="text-sm text-white/55" data-testid="text-coverage-areas">
             {score.coveredCount} of {score.dimensionCount} areas
           </p>
         </div>
@@ -62,7 +62,7 @@ export function CoverageScorePanel({
               />
             </div>
             {bar.coveredBy && (
-              <span className="hidden w-28 truncate text-[10px] text-white/55 sm:inline">
+              <span className="hidden w-28 truncate text-xs text-white/55 sm:inline">
                 {bar.coveredBy}
               </span>
             )}
@@ -80,7 +80,7 @@ export function CoverageScorePanel({
                 className="flex items-start justify-between gap-2 rounded-lg border border-white/10 bg-white/[0.03] p-3"
               >
                 <div className="min-w-0">
-                  <p className="text-[10px] uppercase tracking-wide text-white/55">{s.label}</p>
+                  <p className="text-xs uppercase tracking-wide text-white/55">{s.label}</p>
                   <p className="truncate text-sm text-white">{s.product.name}</p>
                   <p className="text-xs text-white/55">
                     Coverage {s.from} → {s.to}

--- a/client/src/components/store/ProductCompare.tsx
+++ b/client/src/components/store/ProductCompare.tsx
@@ -128,7 +128,7 @@ export function ProductCompareDrawer({
                           {getProductTags(p).map((t) => (
                             <span
                               key={t}
-                              className="rounded-full border border-white/10 bg-white/[0.04] px-2 py-0.5 text-[11px] text-white/60"
+                              className="rounded-full border border-white/10 bg-white/[0.04] px-2 py-0.5 text-sm text-white/60"
                             >
                               {t}
                             </span>

--- a/client/src/components/store/ProductMedia.tsx
+++ b/client/src/components/store/ProductMedia.tsx
@@ -84,12 +84,12 @@ export function ProductMedia({
       {(categoryBadge || visual.vendor) && variant !== "thumb" && (
         <div className="absolute left-3 top-3 z-10 flex max-w-[85%] flex-wrap gap-2 sm:left-4 sm:top-4">
           {categoryBadge && (
-            <span className="rounded-full border border-white/20 bg-black/50 px-2.5 py-1 text-[11px] font-medium text-white/90 backdrop-blur-sm sm:text-xs">
+            <span className="rounded-full border border-white/20 bg-black/50 px-2.5 py-1 text-sm font-medium text-white/90 backdrop-blur-sm sm:text-xs">
               {categoryBadge}
             </span>
           )}
           {visual.vendor && (
-            <span className="rounded-full border border-white/20 bg-black/50 px-2.5 py-1 text-[11px] font-medium text-white/90 backdrop-blur-sm sm:text-xs">
+            <span className="rounded-full border border-white/20 bg-black/50 px-2.5 py-1 text-sm font-medium text-white/90 backdrop-blur-sm sm:text-xs">
               {visual.vendor.name}
             </span>
           )}

--- a/client/src/components/store/ShoppingCart.tsx
+++ b/client/src/components/store/ShoppingCart.tsx
@@ -228,7 +228,7 @@ export function ShoppingCart() {
                                   <h4 className="line-clamp-1 font-medium text-white">
                                     {item.product.name}
                                   </h4>
-                                  <p className="truncate text-[11px] text-white/55">
+                                  <p className="truncate text-sm text-white/55">
                                     {item.product.sku}
                                   </p>
                                   <p className="text-sm text-white/50">

--- a/client/src/components/store/StoreProductCard.tsx
+++ b/client/src/components/store/StoreProductCard.tsx
@@ -120,22 +120,22 @@ export function StoreProductCard({
         <div className="mb-4">
           <div className="mb-2 flex flex-wrap items-center gap-1.5">
             {vendor && (
-              <span className="rounded-full border border-white/10 bg-white/[0.04] px-2.5 py-0.5 text-[11px] font-medium text-white/70">
+              <span className="rounded-full border border-white/10 bg-white/[0.04] px-2.5 py-0.5 text-sm font-medium text-white/70">
                 {vendor.name}
               </span>
             )}
             <span
-              className={`de-store-category rounded-full border border-white/10 bg-white/[0.04] px-2.5 py-0.5 text-[11px] font-medium uppercase tracking-wide ${accent}`}
+              className={`de-store-category rounded-full border border-white/10 bg-white/[0.04] px-2.5 py-0.5 text-sm font-medium uppercase tracking-wide ${accent}`}
             >
               {categoryLabels[product.category]}
             </span>
             {product.isClientOnly && (
-              <span className="rounded-full border border-de-accent/30 bg-de-accent/15 px-2.5 py-0.5 text-[11px] font-medium text-de-accent-ink">
+              <span className="rounded-full border border-de-accent/30 bg-de-accent/15 px-2.5 py-0.5 text-sm font-medium text-de-accent-ink">
                 Client pricing
               </span>
             )}
             {isContract && (
-              <span className="rounded-full border border-amber-500/30 bg-amber-500/10 px-2.5 py-0.5 text-[11px] font-medium text-amber-200">
+              <span className="rounded-full border border-amber-500/30 bg-amber-500/10 px-2.5 py-0.5 text-sm font-medium text-amber-200">
                 Consult
               </span>
             )}
@@ -175,7 +175,7 @@ export function StoreProductCard({
           {tags.map((tag) => (
             <span
               key={tag}
-              className="rounded-full border border-white/10 bg-white/[0.03] px-2.5 py-0.5 text-[11px] text-white/55"
+              className="rounded-full border border-white/10 bg-white/[0.03] px-2.5 py-0.5 text-sm text-white/55"
             >
               {tag}
             </span>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -10,33 +10,37 @@
 /* Performance & Accessibility Optimizations */
 html {
   scroll-behavior: smooth;
-  /* Scale down overall sizing - 14px base instead of 16px default */
-  /* This makes 100% zoom look similar to previous 87.5% zoom */
-  font-size: 14px;
+  /*
+   * Browser-default rem. The previous 14px root made every rem-based
+   * size (type, padding, gaps) read as ~87.5% zoom. Marketing pages
+   * need the full 16px scale so body copy and nav labels stay readable
+   * at 100% without asking visitors to pinch-zoom.
+   */
+  font-size: 16px;
   /* Keep in-page anchors clear of fixed MegaMenu chrome */
   scroll-padding-top: var(--de-nav-offset);
 }
 
 /*
  * Large-display type scale.
- * 14px stays the laptop/monitor default. TVs and 4K walls need a real step
+ * 16px is the laptop/monitor default. TVs and 4K walls need a real step
  * up so the first viewport reads from the couch — not a 1px bump.
  */
 @media (min-width: 1920px) {
-  html {
-    font-size: 16px;
-  }
-}
-
-@media (min-width: 2560px) {
   html {
     font-size: 18px;
   }
 }
 
-@media (min-width: 3840px) {
+@media (min-width: 2560px) {
   html {
     font-size: 20px;
+  }
+}
+
+@media (min-width: 3840px) {
+  html {
+    font-size: 22px;
   }
 }
 
@@ -1010,7 +1014,7 @@ html {
 
 :root {
   --paragraph-2-font-family: "Inter", Helvetica;
-  --paragraph-2-font-size: 14px;
+  --paragraph-2-font-size: 1rem;
   --paragraph-2-font-style: normal;
   --paragraph-2-font-weight: 400;
   --paragraph-2-letter-spacing: 0px;

--- a/client/src/pages/portal/AdminLoginKnocks.tsx
+++ b/client/src/pages/portal/AdminLoginKnocks.tsx
@@ -185,7 +185,7 @@ export function AdminLoginKnocks() {
                         </p>
                       )}
                       {k.userAgent && (
-                        <p className="text-[11px] text-muted-foreground truncate" title={k.userAgent}>
+                        <p className="text-sm text-muted-foreground truncate" title={k.userAgent}>
                           {k.userAgent}
                         </p>
                       )}

--- a/client/src/pages/portal/OrderForm.tsx
+++ b/client/src/pages/portal/OrderForm.tsx
@@ -466,7 +466,7 @@ export function OrderForm() {
                                 data-testid={`service-card-${service.id}`}
                               >
                                 {service.isPopular && (
-                                  <Badge className="absolute -top-2 right-3 bg-[#5034ff] text-white text-[10px] px-1.5 py-0">
+                                  <Badge className="absolute -top-2 right-3 bg-[#5034ff] text-white text-xs px-1.5 py-0">
                                     <Star className="w-2.5 h-2.5 mr-0.5" />
                                     Popular
                                   </Badge>
@@ -481,7 +481,7 @@ export function OrderForm() {
                                       {service.tier && (
                                         <Badge
                                           variant="outline"
-                                          className={`text-[10px] h-5 ${
+                                          className={`text-xs h-5 ${
                                             service.tier === "enterprise"
                                               ? "border-violet-300 text-violet-700 bg-violet-50"
                                               : service.tier === "business"
@@ -501,13 +501,13 @@ export function OrderForm() {
                                       {service.features.slice(0, 3).map((feature, i) => (
                                         <span
                                           key={i}
-                                          className="text-[11px] bg-slate-100 text-slate-600 px-1.5 py-0.5 rounded"
+                                          className="text-sm bg-slate-100 text-slate-600 px-1.5 py-0.5 rounded"
                                         >
                                           {feature}
                                         </span>
                                       ))}
                                       {service.features.length > 3 && (
-                                        <span className="text-[11px] text-[#5034ff]">
+                                        <span className="text-sm text-[#5034ff]">
                                           +{service.features.length - 3} more
                                         </span>
                                       )}
@@ -525,10 +525,10 @@ export function OrderForm() {
                                       {price.primary}
                                     </div>
                                     {price.secondary && (
-                                      <div className="text-[11px] text-slate-400">{price.secondary}</div>
+                                      <div className="text-sm text-slate-400">{price.secondary}</div>
                                     )}
                                     {service.minQuantity > 1 && (
-                                      <div className="text-[11px] text-slate-400">
+                                      <div className="text-sm text-slate-400">
                                         Min: {service.minQuantity}
                                       </div>
                                     )}

--- a/client/src/pages/portal/PortalChat.tsx
+++ b/client/src/pages/portal/PortalChat.tsx
@@ -581,7 +581,7 @@ export default function PortalChat() {
         <div className="overflow-hidden rounded-2xl border border-[#8B5CF6]/35 bg-gradient-to-br from-[#1a0f2e] via-[#140a24] to-[#0f0818] p-4 text-white shadow-[0_0_0_1px_rgba(167,139,250,0.2),0_20px_50px_rgba(40,10,70,0.35)] sm:p-5">
           <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
             <div className="min-w-0">
-              <div className="mb-2 inline-flex items-center gap-2 rounded-full border border-[#A78BFA]/35 bg-[#8B5CF6]/15 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-[#E9D5FF]">
+              <div className="mb-2 inline-flex items-center gap-2 rounded-full border border-[#A78BFA]/35 bg-[#8B5CF6]/15 px-2.5 py-1 text-sm font-semibold uppercase tracking-[0.14em] text-[#E9D5FF]">
                 <Headphones className="h-3.5 w-3.5" aria-hidden />
                 Operations desk
               </div>
@@ -735,7 +735,7 @@ export default function PortalChat() {
                   </div>
                 ) : (
                   <>
-                    <p className="border-b border-white/5 px-4 py-2 text-[10px] uppercase tracking-[0.14em] text-white/40">
+                    <p className="border-b border-white/5 px-4 py-2 text-xs uppercase tracking-[0.14em] text-white/40">
                       Long-press or right-click for options
                     </p>
                     <ul className="divide-y divide-white/5">
@@ -784,12 +784,12 @@ export default function PortalChat() {
                                         {sessionNameLabel(s)}
                                       </span>
                                       {sessionCompanyLabel(s) ? (
-                                        <span className="mt-0.5 block truncate text-[11px] font-normal text-white/45">
+                                        <span className="mt-0.5 block truncate text-sm font-normal text-white/45">
                                           {sessionCompanyLabel(s)}
                                         </span>
                                       ) : null}
                                     </span>
-                                    <span className="inline-flex shrink-0 items-center gap-1 text-[10px] text-white/45">
+                                    <span className="inline-flex shrink-0 items-center gap-1 text-xs text-white/45">
                                       <Clock3 className="h-3 w-3" aria-hidden />
                                       {formatClock(s.updatedAt)}
                                     </span>
@@ -797,7 +797,7 @@ export default function PortalChat() {
                                   <p className="mt-1 line-clamp-2 text-xs text-white/50">
                                     {s.preview || "DE Desk conversation"}
                                   </p>
-                                  <div className="mt-2 flex flex-wrap items-center gap-1.5 text-[10px]">
+                                  <div className="mt-2 flex flex-wrap items-center gap-1.5 text-xs">
                                     <span className="rounded-full bg-white/5 px-2 py-0.5 text-white/55">
                                       {s.messageCount} msgs
                                     </span>
@@ -915,7 +915,7 @@ export default function PortalChat() {
                           {activeSession ? sessionNameLabel(activeSession) : "Name not given yet"}
                         </p>
                         {activeSession && sessionCompanyLabel(activeSession) ? (
-                          <p className="truncate text-[11px] text-white/45">
+                          <p className="truncate text-sm text-white/45">
                             {sessionCompanyLabel(activeSession)}
                           </p>
                         ) : null}
@@ -952,12 +952,12 @@ export default function PortalChat() {
                           </Button>
                         ) : null}
                         {activeSession?.agentActive ? (
-                          <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-emerald-400/30 bg-emerald-400/10 px-2.5 py-1 text-[11px] font-semibold text-emerald-300">
+                          <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-emerald-400/30 bg-emerald-400/10 px-2.5 py-1 text-sm font-semibold text-emerald-300">
                             <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" />
                             On desk
                           </span>
                         ) : (
-                          <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-white/10 bg-white/5 px-2.5 py-1 text-[11px] font-medium text-white/55">
+                          <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-white/10 bg-white/5 px-2.5 py-1 text-sm font-medium text-white/55">
                             Standby
                           </span>
                         )}
@@ -987,7 +987,7 @@ export default function PortalChat() {
                                       : "rounded-bl-md border border-white/10 bg-white/[0.06] text-white/90"
                                 }`}
                               >
-                                <div className="mb-1 flex items-center justify-between gap-3 text-[10px] uppercase tracking-[0.12em] opacity-70">
+                                <div className="mb-1 flex items-center justify-between gap-3 text-xs uppercase tracking-[0.12em] opacity-70">
                                   <span>
                                     {isUser
                                       ? "Visitor"
@@ -1037,7 +1037,7 @@ export default function PortalChat() {
                           <Send className="h-4 w-4" />
                         </Button>
                       </div>
-                      <p className="mt-2 text-[11px] text-white/40">
+                      <p className="mt-2 text-sm text-white/40">
                         Enter to send · Shift+Enter for newline · This channel is website DE Desk
                         only
                       </p>
@@ -1096,7 +1096,7 @@ export default function PortalChat() {
                         >
                           <p className="mb-1 text-xs font-medium opacity-70">{message.senderName}</p>
                           <p className="whitespace-pre-wrap text-sm">{message.content}</p>
-                          <p className="mt-1 text-[10px] opacity-60">
+                          <p className="mt-1 text-xs opacity-60">
                             {formatClock(message.timestamp)}
                           </p>
                         </div>

--- a/client/src/pages/portal/PortalLearning.tsx
+++ b/client/src/pages/portal/PortalLearning.tsx
@@ -252,17 +252,17 @@ export default function PortalLearning() {
                         </div>
                         <div className="min-w-0">
                           <div className="flex items-center gap-2">
-                            <span className="text-[11px] font-mono text-muted-foreground">
+                            <span className="text-sm font-mono text-muted-foreground">
                               {String(idx + 1).padStart(2, "0")}
                             </span>
                             {lesson.badge && (
-                              <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
+                              <Badge variant="secondary" className="text-xs px-1.5 py-0">
                                 {lesson.badge}
                               </Badge>
                             )}
                           </div>
                           <p className="text-sm font-medium leading-snug mt-0.5">{lesson.title}</p>
-                          <p className="text-[11px] text-muted-foreground mt-0.5">{lesson.minutes} min</p>
+                          <p className="text-sm text-muted-foreground mt-0.5">{lesson.minutes} min</p>
                         </div>
                       </div>
                     </button>
@@ -404,7 +404,7 @@ export default function PortalLearning() {
                   <div key={doc.slug} className="border-b border-border/50 pb-2 last:border-0 last:pb-0">
                     <p className="text-sm font-medium leading-snug">{doc.title}</p>
                     {doc.category && (
-                      <p className="text-[11px] text-muted-foreground mt-0.5 capitalize">
+                      <p className="text-sm text-muted-foreground mt-0.5 capitalize">
                         {String(doc.category).replace(/_/g, " ")}
                       </p>
                     )}

--- a/client/src/pages/portal/PortalOrders.tsx
+++ b/client/src/pages/portal/PortalOrders.tsx
@@ -298,7 +298,7 @@ export default function PortalOrders() {
                           <td className="py-4 px-3 max-w-[220px]">
                             <p className="truncate font-medium">{order.title || order.billingName || "—"}</p>
                             {order.hubStatus && (
-                              <p className="text-[11px] text-muted-foreground truncate">
+                              <p className="text-sm text-muted-foreground truncate">
                                 Hub: {order.hubStatus}
                               </p>
                             )}

--- a/client/src/pages/resources/Blog.tsx
+++ b/client/src/pages/resources/Blog.tsx
@@ -131,7 +131,7 @@ export default function Blog() {
         <div className="container relative mx-auto px-4 max-w-7xl py-10 md:py-14">
           <div className="flex flex-col md:flex-row md:items-end md:justify-between gap-6">
             <div>
-              <div className="inline-flex items-center gap-2 text-[11px] font-semibold tracking-[0.2em] text-white/70 uppercase mb-3">
+              <div className="inline-flex items-center gap-2 text-sm font-semibold tracking-[0.2em] text-white/70 uppercase mb-3">
                 <Sparkles className="h-3.5 w-3.5" />
                 A Digerati Experts Publication
               </div>
@@ -205,7 +205,7 @@ export default function Blog() {
                   >
                     {cat === "All" ? "All Posts" : cat}
                     <span
-                      className={`ml-2 inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 rounded-full text-[10px] font-semibold ${
+                      className={`ml-2 inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 rounded-full text-xs font-semibold ${
                         isActive
                           ? "bg-white text-de-accent"
                           : "bg-white/10 text-white/60"
@@ -340,7 +340,7 @@ export default function Blog() {
                       />
                       <div className="absolute inset-0 bg-gradient-to-t from-[#0a0a0a]/70 via-transparent to-transparent" />
                       <div className="absolute top-3 left-3">
-                        <Badge className="bg-black/60 text-white border-white/15 backdrop-blur uppercase text-[10px] tracking-wider font-semibold">
+                        <Badge className="bg-black/60 text-white border-white/15 backdrop-blur uppercase text-xs tracking-wider font-semibold">
                           {post.category}
                         </Badge>
                       </div>

--- a/client/src/pages/resources/BlogPost.tsx
+++ b/client/src/pages/resources/BlogPost.tsx
@@ -505,7 +505,7 @@ export default function BlogPost() {
                   data-testid="tab-overview"
                 >
                   Overview
-                  <span className="ml-2 text-[11px] opacity-70">
+                  <span className="ml-2 text-sm opacity-70">
                     {body.overviewReadTime}
                   </span>
                 </button>
@@ -522,7 +522,7 @@ export default function BlogPost() {
                   data-testid="tab-extended"
                 >
                   Extended Deep Dive
-                  <span className="ml-2 text-[11px] opacity-70">
+                  <span className="ml-2 text-sm opacity-70">
                     {body.extendedReadTime}
                   </span>
                 </button>
@@ -554,7 +554,7 @@ export default function BlogPost() {
               <aside className="hidden lg:block lg:col-span-3" aria-label="Table of contents">
                 <div className="sticky top-28">
                   <div className="rounded-2xl border border-white/10 bg-gradient-to-b from-white/[0.04] to-white/[0.01] p-5 backdrop-blur-sm shadow-[0_10px_40px_-20px_rgba(179,0,255,0.4)]">
-                    <div className="flex items-center gap-2 text-[11px] font-bold text-white/80 mb-5 uppercase tracking-[0.18em]">
+                    <div className="flex items-center gap-2 text-sm font-bold text-white/80 mb-5 uppercase tracking-[0.18em]">
                       <span className="inline-flex items-center justify-center w-6 h-6 rounded-md bg-de-raised border border-de-hairline">
                         <List className="h-3.5 w-3.5 text-de-accent-ink" />
                       </span>
@@ -591,7 +591,7 @@ export default function BlogPost() {
                                   {/* Step dot */}
                                   <span
                                     aria-hidden
-                                    className={`absolute left-[3px] top-[11px] w-3.5 h-3.5 rounded-full border-2 transition-all duration-300 flex items-center justify-center text-[8px] font-bold ${
+                                    className={`absolute left-[3px] top-[11px] w-3.5 h-3.5 rounded-full border-2 transition-all duration-300 flex items-center justify-center text-[0.625rem] font-bold ${
                                       isActive
                                         ? "bg-de-accent border-white/80 scale-110"
                                         : isPast
@@ -621,7 +621,7 @@ export default function BlogPost() {
                                     }`}
                                     data-testid={`toc-${h.id}`}
                                   >
-                                    <span className="text-[10px] font-bold opacity-50 mr-2 tabular-nums">
+                                    <span className="text-xs font-bold opacity-50 mr-2 tabular-nums">
                                       {String(i + 1).padStart(2, "0")}
                                     </span>
                                     {h.text}
@@ -632,7 +632,7 @@ export default function BlogPost() {
                           </ul>
                           {/* Progress meter */}
                           <div className="mt-5 pt-4 border-t border-white/10">
-                            <div className="flex items-center justify-between text-[10px] font-semibold uppercase tracking-wider text-white/50 mb-2">
+                            <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-wider text-white/50 mb-2">
                               <span>Progress</span>
                               <span className="text-de-accent-ink tabular-nums">
                                 {activeIdx < 0 ? 0 : activeIdx + 1}/{headings.length}
@@ -758,7 +758,7 @@ export default function BlogPost() {
                             <Icon className="h-5 w-5" />
                           </div>
                           <div className="flex-1 min-w-0">
-                            <span className={`inline-block text-[10px] font-bold uppercase tracking-[0.14em] mb-2 px-2 py-0.5 rounded-full border ${toneCfg.chip}`}>
+                            <span className={`inline-block text-xs font-bold uppercase tracking-[0.14em] mb-2 px-2 py-0.5 rounded-full border ${toneCfg.chip}`}>
                               {renderTokens(block.title ?? toneCfg.defaultTitle, wordCounter)}
                             </span>
                             <p className="text-white/90 text-[16px] leading-[1.7]">
@@ -881,7 +881,7 @@ export default function BlogPost() {
                             <Icon className="h-5 w-5" />
                           </div>
                           <div className="flex-1 min-w-0">
-                            <span className={`inline-block text-[10px] font-bold uppercase tracking-[0.14em] mb-2 px-2 py-0.5 rounded-full border ${toneCfg.chip}`}>
+                            <span className={`inline-block text-xs font-bold uppercase tracking-[0.14em] mb-2 px-2 py-0.5 rounded-full border ${toneCfg.chip}`}>
                               {renderTokens(toneCfg.title, wordCounter)}
                             </span>
                             <p className="text-white/90 text-[16px] leading-[1.7]">

--- a/client/src/pages/resources/SecurityUpdates.tsx
+++ b/client/src/pages/resources/SecurityUpdates.tsx
@@ -151,7 +151,7 @@ export default function SecurityUpdates() {
                         {formatThreatDate(update.publishedAt, "short")}
                       </span>
                     </div>
-                    <p className="mb-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-[#D3126A]">
+                    <p className="mb-2 text-sm font-semibold uppercase tracking-[0.14em] text-[#D3126A]">
                       {update.kicker}
                     </p>
                     <CardTitle className="text-lg text-white line-clamp-2">{update.title}</CardTitle>

--- a/client/src/pages/sections/BlogSection.tsx
+++ b/client/src/pages/sections/BlogSection.tsx
@@ -255,7 +255,7 @@ export const BlogSection = (): JSX.Element => {
                   </a>
                   {link.version && (
                     <Badge className="h-auto bg-[#5034ff26] rounded-lg border border-solid border-[#5034ff4c] px-2 lg:px-[11px] py-1 lg:py-1.5 hover:bg-[#5034ff26]">
-                      <span className="font-bold text-[#5034ff] text-[10px] lg:text-[11px] tracking-[0] leading-[18.7px]">
+                      <span className="font-bold text-[#5034ff] text-xs lg:text-sm tracking-[0] leading-[18.7px]">
                         {link.version}
                       </span>
                     </Badge>

--- a/client/src/pages/sections/DigeratiThreatsInsightsSection.tsx
+++ b/client/src/pages/sections/DigeratiThreatsInsightsSection.tsx
@@ -50,7 +50,7 @@ function InsightCard({ insight, index }: { insight: ThreatItem; index: number })
             <span className="sm:hidden">{formatThreatDate(insight.publishedAt, "short")}</span>
           </span>
         </div>
-        <p className="mb-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-de-magenta-ink">
+        <p className="mb-2 text-sm font-semibold uppercase tracking-[0.14em] text-de-magenta-ink">
           {insight.kicker}
         </p>
         <CardTitle className="text-base sm:text-lg text-white line-clamp-2">

--- a/client/src/pages/sections/ModernHeroSection.tsx
+++ b/client/src/pages/sections/ModernHeroSection.tsx
@@ -97,7 +97,7 @@ export const ModernHeroSection = (): JSX.Element => {
                 Arizona MSP · Cybersecurity &amp; Managed IT
               </motion.p>
 
-              <h1 className="text-[clamp(1.85rem,7.4vw,3.55rem)] font-bold leading-[1.12] tracking-[-0.03em] text-white">
+              <h1 className="text-[clamp(2.25rem,8vw,3.75rem)] font-bold leading-[1.12] tracking-[-0.03em] text-white">
                 <span>Your Arizona business,</span>
                 <br />
                 <span className="text-[#D3126A]">
@@ -164,7 +164,7 @@ export const ModernHeroSection = (): JSX.Element => {
                   </span>
                 </div>
 
-                <p className="text-base text-white/55 max-w-xl leading-relaxed">
+                <p className="text-base text-white/75 max-w-xl leading-relaxed">
                   Arizona-based · Principal-led · Recommendations sized to your business
                   <span className="mx-2 text-white/25" aria-hidden="true">
                     ·

--- a/client/src/pages/store/ProductDetail.tsx
+++ b/client/src/pages/store/ProductDetail.tsx
@@ -298,7 +298,7 @@ const ProductDetail = () => {
                   {tags.map((tag) => (
                     <span
                       key={tag}
-                      className="rounded-full border border-white/10 bg-white/[0.04] px-2.5 py-0.5 text-[11px] text-white/55"
+                      className="rounded-full border border-white/10 bg-white/[0.04] px-2.5 py-0.5 text-sm text-white/55"
                     >
                       {tag}
                     </span>

--- a/design/DESIGN_SYSTEM.md
+++ b/design/DESIGN_SYSTEM.md
@@ -71,6 +71,7 @@ Do not introduce a new purple, magenta, or near-black. Reuse these.
 - Body: Inter, weight 400, line-height `1.6` (prose `1.75`)
 - Stats/numbers: Oxanium, fallback JetBrains Mono
 - Root font-size: `16px` (`18px` at 1920px, `20px` at 2560px, `22px` at 3840px)
+- Small type: `text-xs` = `0.875rem` (14px), `text-sm` = `1rem` (16px) — lifted so chips and captions stay readable
 - Tailwind: `font-heading`, `font-sans` / `font-body`, `font-mono`
 
 ## Radius

--- a/design/DESIGN_SYSTEM.md
+++ b/design/DESIGN_SYSTEM.md
@@ -70,7 +70,7 @@ Do not introduce a new purple, magenta, or near-black. Reuse these.
 - Headings: Space Grotesk, weight 600–700, letter-spacing `-0.015em` to `-0.03em`, line-height `1.15`
 - Body: Inter, weight 400, line-height `1.6` (prose `1.75`)
 - Stats/numbers: Oxanium, fallback JetBrains Mono
-- Root font-size: `14px` (`15px` at 1920px, `16px` at 2560px)
+- Root font-size: `16px` (`18px` at 1920px, `20px` at 2560px, `22px` at 3840px)
 - Tailwind: `font-heading`, `font-sans` / `font-body`, `font-mono`
 
 ## Radius

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -69,6 +69,12 @@ module.exports = {
         md: "calc(var(--radius) - 2px)",
         sm: "calc(var(--radius) - 4px)",
       },
+      // Lift the small end of the scale so chips, spy nav, and captions
+      // stay readable after the 16px rem restore. text-base stays 1rem.
+      fontSize: {
+        xs: ["0.875rem", { lineHeight: "1.35" }],
+        sm: ["1rem", { lineHeight: "1.5" }],
+      },
       backgroundImage: {
         'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
       },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
The site was deliberately scaled to a **14px** `html` rem root so 100% zoom looked like 87.5%. That made body copy, nav labels, and chips too small across every rem-based page.

This restores the **16px** browser default and steps large displays up (`18 / 20 / 22`). It also lifts the small end of the Tailwind scale (`text-xs` → 14px, `text-sm` → 16px) and moves leftover `8–13px` labels onto rem classes so they grow with the rest of the site.

## Why
DE: every text is too small and not visible enough after the visual polish pass. Size is the lever — this is not another color sweep.

## Files
- `client/src/index.css` — root rem scale
- `tailwind.config.ts` — xs/sm type tokens
- `design/DESIGN_SYSTEM.md` — documented scale
- Homepage hero clamp + contact-line contrast
- Cookie bar, spy nav, mega menu, store/blog labels that still used hardcoded px

## Preserved
- No content, CTAs, nav items, or stats removed
- Page accents and store category hues unchanged
- Portal login URL unchanged

## Verify
Homepage, store, and support at 390 / 768 / 1440 after the rem bump. Watch nav wrap and card density.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55eac13a-e87f-4a00-9c34-f63bb77c3080&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

