### PR TITLE
fix(desk): let visitors expand and resize from any edge

### DIFF
--- a/.cursor/skills/de-desk-ui/tokens-and-structure.md
+++ b/.cursor/skills/de-desk-ui/tokens-and-structure.md
@@ -18,7 +18,7 @@ Do **not** use charcoal hero/rows, black footer, plum washes, or magenta→viole
 
 ## Shared chrome (top → bottom)
 
-1. **Header** — magenta DE mark + green pip; title “DE Desk”; subtitle “Answers · Tickets · Assist”; close. On `sm+` the header moves the window; double-click resets size and position. A south-east grip resizes the window (grows up/left when docked).
+1. **Header** — magenta DE mark + green pip; title “DE Desk”; subtitle “Answers · Tickets · Assist”; Expand (desktop) + close. On `sm+` the header moves the window; double-click resets size and position. Drag any edge or the south-east grip to resize. Expand grows toward the page from a bottom-right dock.
 2. **Tabs** — Desk | Ticket | Resources; active = dark label + magenta underline
 3. **Status row** — paper field; green/sky/amber dot + “DE Desk is online” | “Need help now?”
 4. **Content** — paper body; white raised hero + white raised rows / light inputs

--- a/client/src/components/ZohoASAPWidget.tsx
+++ b/client/src/components/ZohoASAPWidget.tsx
@@ -15,6 +15,8 @@ import {
   LifeBuoy,
   Lock,
   Mail,
+  Maximize2,
+  Minimize2,
   Monitor,
   MessageCircle,
   Paperclip,
@@ -920,6 +922,23 @@ export const ZohoASAPWidget = ({
                   </p>
                 </div>
               </div>
+              {canDrag ? (
+                <button
+                  type="button"
+                  className="de-desk-close"
+                  data-testid="button-expand-desk"
+                  aria-label={deskDrag.expanded ? "Reset DE Desk size" : "Expand DE Desk"}
+                  title={deskDrag.expanded ? "Reset size" : "Expand"}
+                  onPointerDown={(event) => event.stopPropagation()}
+                  onClick={deskDrag.toggleExpanded}
+                >
+                  {deskDrag.expanded ? (
+                    <Minimize2 size={13} aria-hidden="true" />
+                  ) : (
+                    <Maximize2 size={13} aria-hidden="true" />
+                  )}
+                </button>
+              ) : null}
               <button
                 type="button"
                 onClick={() => setIsOpen(false)}
@@ -1551,15 +1570,27 @@ export const ZohoASAPWidget = ({
               </button>
             </footer>
             {canDrag ? (
-              <button
-                type="button"
-                className={`de-desk-resize${deskDrag.resizing ? " is-active" : ""}`}
-                data-testid="desk-resize-handle"
-                aria-label="Resize DE Desk. Drag to make the window larger or smaller."
-                onPointerDown={deskDrag.onResizePointerDown}
-              >
-                <span aria-hidden="true" />
-              </button>
+              <>
+                {(["n", "s", "e", "w", "ne", "nw", "sw"] as const).map((edge) => (
+                  <button
+                    key={edge}
+                    type="button"
+                    className={`de-desk-resize-edge de-desk-resize-${edge}`}
+                    data-testid={`desk-resize-${edge}`}
+                    aria-label={`Resize DE Desk from the ${edge} edge`}
+                    onPointerDown={deskDrag.onResizePointerDown(edge)}
+                  />
+                ))}
+                <button
+                  type="button"
+                  className={`de-desk-resize de-desk-resize-se${deskDrag.resizing ? " is-active" : ""}`}
+                  data-testid="desk-resize-handle"
+                  aria-label="Resize DE Desk. Drag any edge or this corner, or use Expand in the header."
+                  onPointerDown={deskDrag.onResizePointerDown("se")}
+                >
+                  <span aria-hidden="true" />
+                </button>
+              </>
             ) : null}
           </section>
         )}
@@ -2127,6 +2158,21 @@ export const ZohoASAPWidget = ({
               display: flex; align-items: center; gap: 4px; flex: none;
             }
             .de-desk-foot-cta svg { width: 11px; height: 11px; }
+            .de-desk-resize-edge {
+              position: absolute;
+              border: 0;
+              padding: 0;
+              background: transparent;
+              touch-action: none;
+              z-index: 4;
+            }
+            .de-desk-resize-n { top: 0; left: 14px; right: 14px; height: 10px; cursor: ns-resize; }
+            .de-desk-resize-s { bottom: 0; left: 14px; right: 14px; height: 10px; cursor: ns-resize; }
+            .de-desk-resize-e { right: 0; top: 14px; bottom: 14px; width: 10px; cursor: ew-resize; }
+            .de-desk-resize-w { left: 0; top: 14px; bottom: 14px; width: 10px; cursor: ew-resize; }
+            .de-desk-resize-nw { top: 0; left: 0; width: 16px; height: 16px; cursor: nwse-resize; }
+            .de-desk-resize-ne { top: 0; right: 0; width: 16px; height: 16px; cursor: nesw-resize; }
+            .de-desk-resize-sw { bottom: 0; left: 0; width: 16px; height: 16px; cursor: nesw-resize; }
             .de-desk-resize {
               position: absolute;
               right: 0;
@@ -2137,7 +2183,7 @@ export const ZohoASAPWidget = ({
               background: transparent;
               cursor: nwse-resize;
               touch-action: none;
-              z-index: 3;
+              z-index: 5;
             }
             .de-desk-resize span {
               position: absolute;
@@ -2146,9 +2192,9 @@ export const ZohoASAPWidget = ({
               width: 14px;
               height: 14px;
               background:
-                linear-gradient(135deg, transparent 46%, #726c82 46%, #726c82 54%, transparent 54%),
-                linear-gradient(135deg, transparent 66%, #726c82 66%, #726c82 74%, transparent 74%),
-                linear-gradient(135deg, transparent 86%, #726c82 86%, #726c82 94%, transparent 94%);
+                linear-gradient(135deg, transparent 46%, #5c5668 46%, #5c5668 54%, transparent 54%),
+                linear-gradient(135deg, transparent 66%, #5c5668 66%, #5c5668 74%, transparent 74%),
+                linear-gradient(135deg, transparent 86%, #5c5668 86%, #5c5668 94%, transparent 94%);
             }
             .de-desk-resize:hover span,
             .de-desk-resize.is-active span,

--- a/client/src/hooks/useDraggableWindow.ts
+++ b/client/src/hooks/useDraggableWindow.ts
@@ -2,7 +2,10 @@ import { useCallback, useEffect, useRef, useState, type PointerEvent as ReactPoi
 import {
   clampDeskPos,
   clampDeskSize,
-  resizeDeskFromSouthEast,
+  expandDeskWindow,
+  isDeskExpanded,
+  resizeDeskFromEdge,
+  type DeskResizeEdge,
   type DeskViewport,
   type DeskWindowPos,
   type DeskWindowSize,
@@ -61,6 +64,7 @@ export function useDraggableWindow(options: {
   const [size, setSize] = useState<DeskWindowSize | null>(null);
   const [dragging, setDragging] = useState(false);
   const [resizing, setResizing] = useState(false);
+  const [expanded, setExpanded] = useState(false);
   const sizeRef = useRef<DeskWindowSize | null>(null);
   const dragRef = useRef({
     active: false,
@@ -71,6 +75,7 @@ export function useDraggableWindow(options: {
   });
   const resizeRef = useRef({
     active: false,
+    edge: "se" as DeskResizeEdge,
     startX: 0,
     startY: 0,
     origX: 0,
@@ -127,6 +132,14 @@ export function useDraggableWindow(options: {
       /* ignore */
     }
   }, [open, enabled, storageKey, measureAndClamp]);
+
+  useEffect(() => {
+    if (!size) {
+      setExpanded(false);
+      return;
+    }
+    setExpanded(isDeskExpanded(size, readViewport()));
+  }, [size]);
 
   useEffect(() => {
     if (!open || (!pos && !size)) return;
@@ -225,7 +238,18 @@ export function useDraggableWindow(options: {
     window.addEventListener("pointercancel", onUp);
   };
 
-  const onResizePointerDown = (event: ReactPointerEvent<HTMLElement>) => {
+  const applyRect = (next: DeskWindowPos & DeskWindowSize) => {
+    const el = panelRef.current;
+    if (!el) return;
+    el.style.left = `${next.x}px`;
+    el.style.top = `${next.y}px`;
+    el.style.right = "auto";
+    el.style.bottom = "auto";
+    el.style.width = `${next.w}px`;
+    el.style.height = `${next.h}px`;
+  };
+
+  const onResizePointerDown = (edge: DeskResizeEdge) => (event: ReactPointerEvent<HTMLElement>) => {
     if (!enabled) return;
     if (event.pointerType === "mouse" && event.button !== 0) return;
     const el = panelRef.current;
@@ -238,6 +262,7 @@ export function useDraggableWindow(options: {
 
     resizeRef.current = {
       active: true,
+      edge,
       startX: event.clientX,
       startY: event.clientY,
       origX: pinned.x,
@@ -247,20 +272,17 @@ export function useDraggableWindow(options: {
     };
     setResizing(true);
     document.body.style.userSelect = "none";
-    document.body.style.cursor = "nwse-resize";
 
     const onMove = (moveEvent: PointerEvent) => {
       if (!resizeRef.current.active) return;
-      const { startX, startY, origX, origY, origW, origH } = resizeRef.current;
-      const next = resizeDeskFromSouthEast(
+      const { startX, startY, origX, origY, origW, origH, edge: liveEdge } = resizeRef.current;
+      const next = resizeDeskFromEdge(
         { x: origX, y: origY, w: origW, h: origH },
         { dx: moveEvent.clientX - startX, dy: moveEvent.clientY - startY },
+        liveEdge,
         readViewport(),
       );
-      el.style.left = `${next.x}px`;
-      el.style.top = `${next.y}px`;
-      el.style.width = `${next.w}px`;
-      el.style.height = `${next.h}px`;
+      applyRect(next);
     };
 
     const onUp = () => {
@@ -270,7 +292,6 @@ export function useDraggableWindow(options: {
       if (!resizeRef.current.active) return;
       resizeRef.current.active = false;
       document.body.style.userSelect = "";
-      document.body.style.cursor = "";
       setResizing(false);
       const box = el.getBoundingClientRect();
       const view = readViewport();
@@ -285,13 +306,31 @@ export function useDraggableWindow(options: {
     window.addEventListener("pointercancel", onUp);
   };
 
+  const toggleExpanded = () => {
+    if (!enabled) return;
+    const el = panelRef.current;
+    if (!el) return;
+    const pinned = pinCurrentRect();
+    if (!pinned) return;
+    const view = readViewport();
+    if (isDeskExpanded(pinned, view)) {
+      reset();
+      return;
+    }
+    const next = expandDeskWindow(pinned, view);
+    applyRect(next);
+    persist(next, next);
+  };
+
   return {
     panelRef,
     pos,
     size,
     dragging,
     resizing,
+    expanded,
     reset,
+    toggleExpanded,
     onHandlePointerDown,
     onResizePointerDown,
   };

--- a/client/src/lib/deskWindowGeometry.test.ts
+++ b/client/src/lib/deskWindowGeometry.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   clampDeskSize,
+  expandDeskWindow,
+  resizeDeskFromEdge,
   resizeDeskFromSouthEast,
 } from "./deskWindowGeometry";
 
@@ -35,5 +37,27 @@ describe("deskWindowGeometry", () => {
     expect(next.h).toBe(540);
     expect(next.x).toBe(400);
     expect(next.y).toBe(120);
+  });
+
+  it("grows a docked window when the west or north edge is pulled toward the page", () => {
+    const docked = { x: 994, y: 168, w: 410, h: 720 };
+    const fromWest = resizeDeskFromEdge(docked, { dx: -180, dy: 0 }, "w", view);
+    expect(fromWest.w).toBe(590);
+    expect(fromWest.x).toBe(814);
+    expect(fromWest.x + fromWest.w).toBe(docked.x + docked.w);
+
+    const fromNorth = resizeDeskFromEdge(docked, { dx: 0, dy: -80 }, "n", view);
+    expect(fromNorth.h).toBe(800);
+    expect(fromNorth.y).toBeLessThan(docked.y);
+    expect(fromNorth.y + fromNorth.h).toBe(docked.y + docked.h);
+  });
+
+  it("expands a docked window to the max on-screen size", () => {
+    const docked = { x: 994, y: 168, w: 410, h: 720 };
+    const next = expandDeskWindow(docked, view);
+    expect(next.w).toBe(720);
+    expect(next.h).toBe(804);
+    expect(next.x + next.w).toBeLessThanOrEqual(1440 - 24 - 12);
+    expect(next.y + next.h).toBeLessThanOrEqual(900 - 12);
   });
 });

--- a/client/src/lib/deskWindowGeometry.ts
+++ b/client/src/lib/deskWindowGeometry.ts
@@ -16,6 +16,7 @@ export type DeskViewport = {
 
 export type DeskWindowSize = { w: number; h: number };
 export type DeskWindowPos = { x: number; y: number };
+export type DeskResizeEdge = "n" | "s" | "e" | "w" | "ne" | "nw" | "se" | "sw";
 
 export function deskSizeBounds(view: DeskViewport): {
   minW: number;
@@ -58,6 +59,46 @@ export function clampDeskPos(x: number, y: number, width: number, view: DeskView
   };
 }
 
+function deskMaxRight(view: DeskViewport): number {
+  return view.width - view.gutter - DESK_WINDOW_PAD;
+}
+
+function deskMaxBottom(view: DeskViewport): number {
+  return view.height - view.cookieH - DESK_WINDOW_PAD;
+}
+
+/**
+ * Grow/shrink from a window edge or corner. West/north pulls keep the opposite
+ * edge planted so a bottom-right docked Desk can expand toward the page.
+ * East/south growth that would overflow shifts the window up/left.
+ */
+export function resizeDeskFromEdge(
+  start: DeskWindowPos & DeskWindowSize,
+  delta: { dx: number; dy: number },
+  edge: DeskResizeEdge,
+  view: DeskViewport,
+): DeskWindowPos & DeskWindowSize {
+  const fromW = edge.includes("w");
+  const fromE = edge.includes("e");
+  const fromN = edge.includes("n");
+  const fromS = edge.includes("s");
+
+  let nextW = start.w;
+  let nextH = start.h;
+  if (fromE) nextW = start.w + delta.dx;
+  if (fromW) nextW = start.w - delta.dx;
+  if (fromS) nextH = start.h + delta.dy;
+  if (fromN) nextH = start.h - delta.dy;
+
+  const size = clampDeskSize(nextW, nextH, view);
+  let x = fromW ? start.x + start.w - size.w : start.x;
+  let y = fromN ? start.y + start.h - size.h : start.y;
+  if (x + size.w > deskMaxRight(view)) x = deskMaxRight(view) - size.w;
+  if (y + size.h > deskMaxBottom(view)) y = deskMaxBottom(view) - size.h;
+  const pos = clampDeskPos(x, y, size.w, view);
+  return { ...pos, ...size };
+}
+
 /**
  * Grow/shrink from the south-east corner. If the new size would overflow the
  * right or bottom edge, shift the window up/left so a docked Desk can still
@@ -68,13 +109,19 @@ export function resizeDeskFromSouthEast(
   delta: { dx: number; dy: number },
   view: DeskViewport,
 ): DeskWindowPos & DeskWindowSize {
-  const size = clampDeskSize(start.w + delta.dx, start.h + delta.dy, view);
-  const maxRight = view.width - view.gutter - DESK_WINDOW_PAD;
-  const maxBottom = view.height - view.cookieH - DESK_WINDOW_PAD;
-  let x = start.x;
-  let y = start.y;
-  if (x + size.w > maxRight) x = maxRight - size.w;
-  if (y + size.h > maxBottom) y = maxBottom - size.h;
-  const pos = clampDeskPos(x, y, size.w, view);
-  return { ...pos, ...size };
+  return resizeDeskFromEdge(start, delta, "se", view);
+}
+
+/** Grow to the largest on-screen size while keeping the bottom-right planted. */
+export function expandDeskWindow(
+  start: DeskWindowPos & DeskWindowSize,
+  view: DeskViewport,
+): DeskWindowPos & DeskWindowSize {
+  const b = deskSizeBounds(view);
+  return resizeDeskFromEdge(start, { dx: b.maxW - start.w, dy: b.maxH - start.h }, "se", view);
+}
+
+export function isDeskExpanded(size: DeskWindowSize, view: DeskViewport): boolean {
+  const b = deskSizeBounds(view);
+  return size.w >= b.maxW - 16 && size.h >= b.maxH - 16;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Moving DE Desk worked. Resizing did not, because the only grip was the south-east corner of a window already docked in that corner.

- **Expand** in the header grows the window to the largest on-screen size (bottom-right stays planted). Click again to reset.
- Drag the **left or top edge** toward the page to make it larger without moving it first.
- The south-east grip remains for fine adjustment. Other edges/corners also resize.

## Files

- `client/src/lib/deskWindowGeometry.ts`
- `client/src/hooks/useDraggableWindow.ts`
- `client/src/components/ZohoASAPWidget.tsx`

## Preserved

Paper theme, ticket chips, drag-to-move, mobile full sheet, portal login.

## Tests

- Geometry unit tests for west/north grow and expand
- Local 1440: default 410 → Expand 720 wide; west-edge drag also grows width

[DE Desk expanded to 720px](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdesk_expanded_1440.png)
[desk_expand_and_edge_resize.mp4](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdesk_expand_and_edge_resize.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55eac13a-e87f-4a00-9c34-f63bb77c3080&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

