### PR TITLE
feat(desk): route ticket chips and let visitors resize the window

### DIFF
--- a/.cursor/skills/de-desk-ui/tokens-and-structure.md
+++ b/.cursor/skills/de-desk-ui/tokens-and-structure.md
@@ -41,7 +41,7 @@ Do **not** use charcoal hero/rows, black footer, plum washes, or magenta→viole
 ## Ticket
 
 - Paper hero “Create a support ticket”
-- Subject chips in a 2×2 grid so the form starts in view
+- Subject chips in a 2×2 grid (Email or Microsoft 365, Can't sign in, Computer or printer, Possible security incident). Clicking one selects it, fills subject/category/priority, seeds a prompt, and moves focus into the form.
 - Form on paper: Secure & private pill; light fields; solid magenta submit
 
 ## Primary file

--- a/.cursor/skills/de-desk-ui/tokens-and-structure.md
+++ b/.cursor/skills/de-desk-ui/tokens-and-structure.md
@@ -18,7 +18,7 @@ Do **not** use charcoal hero/rows, black footer, plum washes, or magenta→viole
 
 ## Shared chrome (top → bottom)
 
-1. **Header** — magenta DE mark + green pip; title “DE Desk”; subtitle “Answers · Tickets · Assist”; close
+1. **Header** — magenta DE mark + green pip; title “DE Desk”; subtitle “Answers · Tickets · Assist”; close. On `sm+` the header moves the window; double-click resets size and position. A south-east grip resizes the window (grows up/left when docked).
 2. **Tabs** — Desk | Ticket | Resources; active = dark label + magenta underline
 3. **Status row** — paper field; green/sky/amber dot + “DE Desk is online” | “Need help now?”
 4. **Content** — paper body; white raised hero + white raised rows / light inputs

--- a/client/src/components/ZohoASAPWidget.tsx
+++ b/client/src/components/ZohoASAPWidget.tsx
@@ -856,19 +856,29 @@ export const ZohoASAPWidget = ({
   const canvasRight = "calc(var(--de-canvas-gutter) + var(--de-chrome-inset))";
 
   const deskWindowStyle = canDrag
-    ? deskDrag.pos
-      ? {
-          left: deskDrag.pos.x,
-          top: deskDrag.pos.y,
-          right: "auto",
-          bottom: "auto",
-        }
-      : {
-          right: canvasRight,
-          bottom: dockClear,
-          left: "auto",
-          top: "auto",
-        }
+    ? {
+        ...(deskDrag.pos
+          ? {
+              left: deskDrag.pos.x,
+              top: deskDrag.pos.y,
+              right: "auto",
+              bottom: "auto",
+            }
+          : {
+              right: canvasRight,
+              bottom: dockClear,
+              left: "auto",
+              top: "auto",
+            }),
+        ...(deskDrag.size
+          ? {
+              width: deskDrag.size.w,
+              height: deskDrag.size.h,
+              maxWidth: "none",
+              maxHeight: "none",
+            }
+          : {}),
+      }
     : undefined;
 
   return (
@@ -895,7 +905,7 @@ export const ZohoASAPWidget = ({
                 onDoubleClick={canDrag ? deskDrag.reset : undefined}
                 style={canDrag ? { touchAction: "none" } : undefined}
                 data-testid="desk-drag-handle"
-                aria-label={canDrag ? "Move DE Desk window" : undefined}
+                aria-label={canDrag ? "Move DE Desk window. Double-click to reset size and position." : undefined}
               >
                 <div className="de-desk-avatar">
                   DE
@@ -1540,6 +1550,17 @@ export const ZohoASAPWidget = ({
                 <ExternalLink aria-hidden="true" />
               </button>
             </footer>
+            {canDrag ? (
+              <button
+                type="button"
+                className={`de-desk-resize${deskDrag.resizing ? " is-active" : ""}`}
+                data-testid="desk-resize-handle"
+                aria-label="Resize DE Desk. Drag to make the window larger or smaller."
+                onPointerDown={deskDrag.onResizePointerDown}
+              >
+                <span aria-hidden="true" />
+              </button>
+            ) : null}
           </section>
         )}
 
@@ -2106,6 +2127,45 @@ export const ZohoASAPWidget = ({
               display: flex; align-items: center; gap: 4px; flex: none;
             }
             .de-desk-foot-cta svg { width: 11px; height: 11px; }
+            .de-desk-resize {
+              position: absolute;
+              right: 0;
+              bottom: 0;
+              width: 44px;
+              height: 44px;
+              border: 0;
+              background: transparent;
+              cursor: nwse-resize;
+              touch-action: none;
+              z-index: 3;
+            }
+            .de-desk-resize span {
+              position: absolute;
+              right: 8px;
+              bottom: 8px;
+              width: 14px;
+              height: 14px;
+              background:
+                linear-gradient(135deg, transparent 46%, #726c82 46%, #726c82 54%, transparent 54%),
+                linear-gradient(135deg, transparent 66%, #726c82 66%, #726c82 74%, transparent 74%),
+                linear-gradient(135deg, transparent 86%, #726c82 86%, #726c82 94%, transparent 94%);
+            }
+            .de-desk-resize:hover span,
+            .de-desk-resize.is-active span,
+            .de-desk-resize:focus-visible span {
+              background:
+                linear-gradient(135deg, transparent 46%, #d3126a 46%, #d3126a 54%, transparent 54%),
+                linear-gradient(135deg, transparent 66%, #d3126a 66%, #d3126a 74%, transparent 74%),
+                linear-gradient(135deg, transparent 86%, #d3126a 86%, #d3126a 94%, transparent 94%);
+            }
+            .de-desk-resize:focus-visible {
+              outline: 2px solid #d3126a;
+              outline-offset: -4px;
+              border-radius: 10px;
+            }
+            @media (min-width: 640px) {
+              .de-desk-foot { padding-right: 36px; }
+            }
             @media (max-width: 420px) {
               .de-desk-grid2 { grid-template-columns: 1fr; }
               .de-desk-hero-art { display: none; }

--- a/client/src/components/ZohoASAPWidget.tsx
+++ b/client/src/components/ZohoASAPWidget.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import {
   AlertTriangle,
-  AppWindow,
   BookOpen,
   Building2,
   CheckCircle2,
@@ -38,6 +37,12 @@ import type { OpenMspAdvisorDetail } from "@/lib/openMspAdvisor";
 import { STORE_ADVISOR_SEED } from "@/lib/openMspAdvisor";
 import { analytics } from "@/lib/analytics";
 import { useDraggableWindow } from "@/hooks/useDraggableWindow";
+import {
+  DESK_TICKET_CATEGORIES,
+  DESK_TICKET_CHIPS,
+  applyDeskTicketChip,
+  type DeskTicketChipId,
+} from "@/lib/deskTicketChips";
 
 interface ZohoASAPWidgetProps {
   isEnabled?: boolean;
@@ -183,28 +188,12 @@ function BookMagnifier({ className }: { className?: string }) {
   );
 }
 
-const TICKET_CATEGORIES = [
-  "Email",
-  "Access & Security",
-  "Network & VPN",
-  "Software & Applications",
-  "Hardware & Devices",
-  "Backup & Recovery",
-  "Collaboration",
-  "Other",
-] as const;
-
-const TICKET_QUICK_CHIPS: Array<{
-  label: string;
-  icon: typeof Shield;
-  category: (typeof TICKET_CATEGORIES)[number];
-  tone: "red" | "blue" | "violet";
-}> = [
-  { label: "Something broke", icon: AlertTriangle, category: "Hardware & Devices", tone: "red" },
-  { label: "Microsoft 365 help", icon: AppWindow, category: "Collaboration", tone: "blue" },
-  { label: "Access or login issue", icon: KeyRound, category: "Access & Security", tone: "violet" },
-  { label: "Possible security incident", icon: Shield, category: "Access & Security", tone: "red" },
-];
+const TICKET_CHIP_ICONS: Record<DeskTicketChipId, typeof Shield> = {
+  "email-m365": Mail,
+  "sign-in": KeyRound,
+  device: Monitor,
+  "security-incident": Shield,
+};
 
 const RESOURCE_LINKS: Array<{
   title: string;
@@ -298,6 +287,8 @@ export const ZohoASAPWidget = ({
   const [message, setMessage] = useState("");
   const [priority, setPriority] = useState<"Low" | "Medium" | "High" | "Urgent">("Medium");
   const [category, setCategory] = useState("");
+  const [selectedTicketChip, setSelectedTicketChip] = useState<DeskTicketChipId | null>(null);
+  const ticketDetailsRef = useRef<HTMLDivElement>(null);
   const [attachmentName, setAttachmentName] = useState<string | null>(null);
   const [isTicketSending, setIsTicketSending] = useState(false);
   const [ticketResult, setTicketResult] = useState<TicketResult | null>(null);
@@ -750,6 +741,26 @@ export const ZohoASAPWidget = ({
     setAttachmentName(file.name);
   };
 
+  const applyTicketChip = (chipId: DeskTicketChipId) => {
+    const chip = DESK_TICKET_CHIPS.find((item) => item.id === chipId);
+    if (!chip) return;
+    const next = applyDeskTicketChip(chip, { message });
+    setSelectedTicketChip(next.chipId);
+    setSubject(next.subject);
+    setCategory(next.category);
+    setPriority(next.priority);
+    setMessage(next.message);
+    window.requestAnimationFrame(() => {
+      const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+      ticketDetailsRef.current?.scrollIntoView({
+        behavior: reduceMotion ? "auto" : "smooth",
+        block: "start",
+      });
+      const focusId = fullName.trim() && email.trim() ? "support-message" : "support-name";
+      document.getElementById(focusId)?.focus();
+    });
+  };
+
   const handleSubmitTicket = async () => {
     if (!email || !subject || !message) {
       toast({
@@ -815,6 +826,7 @@ export const ZohoASAPWidget = ({
       setMessage("");
       setPriority("Medium");
       setCategory("");
+      setSelectedTicketChip(null);
       setAttachmentName(null);
       if (ticketFileRef.current) ticketFileRef.current.value = "";
 
@@ -1143,28 +1155,31 @@ export const ZohoASAPWidget = ({
                           <DeskHeroArt variant="ticket" />
                         </div>
 
-                        <div className="de-desk-rows is-grid">
-                          {TICKET_QUICK_CHIPS.map(({ label, icon: Icon, category: chipCategory, tone }) => (
-                            <button
-                              key={label}
-                              type="button"
-                              data-tone={tone}
-                              onClick={() => {
-                                setSubject(label);
-                                setCategory(chipCategory);
-                              }}
-                              className="de-desk-row"
-                            >
-                              <span className="de-desk-row-ic">
-                                <Icon aria-hidden="true" />
-                              </span>
-                              <span className="de-desk-row-t">{label}</span>
-                              <ChevronRight className="de-desk-row-chev" aria-hidden="true" />
-                            </button>
-                          ))}
+                        <div className="de-desk-rows is-grid" role="group" aria-label="Common support issues">
+                          {DESK_TICKET_CHIPS.map((chip) => {
+                            const Icon = TICKET_CHIP_ICONS[chip.id];
+                            const selected = selectedTicketChip === chip.id;
+                            return (
+                              <button
+                                key={chip.id}
+                                type="button"
+                                data-tone={chip.tone}
+                                data-testid={`ticket-chip-${chip.id}`}
+                                aria-pressed={selected}
+                                onClick={() => applyTicketChip(chip.id)}
+                                className={`de-desk-row${selected ? " is-selected" : ""}`}
+                              >
+                                <span className="de-desk-row-ic">
+                                  <Icon aria-hidden="true" />
+                                </span>
+                                <span className="de-desk-row-t">{chip.label}</span>
+                                <ChevronRight className="de-desk-row-chev" aria-hidden="true" />
+                              </button>
+                            );
+                          })}
                         </div>
 
-                        <div className="de-desk-details-head">
+                        <div className="de-desk-details-head" ref={ticketDetailsRef}>
                           <h4>Tell us the details</h4>
                           <span className="de-desk-secure">
                             <Lock aria-hidden="true" />
@@ -1259,7 +1274,7 @@ export const ZohoASAPWidget = ({
                                     data-testid="select-support-category"
                                   >
                                     <option value="">Select a category</option>
-                                    {TICKET_CATEGORIES.map((item) => (
+                                    {DESK_TICKET_CATEGORIES.map((item) => (
                                       <option key={item} value={item}>
                                         {item}
                                       </option>
@@ -1768,6 +1783,12 @@ export const ZohoASAPWidget = ({
               border-color: var(--desk-border-strong);
               transform: translateY(-1px);
             }
+            .de-desk-row.is-selected {
+              border-color: #D3126A;
+              background: #fff;
+              box-shadow: inset 0 0 0 1px rgba(211,18,106,0.16);
+            }
+            .de-desk-row.is-selected .de-desk-row-chev { color: #D3126A; }
             .de-desk-rows.is-grid .de-desk-row { padding: 9px 10px; }
             .de-desk-rows.is-grid .de-desk-row-t { font-size: 13.5px; line-height: 1.3; }
             .de-desk-row[data-tone="violet"] { --c: var(--desk-violet); }

--- a/client/src/hooks/useDraggableWindow.ts
+++ b/client/src/hooks/useDraggableWindow.ts
@@ -1,9 +1,14 @@
 import { useCallback, useEffect, useRef, useState, type PointerEvent as ReactPointerEvent } from "react";
+import {
+  clampDeskPos,
+  clampDeskSize,
+  resizeDeskFromSouthEast,
+  type DeskViewport,
+  type DeskWindowPos,
+  type DeskWindowSize,
+} from "@/lib/deskWindowGeometry";
 
-export type WindowPos = { x: number; y: number };
-
-const PAD = 12;
-const TITLE_KEEP = 56;
+export type WindowPos = DeskWindowPos;
 
 function parseCssPx(value: string): number {
   const n = parseFloat(value);
@@ -12,7 +17,7 @@ function parseCssPx(value: string): number {
 
 function canvasGutterPx(): number {
   const gutter = parseCssPx(
-    getComputedStyle(document.documentElement).getPropertyValue("--de-canvas-gutter")
+    getComputedStyle(document.documentElement).getPropertyValue("--de-canvas-gutter"),
   );
   if (gutter > 0) return gutter;
   const raw = getComputedStyle(document.documentElement).getPropertyValue("--de-canvas").trim();
@@ -23,24 +28,27 @@ function canvasGutterPx(): number {
   return Math.max(0, (window.innerWidth - Math.min(window.innerWidth, canvasPx)) / 2);
 }
 
-function clampPos(x: number, y: number, width: number): WindowPos {
-  const navBottom =
-    parseCssPx(
-      getComputedStyle(document.documentElement).getPropertyValue("--de-nav-current-bottom")
-    ) || 72;
-  const cookieH = parseCssPx(
-    getComputedStyle(document.documentElement).getPropertyValue("--de-cookie-h")
-  );
-  const gutter = canvasGutterPx();
-  const minX = gutter + PAD;
-  const maxX = Math.max(minX, window.innerWidth - gutter - width - PAD);
-  const minY = navBottom + PAD;
-  const maxY = Math.max(minY, window.innerHeight - TITLE_KEEP - cookieH - PAD);
+function readViewport(): DeskViewport {
   return {
-    x: Math.min(Math.max(x, minX), maxX),
-    y: Math.min(Math.max(y, minY), maxY),
+    width: window.innerWidth,
+    height: window.innerHeight,
+    gutter: canvasGutterPx(),
+    navBottom:
+      parseCssPx(
+        getComputedStyle(document.documentElement).getPropertyValue("--de-nav-current-bottom"),
+      ) || 72,
+    cookieH: parseCssPx(
+      getComputedStyle(document.documentElement).getPropertyValue("--de-cookie-h"),
+    ),
   };
 }
+
+type StoredLayout = {
+  x?: number;
+  y?: number;
+  w?: number;
+  h?: number;
+};
 
 export function useDraggableWindow(options: {
   enabled: boolean;
@@ -49,8 +57,11 @@ export function useDraggableWindow(options: {
 }) {
   const { enabled, open, storageKey } = options;
   const panelRef = useRef<HTMLElement | null>(null);
-  const [pos, setPos] = useState<WindowPos | null>(null);
+  const [pos, setPos] = useState<DeskWindowPos | null>(null);
+  const [size, setSize] = useState<DeskWindowSize | null>(null);
   const [dragging, setDragging] = useState(false);
+  const [resizing, setResizing] = useState(false);
+  const sizeRef = useRef<DeskWindowSize | null>(null);
   const dragRef = useRef({
     active: false,
     startX: 0,
@@ -58,21 +69,59 @@ export function useDraggableWindow(options: {
     origX: 0,
     origY: 0,
   });
+  const resizeRef = useRef({
+    active: false,
+    startX: 0,
+    startY: 0,
+    origX: 0,
+    origY: 0,
+    origW: 0,
+    origH: 0,
+  });
 
   const measureAndClamp = useCallback((x: number, y: number) => {
     const el = panelRef.current;
-    const width = el?.offsetWidth ?? 460;
-    return clampPos(x, y, width);
+    const width = el?.offsetWidth ?? 410;
+    return clampDeskPos(x, y, width, readViewport());
   }, []);
+
+  const persist = (nextPos: DeskWindowPos | null, nextSize: DeskWindowSize | null) => {
+    if (nextPos) setPos(nextPos);
+    if (nextSize) {
+      sizeRef.current = nextSize;
+      setSize(nextSize);
+    }
+    try {
+      const payload: StoredLayout = {
+        ...(nextPos ?? pos ?? {}),
+        ...(nextSize ?? size ?? {}),
+      };
+      if (
+        typeof payload.x === "number" ||
+        typeof payload.y === "number" ||
+        typeof payload.w === "number" ||
+        typeof payload.h === "number"
+      ) {
+        sessionStorage.setItem(storageKey, JSON.stringify(payload));
+      }
+    } catch {
+      /* ignore */
+    }
+  };
 
   useEffect(() => {
     if (!open || !enabled) return;
     try {
       const raw = sessionStorage.getItem(storageKey);
       if (!raw) return;
-      const parsed = JSON.parse(raw) as WindowPos;
+      const parsed = JSON.parse(raw) as StoredLayout;
       if (typeof parsed.x === "number" && typeof parsed.y === "number") {
         setPos(measureAndClamp(parsed.x, parsed.y));
+      }
+      if (typeof parsed.w === "number" && typeof parsed.h === "number") {
+        const nextSize = clampDeskSize(parsed.w, parsed.h, readViewport());
+        sizeRef.current = nextSize;
+        setSize(nextSize);
       }
     } catch {
       /* ignore */
@@ -80,23 +129,20 @@ export function useDraggableWindow(options: {
   }, [open, enabled, storageKey, measureAndClamp]);
 
   useEffect(() => {
-    if (!open || !pos) return;
-    const onResize = () => setPos((current) => (current ? measureAndClamp(current.x, current.y) : current));
+    if (!open || (!pos && !size)) return;
+    const onResize = () => {
+      const view = readViewport();
+      setPos((current) => (current ? clampDeskPos(current.x, current.y, size?.w ?? panelRef.current?.offsetWidth ?? 410, view) : current));
+      setSize((current) => (current ? clampDeskSize(current.w, current.h, view) : current));
+    };
     window.addEventListener("resize", onResize);
     return () => window.removeEventListener("resize", onResize);
-  }, [open, pos, measureAndClamp]);
-
-  const persist = (next: WindowPos) => {
-    setPos(next);
-    try {
-      sessionStorage.setItem(storageKey, JSON.stringify(next));
-    } catch {
-      /* ignore */
-    }
-  };
+  }, [open, pos, size]);
 
   const reset = useCallback(() => {
     setPos(null);
+    sizeRef.current = null;
+    setSize(null);
     try {
       sessionStorage.removeItem(storageKey);
     } catch {
@@ -108,8 +154,28 @@ export function useDraggableWindow(options: {
       el.style.top = "";
       el.style.right = "";
       el.style.bottom = "";
+      el.style.width = "";
+      el.style.height = "";
     }
   }, [storageKey]);
+
+  const pinCurrentRect = () => {
+    const el = panelRef.current;
+    if (!el) return null;
+    const rect = el.getBoundingClientRect();
+    const start = measureAndClamp(rect.left, rect.top);
+    const nextSize = clampDeskSize(rect.width, rect.height, readViewport());
+    el.style.left = `${start.x}px`;
+    el.style.top = `${start.y}px`;
+    el.style.right = "auto";
+    el.style.bottom = "auto";
+    el.style.width = `${nextSize.w}px`;
+    el.style.height = `${nextSize.h}px`;
+    setPos(start);
+    sizeRef.current = nextSize;
+    setSize(nextSize);
+    return { ...start, ...nextSize };
+  };
 
   const onHandlePointerDown = (event: ReactPointerEvent<HTMLElement>) => {
     if (!enabled) return;
@@ -118,20 +184,15 @@ export function useDraggableWindow(options: {
     if (!el) return;
     event.preventDefault();
 
-    const rect = el.getBoundingClientRect();
-    const start = measureAndClamp(rect.left, rect.top);
-    el.style.left = `${start.x}px`;
-    el.style.top = `${start.y}px`;
-    el.style.right = "auto";
-    el.style.bottom = "auto";
-    setPos(start);
+    const pinned = pinCurrentRect();
+    if (!pinned) return;
 
     dragRef.current = {
       active: true,
       startX: event.clientX,
       startY: event.clientY,
-      origX: start.x,
-      origY: start.y,
+      origX: pinned.x,
+      origY: pinned.y,
     };
     setDragging(true);
     document.body.style.userSelect = "none";
@@ -141,7 +202,7 @@ export function useDraggableWindow(options: {
       const { startX, startY, origX, origY } = dragRef.current;
       const next = measureAndClamp(
         origX + moveEvent.clientX - startX,
-        origY + moveEvent.clientY - startY
+        origY + moveEvent.clientY - startY,
       );
       el.style.left = `${next.x}px`;
       el.style.top = `${next.y}px`;
@@ -156,7 +217,67 @@ export function useDraggableWindow(options: {
       document.body.style.userSelect = "";
       setDragging(false);
       const box = el.getBoundingClientRect();
-      persist(measureAndClamp(box.left, box.top));
+      persist(measureAndClamp(box.left, box.top), sizeRef.current);
+    };
+
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+    window.addEventListener("pointercancel", onUp);
+  };
+
+  const onResizePointerDown = (event: ReactPointerEvent<HTMLElement>) => {
+    if (!enabled) return;
+    if (event.pointerType === "mouse" && event.button !== 0) return;
+    const el = panelRef.current;
+    if (!el) return;
+    event.preventDefault();
+    event.stopPropagation();
+
+    const pinned = pinCurrentRect();
+    if (!pinned) return;
+
+    resizeRef.current = {
+      active: true,
+      startX: event.clientX,
+      startY: event.clientY,
+      origX: pinned.x,
+      origY: pinned.y,
+      origW: pinned.w,
+      origH: pinned.h,
+    };
+    setResizing(true);
+    document.body.style.userSelect = "none";
+    document.body.style.cursor = "nwse-resize";
+
+    const onMove = (moveEvent: PointerEvent) => {
+      if (!resizeRef.current.active) return;
+      const { startX, startY, origX, origY, origW, origH } = resizeRef.current;
+      const next = resizeDeskFromSouthEast(
+        { x: origX, y: origY, w: origW, h: origH },
+        { dx: moveEvent.clientX - startX, dy: moveEvent.clientY - startY },
+        readViewport(),
+      );
+      el.style.left = `${next.x}px`;
+      el.style.top = `${next.y}px`;
+      el.style.width = `${next.w}px`;
+      el.style.height = `${next.h}px`;
+    };
+
+    const onUp = () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      window.removeEventListener("pointercancel", onUp);
+      if (!resizeRef.current.active) return;
+      resizeRef.current.active = false;
+      document.body.style.userSelect = "";
+      document.body.style.cursor = "";
+      setResizing(false);
+      const box = el.getBoundingClientRect();
+      const view = readViewport();
+      persist(
+        clampDeskPos(box.left, box.top, box.width, view),
+        clampDeskSize(box.width, box.height, view),
+      );
     };
 
     window.addEventListener("pointermove", onMove);
@@ -167,8 +288,11 @@ export function useDraggableWindow(options: {
   return {
     panelRef,
     pos,
+    size,
     dragging,
+    resizing,
     reset,
     onHandlePointerDown,
+    onResizePointerDown,
   };
 }

--- a/client/src/lib/deskTicketChips.test.ts
+++ b/client/src/lib/deskTicketChips.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  DESK_TICKET_CHIPS,
+  applyDeskTicketChip,
+  isDeskTicketChipPrompt,
+} from "./deskTicketChips";
+
+describe("DE Desk ticket chips", () => {
+  it("covers the four most common DE helpdesk paths", () => {
+    expect(DESK_TICKET_CHIPS.map((chip) => chip.id)).toEqual([
+      "email-m365",
+      "sign-in",
+      "device",
+      "security-incident",
+    ]);
+    expect(DESK_TICKET_CHIPS.map((chip) => chip.category)).toEqual([
+      "Email",
+      "Access & Security",
+      "Hardware & Devices",
+      "Access & Security",
+    ]);
+    expect(DESK_TICKET_CHIPS.find((chip) => chip.id === "security-incident")?.priority).toBe(
+      "Urgent",
+    );
+  });
+
+  it("fills subject, category, and priority, and seeds a prompt", () => {
+    const email = DESK_TICKET_CHIPS[0];
+    const next = applyDeskTicketChip(email, { message: "" });
+    expect(next.subject).toBe("Email or Microsoft 365 issue");
+    expect(next.category).toBe("Email");
+    expect(next.priority).toBe("High");
+    expect(next.message).toContain("Outlook, Teams, web mail");
+    expect(isDeskTicketChipPrompt(next.message)).toBe(true);
+  });
+
+  it("replaces a previous chip prompt but keeps visitor-written details", () => {
+    const email = DESK_TICKET_CHIPS[0];
+    const signIn = DESK_TICKET_CHIPS[1];
+    const fromEmail = applyDeskTicketChip(email, { message: "" });
+    const switched = applyDeskTicketChip(signIn, { message: fromEmail.message });
+    expect(switched.subject).toBe("Sign-in or MFA issue");
+    expect(switched.message).toContain("password, MFA, VPN");
+
+    const custom = applyDeskTicketChip(signIn, {
+      message: "Outlook will not open on Jane's laptop since 9am.",
+    });
+    expect(custom.message).toBe("Outlook will not open on Jane's laptop since 9am.");
+    expect(custom.priority).toBe("High");
+  });
+});

--- a/client/src/lib/deskTicketChips.ts
+++ b/client/src/lib/deskTicketChips.ts
@@ -1,0 +1,103 @@
+/**
+ * Ticket issue chips for DE Desk.
+ * Four paths that match the most common MSP/MSSP work DE actually handles:
+ * email/M365, identity/sign-in, endpoint/printer, and security incidents.
+ */
+export const DESK_TICKET_PRIORITIES = ["Low", "Medium", "High", "Urgent"] as const;
+export type DeskTicketPriority = (typeof DESK_TICKET_PRIORITIES)[number];
+
+export const DESK_TICKET_CATEGORIES = [
+  "Email",
+  "Access & Security",
+  "Network & VPN",
+  "Software & Applications",
+  "Hardware & Devices",
+  "Backup & Recovery",
+  "Collaboration",
+  "Other",
+] as const;
+export type DeskTicketCategory = (typeof DESK_TICKET_CATEGORIES)[number];
+
+export type DeskTicketChipId = "email-m365" | "sign-in" | "device" | "security-incident";
+
+export type DeskTicketChip = {
+  id: DeskTicketChipId;
+  label: string;
+  tone: "red" | "blue" | "violet";
+  category: DeskTicketCategory;
+  priority: DeskTicketPriority;
+  subject: string;
+  prompt: string;
+};
+
+export const DESK_TICKET_CHIPS: DeskTicketChip[] = [
+  {
+    id: "email-m365",
+    label: "Email or Microsoft 365",
+    tone: "blue",
+    category: "Email",
+    priority: "High",
+    subject: "Email or Microsoft 365 issue",
+    prompt:
+      "What's happening (Outlook, Teams, web mail, or something else):\nWho is affected (just you / several people / everyone):\nWhen it started:\nWhat you already tried:\n",
+  },
+  {
+    id: "sign-in",
+    label: "Can't sign in",
+    tone: "violet",
+    category: "Access & Security",
+    priority: "High",
+    subject: "Sign-in or MFA issue",
+    prompt:
+      "What's failing (password, MFA, VPN, portal, or a specific app):\nWho is affected:\nWhen it started:\nWhat you already tried:\n",
+  },
+  {
+    id: "device",
+    label: "Computer or printer",
+    tone: "blue",
+    category: "Hardware & Devices",
+    priority: "Medium",
+    subject: "Computer or printer issue",
+    prompt:
+      "Which device (computer, laptop, or printer):\nWhat's happening:\nWhen it started:\nWhat you already tried:\n",
+  },
+  {
+    id: "security-incident",
+    label: "Possible security incident",
+    tone: "red",
+    category: "Access & Security",
+    priority: "Urgent",
+    subject: "Possible security incident",
+    prompt:
+      "What did you notice (phishing email, unusual login, ransomware warning, or something else):\nWho is affected:\nWhen you first saw it:\nDo not include passwords or MFA codes.\n",
+  },
+];
+
+export function deskTicketChipById(id: DeskTicketChipId | null): DeskTicketChip | undefined {
+  return DESK_TICKET_CHIPS.find((chip) => chip.id === id);
+}
+
+export function isDeskTicketChipPrompt(message: string): boolean {
+  const normalized = message.replace(/\s+$/g, "");
+  return DESK_TICKET_CHIPS.some((chip) => chip.prompt.replace(/\s+$/g, "") === normalized);
+}
+
+export function applyDeskTicketChip(
+  chip: DeskTicketChip,
+  current: { message: string },
+): {
+  subject: string;
+  category: DeskTicketCategory;
+  priority: DeskTicketPriority;
+  message: string;
+  chipId: DeskTicketChipId;
+} {
+  const canReplacePrompt = !current.message.trim() || isDeskTicketChipPrompt(current.message);
+  return {
+    subject: chip.subject,
+    category: chip.category,
+    priority: chip.priority,
+    message: canReplacePrompt ? chip.prompt : current.message,
+    chipId: chip.id,
+  };
+}

--- a/client/src/lib/deskWindowGeometry.test.ts
+++ b/client/src/lib/deskWindowGeometry.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  clampDeskSize,
+  resizeDeskFromSouthEast,
+} from "./deskWindowGeometry";
+
+const view = {
+  width: 1440,
+  height: 900,
+  gutter: 24,
+  navBottom: 72,
+  cookieH: 0,
+};
+
+describe("deskWindowGeometry", () => {
+  it("clamps size between the usable min and max", () => {
+    expect(clampDeskSize(100, 100, view)).toEqual({ w: 360, h: 440 });
+    expect(clampDeskSize(2000, 2000, view)).toEqual({ w: 720, h: 804 });
+  });
+
+  it("grows a bottom-right docked window up and left", () => {
+    const docked = { x: 994, y: 168, w: 410, h: 720 };
+    const next = resizeDeskFromSouthEast(docked, { dx: 200, dy: 200 }, view);
+    expect(next.w).toBeGreaterThan(docked.w);
+    expect(next.h).toBeGreaterThan(docked.h);
+    expect(next.x + next.w).toBeLessThanOrEqual(1440 - 24 - 12);
+    expect(next.y + next.h).toBeLessThanOrEqual(900 - 12);
+    expect(next.x).toBeLessThan(docked.x);
+  });
+
+  it("shrinks from the south-east corner without leaving the canvas", () => {
+    const mid = { x: 400, y: 120, w: 520, h: 600 };
+    const next = resizeDeskFromSouthEast(mid, { dx: -80, dy: -60 }, view);
+    expect(next.w).toBe(440);
+    expect(next.h).toBe(540);
+    expect(next.x).toBe(400);
+    expect(next.y).toBe(120);
+  });
+});

--- a/client/src/lib/deskWindowGeometry.ts
+++ b/client/src/lib/deskWindowGeometry.ts
@@ -1,0 +1,80 @@
+/** Layout math for the DE Desk floating window. Viewport values are injected so tests stay deterministic. */
+
+export const DESK_WINDOW_PAD = 12;
+export const DESK_MIN_W = 360;
+export const DESK_MIN_H = 440;
+export const DESK_MAX_W = 720;
+export const DESK_TITLE_KEEP = 56;
+
+export type DeskViewport = {
+  width: number;
+  height: number;
+  gutter: number;
+  navBottom: number;
+  cookieH: number;
+};
+
+export type DeskWindowSize = { w: number; h: number };
+export type DeskWindowPos = { x: number; y: number };
+
+export function deskSizeBounds(view: DeskViewport): {
+  minW: number;
+  minH: number;
+  maxW: number;
+  maxH: number;
+} {
+  const maxW = Math.max(
+    280,
+    Math.min(DESK_MAX_W, view.width - view.gutter * 2 - DESK_WINDOW_PAD * 2),
+  );
+  const maxH = Math.max(
+    320,
+    view.height - view.navBottom - view.cookieH - DESK_WINDOW_PAD * 2,
+  );
+  return {
+    minW: Math.min(DESK_MIN_W, maxW),
+    minH: Math.min(DESK_MIN_H, maxH),
+    maxW,
+    maxH,
+  };
+}
+
+export function clampDeskSize(w: number, h: number, view: DeskViewport): DeskWindowSize {
+  const b = deskSizeBounds(view);
+  return {
+    w: Math.min(Math.max(Math.round(w), b.minW), b.maxW),
+    h: Math.min(Math.max(Math.round(h), b.minH), b.maxH),
+  };
+}
+
+export function clampDeskPos(x: number, y: number, width: number, view: DeskViewport): DeskWindowPos {
+  const minX = view.gutter + DESK_WINDOW_PAD;
+  const maxX = Math.max(minX, view.width - view.gutter - width - DESK_WINDOW_PAD);
+  const minY = view.navBottom + DESK_WINDOW_PAD;
+  const maxY = Math.max(minY, view.height - DESK_TITLE_KEEP - view.cookieH - DESK_WINDOW_PAD);
+  return {
+    x: Math.min(Math.max(x, minX), maxX),
+    y: Math.min(Math.max(y, minY), maxY),
+  };
+}
+
+/**
+ * Grow/shrink from the south-east corner. If the new size would overflow the
+ * right or bottom edge, shift the window up/left so a docked Desk can still
+ * get larger.
+ */
+export function resizeDeskFromSouthEast(
+  start: DeskWindowPos & DeskWindowSize,
+  delta: { dx: number; dy: number },
+  view: DeskViewport,
+): DeskWindowPos & DeskWindowSize {
+  const size = clampDeskSize(start.w + delta.dx, start.h + delta.dy, view);
+  const maxRight = view.width - view.gutter - DESK_WINDOW_PAD;
+  const maxBottom = view.height - view.cookieH - DESK_WINDOW_PAD;
+  let x = start.x;
+  let y = start.y;
+  if (x + size.w > maxRight) x = maxRight - size.w;
+  if (y + size.h > maxBottom) y = maxBottom - size.h;
+  const pos = clampDeskPos(x, y, size.w, view);
+  return { ...pos, ...size };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Ticket issue chips now start a real ticket, and the DE Desk window can be resized on desktop.

### Ticket chips
The 2×2 tiles used to set a vague subject and a often-wrong category. They now match the issues DE actually handles:

1. **Email or Microsoft 365** → Email, High
2. **Can't sign in** → Access & Security, High
3. **Computer or printer** → Hardware & Devices, Medium
4. **Possible security incident** → Access & Security, Urgent

Clicking a chip selects it, fills subject/category/priority, seeds a prompt, and focuses the form.

### Resizable window
Desktop Desk is no longer locked at 410×760. A south-east grip lets visitors make it larger. If the window is docked in the bottom-right, growing shifts it up and left so it stays on screen. Size persists for the session. Double-click the header to reset. Mobile stays a full sheet.

## Files

- `client/src/lib/deskTicketChips.ts`
- `client/src/lib/deskWindowGeometry.ts`
- `client/src/hooks/useDraggableWindow.ts`
- `client/src/components/ZohoASAPWidget.tsx`
- `.cursor/skills/de-desk-ui/tokens-and-structure.md`

## Preserved

- Paper theme, magenta CTA, tabs, composer, Assist, portal login
- Drag-to-move on `sm+`
- Ticket submit API and chat thread

## Tests

- Vitest: 67 passed, including chip routing and resize geometry
- CI baseline typecheck/test/build: green
- Browser at 1440: default Desk 410×760; after SE drag, 635×710 (content reflows)
- Browser at 390: full-sheet Desk, no resize handle

[DE Desk at default 410px width](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdesk_resize_before_410.png)
[DE Desk after resize to 635px width](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdesk_resize_after_635.png)
[desk_resize_drag_to_enlarge.mp4](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdesk_resize_drag_to_enlarge.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55eac13a-e87f-4a00-9c34-f63bb77c3080&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

