### PR TITLE
One paper Desk theme and vendor-forward store cards

### DIFF
--- a/.cursor/rules/blog-store-color-lock.mdc
+++ b/.cursor/rules/blog-store-color-lock.mdc
@@ -1,0 +1,40 @@
+---
+description: Freeze current Blog (Journal) and Store color systems — do not restyle
+globs:
+  - client/src/pages/resources/**
+  - client/src/pages/store/**
+  - client/src/components/store/**
+  - client/src/App.tsx
+  - client/src/index.css
+alwaysApply: true
+---
+
+# Blog and Store color lock
+
+DE settled these palettes. Do **not** restyle them to magenta, paper, cyan, or another family’s hue. Size, layout, and type may change. **Colors stay.**
+
+Ask DE before changing any value below.
+
+## Blog / Journal (`/resources/blog`, `/resources/blog/*`)
+
+- Page accent: `data-accent="amber"` via `ACCENT_BY_PREFIX` in `client/src/App.tsx` (`/resources` and `/case-studies`).
+- Tokens in `client/src/index.css`: `--de-accent-rgb: 180 83 9`; `--de-accent-ink-rgb: 251 191 36`.
+- Masthead stays the charcoal ladder (`#050312` → `#0a0a0a` → `#151217`). “Journal” uses `text-de-accent-ink` (amber), not magenta.
+- Do not flatten the Journal to a paper chapter or repaint it electric/magenta/cyan.
+
+## Store (`/store`, `/store/*`)
+
+- Page accent: `data-accent="electric"`.
+- Tokens: `--de-accent-rgb: 29 111 242`; `--de-accent-ink-rgb: 111 179 255`.
+- Category pills stay **pill-only** with the 14 distinct hues in `categoryAccent` (`StoreProductCard.tsx`). Guard: `categoryAccent.test.ts`.
+  - `comanaged_subscriptions` teal-300, `comanaged_onboarding` lime-300, `digital_templates` yellow-300, `professional_services` pink-300.
+- Do not paint cards, rails, or the catalog field with those pill hues. Do not collapse pills onto violet/purple/indigo or onto one store-wide color.
+- Vendor marks stay vendor colors. Do not recolor logos.
+
+## Shared
+
+- Primary marketing CTA fill stays `#D3126A` sitewide, including on blog and store chrome that is not the page accent.
+- Gold (`#e7b20d`) is the wordmark bars only — not a blog or store fill.
+- Portal `/portal/*` is out of scope.
+
+If a sweep, audit, or “one theme” pass wants to unify accents: **skip blog and store.**

--- a/.cursor/rules/brand.mdc
+++ b/.cursor/rules/brand.mdc
@@ -49,6 +49,7 @@ Accent:
 Homepage chapters must juxtapose this ladder (well / surface / paper / magenta) — do not flatten every section to one `#0a0a0a` slab.
 The DE mark is white type + gold 3-bar icon (`#e7b20d`). Gold is secondary only. Do not adopt reference-site yellow as a brand or CTA color.
 Executable rule: `.cursor/rules/dark-field-accent-pop.mdc`.
+Blog/Journal and Store palettes are locked — `.cursor/rules/blog-store-color-lock.mdc`.
 ## MATERIALS
 Preferred:
 - graphite wells and charcoal raised boxes (hairline, not color-filled)

--- a/.cursor/rules/de-desk-design.mdc
+++ b/.cursor/rules/de-desk-design.mdc
@@ -1,5 +1,5 @@
 ---
-description: DE Desk widget visual + copy playbook (light shell, dark boxes, function labels)
+description: DE Desk widget visual + copy playbook (one paper theme, function labels)
 globs: client/src/components/ZohoASAPWidget.tsx,client/src/pages/portal/PortalChat.tsx
 alwaysApply: false
 ---
@@ -10,20 +10,19 @@ Primary file: `client/src/components/ZohoASAPWidget.tsx`. Full playbook: `.curso
 
 ## Shell (all tabs)
 
-- One **light chrome** frame for Desk / Ticket / Resources — white header, underline tabs, status row, light body.
-- **Dark boxes** sit on that light field (hero, prompt rows, form inputs).
-- **Dark composer + footer** stay graphite (`#131218` / `#0F0E14`).
+- **One paper theme** for Desk / Ticket / Resources — header, tabs, status, body, composer, and footer all sit on `#F7F5F2`.
+- **White raised cards** for hero, prompt rows, resource rows, and form fields.
 - Brand magenta `#D3126A` for avatar, active underline, send, CTAs. Violet `#8B5CF6` is icon-well accent only — no purple wash fills.
 - Active tab: dark label + magenta underline. Inactive: muted shell dim.
-- High contrast text always. Dark boxes use white type; labels on the light body use `#68637A`.
+- High contrast: dark ink on paper. Do not restore charcoal boxes or a black footer.
 
 ## Tab content
 
-| Tab | Panel inside light shell |
+| Tab | Panel inside paper shell |
 |-----|--------------------------|
-| **Desk** | Dark hero + dark prompt rows; conversation uses magenta user / dark assistant bubbles. |
-| **Ticket** | Same hero language + dark chip rows + dark inputs on the light body. |
-| **Resources** | Same hero language + dark resource rows + assessment highlight + security alert. |
+| **Desk** | Paper hero + paper prompt rows; conversation uses magenta user / paper assistant bubbles. |
+| **Ticket** | Same hero language + paper chip rows + light inputs. |
+| **Resources** | Same hero language + paper resource rows + assessment highlight + security alert. |
 
 Do not invent a third unrelated theme per tab. Elevate in place; ask DE before removing CTAs, tabs, disclaimers, or resource links.
 

--- a/.cursor/rules/ui-ux.mdc
+++ b/.cursor/rules/ui-ux.mdc
@@ -120,3 +120,4 @@ Canonical portal login: `https://portal.digeratiexperts.com/portal/login` — ne
 Preserve existing DE content, CTAs, nav, and stats unless DE explicitly approves removal.
 Inspect rendered UI at 390 / 768 / 1440 at minimum. Never judge UI from source code alone.
 Dark fields stay black/charcoal so `#D3126A` pops — see `.cursor/rules/dark-field-accent-pop.mdc`. No purple-filled boxes.
+Blog/Journal stays amber; Store stays electric + the 14 category-pill hues — `.cursor/rules/blog-store-color-lock.mdc`. Do not restyle those colors.

--- a/.cursor/skills/de-desk-ui/SKILL.md
+++ b/.cursor/skills/de-desk-ui/SKILL.md
@@ -2,9 +2,9 @@
 name: de-desk-ui
 description: >-
   Designs and restyles the DE Desk support widget (Desk / Ticket / Resources)
-  to DE’s approved dark-glass + dual-tone playbook. Use when editing
-  ZohoASAPWidget, DE Desk, Ask DE, ASAP widget, support modal tabs, desk
-  resources copy, or when DE attaches DE Desk mockups / asks for Desk UI polish.
+  as one paper theme. Use when editing ZohoASAPWidget, DE Desk, Ask DE, ASAP
+  widget, support modal tabs, desk resources copy, or when DE attaches DE Desk
+  mockups / asks for Desk UI polish.
 ---
 
 # DE Desk UI
@@ -12,18 +12,14 @@ description: >-
 ## Before you edit
 
 1. Read this skill, then [tokens-and-structure.md](tokens-and-structure.md).
-2. Open mockups under [references/](references/) with the Read tool (images):
-   - `resources-premium.png` / `resources-dark.png` — Resources quality bar
-   - `desk-dual-tone.png` — Desk light chat insert
-   - `ticket-dark.png` — Ticket dark nested form
-3. Screenshot live site with Browser after changes; compare to mockups.
-4. Prefer **Gemini 3.1 Pro** or **Composer 2.5** for visual passes when available.
+2. Screenshot live site with Browser after changes.
+3. Prefer **Gemini 3.1 Pro** or **Composer 2.5** for visual passes when available.
 
 ## Non-negotiables
 
-- **One shell** for all three tabs: light chrome (header, underline tabs, status) + dark composer/footer.
-- **Content boxes** are dark (hero, rows, inputs) on the light body — that contrast is the quality reference.
+- **One paper theme** for the whole widget: header, tabs, hero, rows, inputs, composer, and footer. No charcoal hero. No black footer. No white/black stripe.
 - **Desk / Ticket / Resources** share that language. Do not put a second nested theme per tab.
+- Magenta `#D3126A` is the only loud color (avatar, active tab, send, submit, user bubbles).
 - **Function labels**, not vendor names (`Remote session` not `Zoho Assist`). Keep hrefs.
 - Do **not** remove tabs, CTAs, disclaimers, or resource rows without asking DE.
 - Do **not** invent `//login`; use `PORTAL_LOGIN`.
@@ -34,12 +30,12 @@ description: >-
 
 ```
 DE Desk UI checklist:
-- [ ] Light shell chrome shared (no per-tab conflicting tab styles)
-- [ ] Dark boxes on the light body (hero, rows, inputs)
-- [ ] Dark composer + footer on all tabs
+- [ ] One paper field for the whole chrome
+- [ ] White raised cards for hero, rows, and form
+- [ ] Paper composer + footer (not charcoal)
 - [ ] Copy is function-based
-- [ ] Contrast checked (no white-on-white buttons)
-- [ ] Browser screenshot vs mockup
+- [ ] Contrast checked (dark ink on paper)
+- [ ] Browser screenshot
 - [ ] Logic untouched unless requested
 ```
 
@@ -47,19 +43,11 @@ DE Desk UI checklist:
 
 1. Change layout/classes in `client/src/components/ZohoASAPWidget.tsx` only as needed.
 2. Keep `RESOURCE_LINKS` titles functional; tags describe capability.
-3. Deploy path (production): commit → push `main` →  
-   `sudo -u diger7051 bash -lc 'DEPLOY_BRANCH=main bash /home/digeratiexperts.com/current/deploy/vps/deploy.sh production'`
-
-### If DE says “Resources good, X sucks”
-
-- Keep Resources.
-- Fix X to the shell + panel model above.
-- Do not reinvent the whole modal theme.
 
 ## Anti-patterns
 
-- Juxtaposed light inactive tabs only on one tab while others use underline dark tabs
-- Muddy mid-gradient chat backgrounds that kill text contrast
+- Dual-tone stripe (light header + charcoal cards + black footer)
+- Dark boxes on a light body
+- Muddy mid-gradient chat backgrounds
 - Product/vendor branding in client-facing resource titles
-- Outline buttons with default `bg-background` on dark pages (renders blank white)
 - Purple-on-cream / generic AI SaaS aesthetics unrelated to DE magenta brand

--- a/.cursor/skills/de-desk-ui/tokens-and-structure.md
+++ b/.cursor/skills/de-desk-ui/tokens-and-structure.md
@@ -2,30 +2,28 @@
 
 ## Brand tokens
 
-Map dark surfaces to the site ladder. Magenta pops because the field stays charcoal.
+One paper sheet. Magenta pops because the field stays cream.
 
 | Token | Value | Use |
 |-------|-------|-----|
 | Magenta | `#D3126A` | Avatar, active underline, send, CTAs, user bubbles |
 | Violet | `#8B5CF6` | Icon-well accent only — never a wash fill or CTA gradient |
-| Shell | `#FFFFFF` / paper `#F7F5F2` | Header, tabs, status, body |
-| Shell text | `#17141F` / `#5C5668` | Titles and labels on light chrome |
-| Raised | `#151217` | Hero, rows, composer |
-| Well | `#050312` | Inputs, footer, icon wells |
-| Hairline | `rgba(255,255,255,0.10)` | Dark borders |
-| Dark ink | `#fff` / 78% / 55% | Type on dark surfaces |
+| Field | paper `#F7F5F2` | Entire chrome: header, body, composer, footer |
+| Raised | `#FFFFFF` | Hero, rows, form card, composer input |
+| Hairline | `rgba(20,16,30,0.10)` | Paper borders |
+| Ink | `#17141F` / `#5C5668` | Titles and body on every tab |
 | Online | Emerald pip | Availability |
 
-Do **not** use plum washes (`#2e1d2a`), composer `#131218`, or magenta→violet CTA gradients.
+Do **not** use charcoal hero/rows, black footer, plum washes, or magenta→violet CTA gradients.
 
 ## Shared chrome (top → bottom)
 
 1. **Header** — magenta DE mark + green pip; title “DE Desk”; subtitle “Answers · Tickets · Assist”; close
 2. **Tabs** — Desk | Ticket | Resources; active = dark label + magenta underline
 3. **Status row** — paper field; green/sky/amber dot + “DE Desk is online” | “Need help now?”
-4. **Content** — light body; charcoal hero + charcoal rows / well inputs
-5. **Composer** — raised `#151217` ask bar + solid magenta send
-6. **Footer** — well `#050312`; “DE Desk · Ticket · Resources · Assist” (Assist → remote session) | Create ticket
+4. **Content** — paper body; white raised hero + white raised rows / light inputs
+5. **Composer** — paper ask bar + white input + solid magenta send
+6. **Footer** — paper; “DE Desk · Ticket · Resources · Assist” (Assist → remote session) | Create ticket
 
 ## Resources
 
@@ -36,15 +34,15 @@ Do **not** use plum washes (`#2e1d2a`), composer `#131218`, or magenta→violet 
 
 ## Desk
 
-- Charcoal hero “Talk to DE Desk” + charcoal prompt rows (all four visible)
-- After send: magenta user bubbles, dark assistant bubbles
-- Shared raised composer under all tabs
+- Paper hero “Talk to DE Desk” + paper prompt rows (all four visible)
+- After send: magenta user bubbles, paper assistant bubbles
+- Shared paper composer under all tabs
 
 ## Ticket
 
-- Charcoal hero “Create a support ticket”
+- Paper hero “Create a support ticket”
 - Subject chips in a 2×2 grid so the form starts in view
-- Form on the light body: Secure & private pill; well fields; solid magenta submit
+- Form on paper: Secure & private pill; light fields; solid magenta submit
 
 ## Primary file
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Authoritative policy: **`.cursorrules`** (sections 1?42). Always-applied pointer: `.cursor/rules/00-follow-cursorrules.mdc`.
 
-Design OS (execution layer, does not replace `.cursorrules`): `.cursor/rules/ui-ux.mdc`, `brand.mdc`, `frontend.mdc` + `design/DESIGN_SYSTEM.md`. Never judge UI from source code alone.
+Design OS (execution layer, does not replace `.cursorrules`): `.cursor/rules/ui-ux.mdc`, `brand.mdc`, `frontend.mdc` + `design/DESIGN_SYSTEM.md`. Never judge UI from source code alone. Blog/Journal and Store colors are locked: `.cursor/rules/blog-store-color-lock.mdc`.
 
 ## Closed loop (UI work)
 

--- a/client/src/components/ZohoASAPWidget.tsx
+++ b/client/src/components/ZohoASAPWidget.tsx
@@ -1532,22 +1532,22 @@ export const ZohoASAPWidget = ({
         dangerouslySetInnerHTML={{
           __html: `
             .de-desk-shell {
-              --desk-shell: #ffffff;
-              --desk-shell-soft: #f7f5f2;
+              --desk-shell: #f7f5f2;
+              --desk-shell-soft: #ffffff;
               --desk-shell-border: rgba(20,16,30,0.08);
               --desk-shell-border-strong: rgba(20,16,30,0.14);
               --desk-shell-text: #17141f;
               --desk-shell-muted: #5c5668;
               --desk-shell-dim: #726c82;
-              --desk-well: #050312;
-              --desk-surface: #0a0a0a;
-              --desk-box: #151217;
-              --desk-inset: #050312;
-              --desk-border: rgba(255,255,255,0.10);
-              --desk-border-strong: rgba(255,255,255,0.16);
-              --desk-ink: #ffffff;
-              --desk-ink-muted: rgba(255,255,255,0.78);
-              --desk-ink-dim: rgba(255,255,255,0.55);
+              --desk-well: #ffffff;
+              --desk-surface: #f7f5f2;
+              --desk-box: #ffffff;
+              --desk-inset: #ffffff;
+              --desk-border: rgba(20,16,30,0.10);
+              --desk-border-strong: rgba(20,16,30,0.16);
+              --desk-ink: #17141f;
+              --desk-ink-muted: #5c5668;
+              --desk-ink-dim: #726c82;
               --desk-pink: #d3126a;
               --desk-violet: #8b5cf6;
               --desk-blue: #3b9eff;
@@ -1558,7 +1558,7 @@ export const ZohoASAPWidget = ({
               background: var(--desk-shell);
               border: 1px solid var(--desk-shell-border-strong);
               border-radius: 20px;
-              box-shadow: 0 34px 90px -22px rgba(0,0,0,0.65), 0 0 0 1px rgba(20,16,30,0.04), 0 0 70px -16px rgba(211,18,106,0.20);
+              box-shadow: 0 34px 90px -22px rgba(0,0,0,0.45), 0 0 0 1px rgba(20,16,30,0.04), 0 0 70px -16px rgba(211,18,106,0.16);
               color: var(--desk-shell-text);
             }
             .de-desk-shell ::selection {
@@ -1619,11 +1619,11 @@ export const ZohoASAPWidget = ({
             .de-desk-id h2 {
               font-family: "Space Grotesk", sans-serif;
               font-weight: 600;
-              font-size: 14.5px;
+              font-size: 16px;
               color: var(--desk-shell-text);
               line-height: 1.2;
             }
-            .de-desk-id p { font-size: 11.5px; color: var(--desk-shell-muted); margin-top: 1px; }
+            .de-desk-id p { font-size: 13px; color: var(--desk-shell-muted); margin-top: 1px; }
             .de-desk-close {
               width: 30px; height: 30px; border-radius: 9px;
               border: 1px solid var(--desk-shell-border-strong);
@@ -1643,7 +1643,7 @@ export const ZohoASAPWidget = ({
               background: none; border: none;
               padding: 12px 0;
               font-family: "Space Grotesk", sans-serif;
-              font-weight: 600; font-size: 13.5px;
+              font-weight: 600; font-size: 15px;
               color: var(--desk-shell-dim);
               display: flex; align-items: center; gap: 6px;
               position: relative;
@@ -1668,9 +1668,9 @@ export const ZohoASAPWidget = ({
             .de-desk-status {
               display: flex; align-items: center; justify-content: space-between;
               padding: 9px 17px;
-              background: var(--desk-shell-soft);
+              background: var(--desk-shell);
               border-bottom: 1px solid var(--desk-shell-border);
-              font-size: 11.5px;
+              font-size: 13px;
               flex-shrink: 0;
             }
             .de-desk-status-l {
@@ -1710,17 +1710,17 @@ export const ZohoASAPWidget = ({
             .de-desk-hero {
               position: relative; overflow: hidden;
               border-radius: 13px;
-              border: 1px solid rgba(211,18,106,0.38);
+              border: 1px solid var(--desk-border-strong);
               background: var(--desk-box);
               padding: 16px 16px;
               display: flex; align-items: center; gap: 12px;
-              box-shadow: 0 16px 34px -18px rgba(211,18,106,0.28), inset 0 1px 0 rgba(255,255,255,0.06);
+              box-shadow: 0 10px 24px -16px rgba(20,16,30,0.18);
               flex-shrink: 0;
             }
             .de-desk-hero::before {
               content: "";
               position: absolute; inset: 0;
-              background-image: radial-gradient(rgba(255,255,255,0.10) 1px, transparent 1.15px);
+              background-image: radial-gradient(rgba(20,16,30,0.06) 1px, transparent 1.15px);
               background-size: 7px 7px;
               opacity: 0.45;
               pointer-events: none;
@@ -1742,11 +1742,11 @@ export const ZohoASAPWidget = ({
             .de-desk-hero-ring svg { width: 17px; height: 17px; }
             .de-desk-hero h3 {
               font-family: "Space Grotesk", sans-serif;
-              font-size: 17px; font-weight: 700; color: var(--desk-ink);
+              font-size: 18px; font-weight: 700; color: var(--desk-ink);
               letter-spacing: -0.01em;
             }
             .de-desk-hero p {
-              font-size: 12px; color: var(--desk-ink-muted); margin-top: 5px;
+              font-size: 14px; color: var(--desk-ink-muted); margin-top: 5px;
               line-height: 1.5; max-width: 210px;
             }
             .de-desk-hero-art { width: 86px; height: 86px; flex: none; position: relative; z-index: 1; }
@@ -1764,12 +1764,12 @@ export const ZohoASAPWidget = ({
               transition: background 0.16s ease, border-color 0.16s ease, transform 0.16s ease;
             }
             .de-desk-row:hover {
-              background: #1c191f;
+              background: #f3f0ec;
               border-color: var(--desk-border-strong);
               transform: translateY(-1px);
             }
             .de-desk-rows.is-grid .de-desk-row { padding: 9px 10px; }
-            .de-desk-rows.is-grid .de-desk-row-t { font-size: 12px; line-height: 1.3; }
+            .de-desk-rows.is-grid .de-desk-row-t { font-size: 13.5px; line-height: 1.3; }
             .de-desk-row[data-tone="violet"] { --c: var(--desk-violet); }
             .de-desk-row[data-tone="blue"] { --c: var(--desk-blue); }
             .de-desk-row[data-tone="teal"] { --c: var(--desk-teal); }
@@ -1791,9 +1791,9 @@ export const ZohoASAPWidget = ({
             .de-desk-row.is-lg .de-desk-row-ic { width: 46px; height: 46px; border-radius: 13px; }
             .de-desk-row.is-lg .de-desk-row-ic svg { width: 20px; height: 20px; }
             .de-desk-row-body { flex: 1; min-width: 0; }
-            .de-desk-row-t { font-size: 13px; font-weight: 600; color: #fff; }
+            .de-desk-row-t { font-size: 14.5px; font-weight: 600; color: var(--desk-ink); }
             .de-desk-row.is-lg .de-desk-row-t { font-size: 13.5px; }
-            .de-desk-row-d { display: block; font-size: 11.5px; color: var(--desk-ink-muted); margin-top: 2px; line-height: 1.4; }
+            .de-desk-row-d { display: block; font-size: 13px; color: var(--desk-ink-muted); margin-top: 2px; line-height: 1.4; }
             .de-desk-badge-rec {
               display: inline-block;
               font-size: 9.5px; font-weight: 700; letter-spacing: 0.03em;
@@ -1837,7 +1837,7 @@ export const ZohoASAPWidget = ({
             }
             .de-desk-section-head h4 {
               font-family: "Space Grotesk", sans-serif;
-              font-size: 13px; font-weight: 600; color: var(--desk-shell-text);
+              font-size: 14.5px; font-weight: 600; color: var(--desk-shell-text);
             }
             .de-desk-section-head a { font-size: 12px; color: var(--desk-pink); font-weight: 600; }
             .de-desk-details-head {
@@ -1846,7 +1846,7 @@ export const ZohoASAPWidget = ({
             }
             .de-desk-details-head h4 {
               font-family: "Space Grotesk", sans-serif;
-              font-size: 11.5px; font-weight: 700;
+              font-size: 13px; font-weight: 700;
               letter-spacing: 0.06em; text-transform: uppercase;
               color: var(--desk-shell-muted);
             }
@@ -1854,14 +1854,14 @@ export const ZohoASAPWidget = ({
               display: flex; align-items: center; gap: 5px;
               border: 1px solid var(--desk-green); color: #178a4c;
               border-radius: 999px; padding: 3px 9px;
-              font-size: 10.5px; font-weight: 600;
+              font-size: 12px; font-weight: 600;
               background: rgba(34,197,94,0.08);
             }
             .de-desk-secure svg { width: 10px; height: 10px; }
             .de-desk-form { display: flex; flex-direction: column; gap: 10px; }
             .de-desk-grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
             .de-desk-field label {
-              display: block; font-size: 11px; font-weight: 600;
+              display: block; font-size: 13px; font-weight: 600;
               color: var(--desk-shell-muted); margin-bottom: 6px;
             }
             .de-desk-input-wrap { position: relative; }
@@ -1874,11 +1874,11 @@ export const ZohoASAPWidget = ({
               height: 40px;
               background: var(--desk-inset) !important;
               border: 1px solid var(--desk-border) !important;
-              color: #fff !important;
+              color: var(--desk-ink) !important;
               border-radius: 10px;
               padding: 10px 11px 10px 32px;
-              font-size: 13px;
-              box-shadow: inset 0 1px 0 rgba(255,255,255,0.04) !important;
+              font-size: 14px;
+              box-shadow: none !important;
             }
             .de-desk-shell .de-desk-input::placeholder { color: var(--desk-ink-dim); }
             .de-desk-shell .de-desk-select { appearance: none; padding-right: 28px; }
@@ -1904,11 +1904,11 @@ export const ZohoASAPWidget = ({
             }
             .de-desk-attach:hover { border-color: var(--desk-pink); }
             .de-desk-attach svg { width: 14px; height: 14px; color: var(--desk-ink-dim); flex: none; margin-top: 2px; }
-            .de-desk-attach-t { display: block; font-size: 12.5px; font-weight: 600; color: var(--desk-ink); }
-            .de-desk-attach-h { display: block; font-size: 10.5px; color: var(--desk-ink-muted); margin-top: 1px; }
+            .de-desk-attach-t { display: block; font-size: 14px; font-weight: 600; color: var(--desk-ink); }
+            .de-desk-attach-h { display: block; font-size: 12.5px; color: var(--desk-ink-muted); margin-top: 1px; }
             .de-desk-caption {
               display: flex; align-items: center; gap: 6px;
-              font-size: 11px; color: var(--desk-shell-muted);
+              font-size: 13px; color: var(--desk-shell-muted);
             }
             .de-desk-caption svg { width: 11px; height: 11px; }
             .de-desk-btn-grad {
@@ -1933,7 +1933,7 @@ export const ZohoASAPWidget = ({
               border-bottom-right-radius: 6px;
             }
             .de-desk-bubble.is-bot, .de-desk-bubble.is-agent {
-              background: var(--desk-box); color: #fff;
+              background: var(--desk-box); color: var(--desk-ink);
               border: 1px solid var(--desk-border);
               border-bottom-left-radius: 6px;
             }
@@ -1954,7 +1954,7 @@ export const ZohoASAPWidget = ({
             .de-desk-success p { max-width: none; }
             .de-desk-ticket-ref {
               font-family: ui-monospace, monospace;
-              font-size: 12px; font-weight: 600; color: #f0b4cc;
+              font-size: 13px; font-weight: 600; color: var(--desk-pink);
               margin-top: 8px;
             }
             .de-desk-success-actions { display: flex; flex-direction: column; gap: 8px; width: 100%; margin-top: 14px; }
@@ -1967,7 +1967,7 @@ export const ZohoASAPWidget = ({
               border-radius: 16px;
               background: var(--desk-box);
               border: 1px solid rgba(211,18,106,0.42);
-              box-shadow: 0 16px 36px rgba(0,0,0,0.38), 0 0 0 1px rgba(211,18,106,0.12);
+              box-shadow: 0 16px 36px rgba(20,16,30,0.16), 0 0 0 1px rgba(211,18,106,0.10);
               animation: de-desk-heads-in 0.28s ease-out;
             }
             .de-desk-heads-up.is-out { border-color: rgba(255,255,255,0.16); }
@@ -1991,13 +1991,13 @@ export const ZohoASAPWidget = ({
               display: flex; align-items: baseline; justify-content: space-between; gap: 8px;
             }
             .de-desk-heads-up-top strong {
-              font-size: 12.5px; font-weight: 700; color: #fff;
+              font-size: 13.5px; font-weight: 700; color: var(--desk-ink);
             }
             .de-desk-heads-up-top em {
-              font-style: normal; font-size: 10px; color: #9C97A8; flex: none;
+              font-style: normal; font-size: 11px; color: var(--desk-ink-dim); flex: none;
             }
             .de-desk-heads-up-preview {
-              font-size: 12.5px; line-height: 1.35; color: #E8E4F0;
+              font-size: 13.5px; line-height: 1.35; color: var(--desk-ink-muted);
               display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
             }
             .de-desk-heads-up-hint {
@@ -2005,10 +2005,10 @@ export const ZohoASAPWidget = ({
             }
             .de-desk-heads-up-x {
               width: 28px; height: 28px; border-radius: 8px; flex: none; align-self: flex-start;
-              border: none; background: transparent; color: #9C97A8;
+              border: none; background: transparent; color: var(--desk-ink-dim);
               display: flex; align-items: center; justify-content: center;
             }
-            .de-desk-heads-up-x:hover { color: #fff; background: rgba(255,255,255,0.06); }
+            .de-desk-heads-up-x:hover { color: var(--desk-ink); background: rgba(20,16,30,0.06); }
             @keyframes de-desk-heads-in {
               from { opacity: 0; transform: translateY(10px); }
               to { opacity: 1; transform: translateY(0); }
@@ -2019,10 +2019,9 @@ export const ZohoASAPWidget = ({
             .de-desk-composer {
               display: flex; gap: 8px;
               padding: 12px 17px 10px;
-              border-top: 1px solid var(--desk-border-strong);
-              background: var(--desk-box);
+              border-top: 1px solid var(--desk-shell-border);
+              background: var(--desk-shell);
               color: var(--desk-ink);
-              box-shadow: inset 0 1px 0 rgba(255,255,255,0.05);
               flex-shrink: 0;
             }
             .de-desk-composer.is-live input {
@@ -2035,8 +2034,7 @@ export const ZohoASAPWidget = ({
               border: 1px solid var(--desk-border);
               border-radius: 11px;
               padding: 11px 13px;
-              color: var(--desk-ink); font-size: 13px;
-              box-shadow: inset 0 1px 0 rgba(255,255,255,0.04);
+              color: var(--desk-ink); font-size: 14px;
             }
             .de-desk-composer input::placeholder { color: var(--desk-ink-dim); }
             .de-desk-composer input:focus {
@@ -2056,21 +2054,21 @@ export const ZohoASAPWidget = ({
             .de-desk-composer-caption {
               display: flex; align-items: center; gap: 6px;
               padding: 0 17px 10px;
-              background: var(--desk-box);
-              font-size: 11px; color: var(--desk-ink);
+              background: var(--desk-shell);
+              font-size: 12.5px; color: var(--desk-ink-muted);
               flex-shrink: 0;
             }
             .de-desk-composer-caption svg { width: 11px; height: 11px; color: var(--desk-ink); }
             .de-desk-foot {
               display: flex; align-items: center; justify-content: space-between;
               padding: 11px 17px;
-              border-top: 1px solid var(--desk-border);
-              background: var(--desk-well);
+              border-top: 1px solid var(--desk-shell-border);
+              background: var(--desk-shell);
               color: var(--desk-ink-muted);
               flex-shrink: 0;
             }
             .de-desk-foot-nav {
-              font-size: 11px; color: var(--desk-ink-muted);
+              font-size: 13px; color: var(--desk-ink-muted);
               display: flex; align-items: center; gap: 5px; min-width: 0;
             }
             .de-desk-foot-nav button,
@@ -2083,15 +2081,15 @@ export const ZohoASAPWidget = ({
             .de-desk-foot-nav .is-active { color: var(--desk-pink); font-weight: 600; }
             .de-desk-foot-assist { text-decoration: underline; text-underline-offset: 2px; }
             .de-desk-foot-cta {
-              font-size: 11.5px; color: var(--desk-pink); font-weight: 600;
+              font-size: 13px; color: var(--desk-pink); font-weight: 600;
               display: flex; align-items: center; gap: 4px; flex: none;
             }
             .de-desk-foot-cta svg { width: 11px; height: 11px; }
             @media (max-width: 420px) {
               .de-desk-grid2 { grid-template-columns: 1fr; }
               .de-desk-hero-art { display: none; }
-              .de-desk-tab { font-size: 12.5px; }
-              .de-desk-hero h3 { font-size: 16.5px; }
+              .de-desk-tab { font-size: 14px; }
+              .de-desk-hero h3 { font-size: 17px; }
             }
           `,
         }}

--- a/client/src/components/store/ProductMedia.tsx
+++ b/client/src/components/store/ProductMedia.tsx
@@ -32,10 +32,10 @@ export function ProductMedia({
 
   const logoBox =
     variant === "detail"
-      ? "h-[46%] w-[46%] max-h-56 max-w-56 min-h-36 min-w-36 p-6 sm:p-8"
+      ? "aspect-square w-[48%] max-w-[14rem] p-6 sm:p-8"
       : variant === "card"
-        ? "h-[46%] w-[46%] max-h-44 max-w-44 min-h-28 min-w-28 p-4"
-        : "h-[42%] w-[42%] max-h-16 max-w-16 min-h-12 min-w-12 p-2";
+        ? "aspect-square w-[46%] max-w-[11rem] p-4"
+        : "aspect-square w-[46%] max-w-[7rem] p-3";
 
   return (
     <div

--- a/client/src/components/store/ProductMedia.tsx
+++ b/client/src/components/store/ProductMedia.tsx
@@ -10,7 +10,7 @@ interface ProductMediaProps {
 }
 
 /**
- * Dominant product visual: branded category hero + vendor mark overlay.
+ * Vendor plate is the subject. Category/Meshy art is atmosphere only.
  * Used by listing cards and product detail so imagery stays consistent.
  */
 export function ProductMedia({
@@ -32,10 +32,10 @@ export function ProductMedia({
 
   const logoBox =
     variant === "detail"
-      ? "h-36 w-36 sm:h-44 sm:w-44 md:h-52 md:w-52 p-6 sm:p-8"
+      ? "h-[46%] w-[46%] max-h-56 max-w-56 min-h-36 min-w-36 p-6 sm:p-8"
       : variant === "card"
-        ? "h-20 w-20 p-3"
-        : "h-12 w-12 p-2";
+        ? "h-[46%] w-[46%] max-h-44 max-w-44 min-h-28 min-w-28 p-4"
+        : "h-[42%] w-[42%] max-h-16 max-w-16 min-h-12 min-w-12 p-2";
 
   return (
     <div
@@ -46,11 +46,11 @@ export function ProductMedia({
       <img
         src={mediaSrc}
         alt=""
-        className="absolute inset-0 h-full w-full object-cover"
+        className="absolute inset-0 h-full w-full scale-110 object-cover opacity-50"
         loading={variant === "detail" ? "eager" : "lazy"}
         decoding="async"
       />
-      <div className="absolute inset-0 bg-gradient-to-t from-black/55 via-black/15 to-transparent" />
+      <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/40 to-black/20" />
 
       <div className="absolute inset-0 flex items-center justify-center p-4">
         {visual.logoUrl ? (

--- a/client/src/components/store/StoreProductCard.tsx
+++ b/client/src/components/store/StoreProductCard.tsx
@@ -110,7 +110,7 @@ export function StoreProductCard({
       <Link href={`/store/product/${product.sku}`}>
         <ProductMedia
           product={product}
-          variant={compact ? "thumb" : "card"}
+          variant="card"
           className="rounded-none border-0 border-b border-white/10"
           categoryBadge={categoryLabels[product.category]}
         />

--- a/docs/BRAND-SWEEP-NEXT.md
+++ b/docs/BRAND-SWEEP-NEXT.md
@@ -10,6 +10,7 @@ The audit (`scripts/brand-audit.mjs`) is a regression detector, not a requiremen
 
 - Marketing field stays the charcoal ladder. Primary CTA fill is solid `#D3126A`.
 - Page families keep one topical hue: store → electric, support → cyan, resources → amber, everything else inherits magenta.
+- **Locked (DE):** Blog/Journal and Store keep the colors they have now. Do not restyle those palettes. Rule: `.cursor/rules/blog-store-color-lock.mdc`.
 - Store category pills stay pill-only and use 14 distinct hues. Teal / lime / yellow replaced the three that had collapsed onto violet; `professional_services` moved to pink so teal could stay. Guard: `client/src/components/store/categoryAccent.test.ts`.
 - Portal, login, and signup are out of scope unless DE asks for a separate portal UI pass.
 - Dead `client/src/pages/Homepage.tsx` and the legacy sections it imports are not routed (`/` uses `DigeratiHomepage`). Sweeping them is diff noise.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
Same system in two places: **one field, subject over decoration.**

**DE Desk** is one paper sheet. Header, tabs, hero, rows, form, composer, and footer sit on `#F7F5F2` with white raised cards and dark ink. Magenta stays the only loud color. The white/charcoal/black stripe is gone.

**Store cards** make the vendor plate the subject (~46% of the media). Category/Meshy art is dimmed atmosphere. Compact rails (Best Value) use the same card plate. The 14 category pill hues and catalog items are unchanged.

**Color lock (DE):** Blog/Journal and Store keep the colors they have now. Rule: `.cursor/rules/blog-store-color-lock.mdc`. Later sweeps must skip those palettes.

## Why
DE: Ticket and Resources in Desk looked ugly in black, and store cards looked generic because the vendor mark was an 80px sticker on a 3D tile. Then: lock blog and store colors so they are not restyled again.

## Preserved
- All Desk tabs, CTAs, chat, ticket fields, resource rows, Assist, `PORTAL_LOGIN`
- Store compare, cart, SKUs, category hue map
- Journal amber + charcoal masthead; Store electric accent

## Verify
- `npm test` 56/56
- Desk / Ticket / Resources paper theme measured: shell `#F7F5F2`, cards white, footer paper
- Best Value vendor plates ~42% of media width (was ~18%)
- 390 and 1440 screenshots

[DE Desk paper theme](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdesk_1440_paper.png)
[Ticket tab on paper](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdesk_ticket_1440_paper.png)
[Store Best Value vendor plates](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstore_best_value_desktop_vendor.png)
[desk_paper_and_store_vendor_plates.mp4](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdesk_paper_and_store_vendor_plates.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55eac13a-e87f-4a00-9c34-f63bb77c3080&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

