### PR TITLE
fix(store): scroll filtered catalog into view and uncrush outcome cards

### DIFF
--- a/client/src/components/store/ConfigureProductDrawer.tsx
+++ b/client/src/components/store/ConfigureProductDrawer.tsx
@@ -149,7 +149,7 @@ export function ConfigureProductDrawer({
             animate={{ x: 0 }}
             exit={{ x: "100%" }}
             transition={{ type: "spring", damping: 28, stiffness: 320 }}
-            className="fixed right-0 top-0 z-[61] flex h-full w-full max-w-md flex-col border-l border-white/10 bg-[#0a0a0a]"
+            className="fixed right-0 top-0 z-[61] flex h-full min-h-0 w-full max-w-md flex-col overflow-hidden border-l border-white/10 bg-[#0a0a0a]"
             data-testid="configure-product-drawer"
             role="dialog"
             aria-modal="true"
@@ -180,7 +180,7 @@ export function ConfigureProductDrawer({
               </Button>
             </div>
 
-            <div className="flex-1 space-y-6 overflow-y-auto p-6">
+            <div className="min-h-0 flex-1 space-y-6 overflow-y-auto p-6 pb-8">
               <div className="flex gap-4">
                 <ProductMedia
                   product={product}
@@ -195,31 +195,6 @@ export function ConfigureProductDrawer({
                   <p className="mt-2 text-sm text-white/55">{formatPrice(product)}</p>
                 </div>
               </div>
-
-              {product.features.length > 0 && (
-                <div className="rounded-xl border border-white/10 bg-[#141414] p-4">
-                  <p className="mb-3 text-sm font-medium text-white/70">What you get</p>
-                  <ul className="space-y-2">
-                    {product.features.slice(0, 4).map((feature) => (
-                      <li key={feature} className="flex items-start gap-2 text-sm text-white/60">
-                        <Check className="mt-0.5 h-4 w-4 flex-shrink-0 text-de-accent-ink" />
-                        <span>{feature}</span>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-
-              {(includedHint || upgradeName) && (
-                <div className="space-y-1.5 text-sm text-white/50">
-                  {includedHint && (
-                    <p className="text-de-accent-ink/90" data-testid="configure-included-hint">
-                      {includedHint}
-                    </p>
-                  )}
-                  {upgradeName && <p>Upgrade path: {upgradeName}</p>}
-                </div>
-              )}
 
               <div className="rounded-xl border border-white/10 bg-[#141414] p-5">
                 <label
@@ -268,6 +243,31 @@ export function ConfigureProductDrawer({
                   Minimum {product.minimumQuantity || 1} {unit}
                 </p>
               </div>
+
+              {product.features.length > 0 && (
+                <div className="rounded-xl border border-white/10 bg-[#141414] p-4">
+                  <p className="mb-3 text-sm font-medium text-white/70">What you get</p>
+                  <ul className="space-y-2">
+                    {product.features.slice(0, 4).map((feature) => (
+                      <li key={feature} className="flex items-start gap-2 text-sm text-white/60">
+                        <Check className="mt-0.5 h-4 w-4 flex-shrink-0 text-de-accent-ink" />
+                        <span>{feature}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {(includedHint || upgradeName) && (
+                <div className="space-y-1.5 text-sm text-white/50">
+                  {includedHint && (
+                    <p className="text-de-accent-ink/90" data-testid="configure-included-hint">
+                      {includedHint}
+                    </p>
+                  )}
+                  {upgradeName && <p>Upgrade path: {upgradeName}</p>}
+                </div>
+              )}
 
               {recurring && product.pricingType !== "yearly" && (
                 <div className="rounded-xl border border-white/10 bg-[#141414] p-5">

--- a/client/src/components/store/ShopByOutcome.tsx
+++ b/client/src/components/store/ShopByOutcome.tsx
@@ -18,7 +18,7 @@ export function ShopByOutcome({ selected, onSelect }: ShopByOutcomeProps) {
           Start with the result you need — we map it to real catalog categories.
         </p>
       </div>
-      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-7">
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
         {storeOutcomes.map((outcome) => {
           const isActive = selected === outcome.id;
           return (
@@ -48,7 +48,7 @@ export function ShopByOutcome({ selected, onSelect }: ShopByOutcomeProps) {
                 />
               </div>
               <p className="text-base font-semibold text-white">{outcome.label}</p>
-              <p className="mt-1.5 line-clamp-2 text-sm text-white/50">{outcome.blurb}</p>
+              <p className="mt-1.5 text-sm leading-snug text-white/50">{outcome.blurb}</p>
             </button>
           );
         })}

--- a/client/src/pages/store/CoManagedStore.tsx
+++ b/client/src/pages/store/CoManagedStore.tsx
@@ -116,6 +116,23 @@ function parseCatalogSearch(searchString: string) {
   };
 }
 
+/** True when the catalog URL already names a filter — used to scroll past the hero. */
+export function catalogSearchHasDeepLink(searchString: string): boolean {
+  const parsed = parseCatalogSearch(searchString);
+  return (
+    parsed.outcome !== null ||
+    parsed.category !== "all" ||
+    parsed.vendor !== "all" ||
+    parsed.compliance !== "all" ||
+    parsed.size !== "all" ||
+    parsed.q.trim().length > 0 ||
+    parsed.billing !== "all" ||
+    parsed.priceBand !== "all" ||
+    parsed.purchasePath !== "all" ||
+    parsed.coverage !== "all"
+  );
+}
+
 const CoManagedStore = () => {
   const prefersReducedMotion = useReducedMotion();
   const searchString = useSearch();
@@ -491,8 +508,29 @@ const CoManagedStore = () => {
   };
 
   const scrollToCatalog = () => {
-    catalogRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+    const behavior = window.matchMedia("(prefers-reduced-motion: reduce)").matches
+      ? "auto"
+      : "smooth";
+    catalogRef.current?.scrollIntoView({ behavior, block: "start" });
   };
+
+  // Deep links like /store/co-managed?outcome=protect used to land on the hero
+  // (~6k px above the filtered grid). Scroll once after mount so clicking an
+  // outcome actually shows the matching products.
+  useEffect(() => {
+    if (!catalogSearchHasDeepLink(searchString)) return;
+
+    let timeout = 0;
+    const frame = window.requestAnimationFrame(() => {
+      timeout = window.setTimeout(scrollToCatalog, 80);
+    });
+    return () => {
+      window.cancelAnimationFrame(frame);
+      window.clearTimeout(timeout);
+    };
+    // Intentionally mount-only: later filter changes already call scrollToCatalog.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleOutcomeSelect = (id: StoreOutcomeId | null) => {
     setSelectedOutcome(id);
@@ -651,7 +689,7 @@ const CoManagedStore = () => {
           <StoreBundlesSection isLoggedIn={isLoggedIn} onAddBundle={handleAddBundle} />
 
           {/* Catalog + sticky assessment */}
-          <div ref={catalogRef} className="scroll-mt-28">
+          <div ref={catalogRef} id="store-catalog" className="scroll-mt-28">
             <div className="mb-6 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
               <div>
                 <h2 className="text-3xl font-bold text-white md:text-4xl">Full catalog</h2>

--- a/client/src/pages/store/StoreLanding.tsx
+++ b/client/src/pages/store/StoreLanding.tsx
@@ -131,7 +131,7 @@ const StoreLanding = () => {
   const handleOutcomeSelect = (id: StoreOutcomeId | null) => {
     setOutcomeHighlight(id);
     if (id) {
-      setLocation(`/store/co-managed?outcome=${id}`);
+      setLocation(`/store/co-managed?outcome=${id}#store-catalog`);
     }
   };
 

--- a/client/src/pages/store/catalogSearchHasDeepLink.test.ts
+++ b/client/src/pages/store/catalogSearchHasDeepLink.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { catalogSearchHasDeepLink } from "./CoManagedStore";
+
+describe("catalogSearchHasDeepLink", () => {
+  it("is false for an unfiltered catalog", () => {
+    expect(catalogSearchHasDeepLink("")).toBe(false);
+    expect(catalogSearchHasDeepLink("?")).toBe(false);
+  });
+
+  it("is true when an outcome or other catalog filter is present", () => {
+    expect(catalogSearchHasDeepLink("?outcome=protect")).toBe(true);
+    expect(catalogSearchHasDeepLink("?category=comanaged_subscriptions")).toBe(true);
+    expect(catalogSearchHasDeepLink("?q=endpoint")).toBe(true);
+    expect(catalogSearchHasDeepLink("?vendor=Coro")).toBe(true);
+  });
+
+  it("ignores unknown outcome ids", () => {
+    expect(catalogSearchHasDeepLink("?outcome=not-a-real-outcome")).toBe(false);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Store click/scroll audit on the live catalog found three interaction bugs. This PR fixes those without restyling Blog/Store colors.

1. **Outcome click missed the catalog.** Shop by Outcome from `/store` goes to `/store/co-managed?outcome=protect`, but the filtered grid sits ~6,000px below a repeated hero + rails. The page now scrolls to `#store-catalog` on deep-linked filters (outcome, category, vendor, search, etc.).
2. **Seven-up outcome cards crushed copy.** `lg:grid-cols-7` truncated every blurb to “identity…”. Cards now wrap at 4 columns and show the full blurb.
3. **Configure quantity sat under the footer.** Quantity is now the first control in the drawer, and the panel uses `min-h-0` / `overflow-hidden` so the sticky cart actions no longer cover the stepper.

## Why

Clicking “Protect” looked like a no-op. Buyers never saw the 18 matching products unless they hunted. Quantity is the primary configure action and was below the fold on a 900px viewport.

## Files

- `client/src/pages/store/CoManagedStore.tsx`
- `client/src/pages/store/StoreLanding.tsx`
- `client/src/components/store/ShopByOutcome.tsx`
- `client/src/components/store/ConfigureProductDrawer.tsx`
- `client/src/pages/store/catalogSearchHasDeepLink.test.ts`

## Preserved

- Electric store accent and 14 category-pill hues (color lock)
- Catalog filters, rails, merchandising, CTAs, portal login
- Configure add-ons, notes, quote, and cart actions

## Tests

- `npm test` — 61/61 passed, including `catalogSearchHasDeepLink` and `categoryAccent`
- Local browser on `:8081` at 390 / 768 / 1440
- Click Protect → URL `?outcome=protect#store-catalog`, scrollY ~6470, “Full catalog” in view, “Showing 18 of 51 products”
- Configure quantity visible above the footer (gap 198–280px; no overlap) at 390 / 768 / 1440
- Outcome blurbs render in full on desktop and mobile

[Outcome cards with full blurbs](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstore_1440_outcomes_readable.png)
[Catalog after Protect click](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstore_1440_catalog_after_protect.png)
[Configure quantity above the fold](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstore_1440_configure_qty.png)
[store_click_scroll_protect_configure.mp4](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstore_click_scroll_protect_configure.mp4)

## Not in this PR

- First-visit overlay stack (cookie + sticky Risk Assessment + Ask DE) still covers cards. That is sitewide chrome, not store-only.
- Ask DE can cover the last visible rail card’s Configure button. Same chrome system.
- Production is unchanged until this branch is merged and deployed. Live `release.txt` remains `b42e5c5d`.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55eac13a-e87f-4a00-9c34-f63bb77c3080&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

