### PR TITLE
Sharpen DE Desk: Ask DE, Get Support, Client Tools

### DIFF
--- a/.cursor/rules/de-desk-design.mdc
+++ b/.cursor/rules/de-desk-design.mdc
@@ -10,9 +10,9 @@ Primary file: `client/src/components/ZohoASAPWidget.tsx`. Full playbook: `.curso
 
 ## Shell (all tabs)
 
-- **One paper theme** for Desk / Ticket / Resources — header, tabs, status, body, composer, and footer all sit on `#F7F5F2`.
-- **White raised cards** for hero, prompt rows, resource rows, and form fields.
-- Brand magenta `#D3126A` for avatar, active underline, send, CTAs. Violet `#8B5CF6` is icon-well accent only — no purple wash fills.
+- **One paper theme** for Ask DE / Get Support / Client Tools — header, tabs, status, body, composer, and footer all sit on `#F7F5F2`.
+- **White raised cards** for hero, prompt rows, tool rows, and form fields.
+- Brand magenta `#D3126A` for avatar, active underline, send, CTAs, incident rail. Violet `#8B5CF6` is icon-well accent only — no purple wash fills.
 - Active tab: dark label + magenta underline. Inactive: muted shell dim.
 - High contrast: dark ink on paper. Do not restore charcoal boxes or a black footer.
 
@@ -20,9 +20,9 @@ Primary file: `client/src/components/ZohoASAPWidget.tsx`. Full playbook: `.curso
 
 | Tab | Panel inside paper shell |
 |-----|--------------------------|
-| **Desk** | Paper hero + paper prompt rows; conversation uses magenta user / paper assistant bubbles. |
-| **Ticket** | Same hero language + paper chip rows + light inputs. |
-| **Resources** | Same hero language + paper resource rows + assessment highlight + security alert. |
+| **Ask DE** | Paper hero + intent prompt rows; conversation uses magenta user / paper assistant bubbles. |
+| **Get Support** | Same hero language + featured incident card + 2×2 chips + light inputs. |
+| **Client Tools** | Same hero language + portal / remote / KB / status rows + assessment highlight + security alert. |
 
 Do not invent a third unrelated theme per tab. Elevate in place; ask DE before removing CTAs, tabs, disclaimers, or resource links.
 
@@ -36,4 +36,6 @@ Do not invent a third unrelated theme per tab. Elevate in place; ask DE before r
 
 Preserve chat send/poll, agent live, ticket submit, resources links, analytics, ASAP bootstrap, cookie offset, `de-open-msp-advisor`.
 
-The composer stays on **all three tabs** and is the same Desk thread. Sending from Ticket or Resources must **not** force a tab switch. Incoming replies while on another tab show an Android-style heads-up over the panel plus a Desk tab badge; the visitor can reply in the shared composer or tap the toast to open Desk.
+The composer stays on **all three tabs** and is the same Ask DE thread. Sending from Get Support or Client Tools must **not** force a tab switch. Incoming replies while on another tab show an Android-style heads-up over the panel plus an Ask DE tab badge; the visitor can reply in the shared composer or tap the toast to open Ask DE.
+
+Do not say “online” unless a human has joined. Status CTA is “Open a support ticket” / “Ask DE instead”, never “Need help now?”. Do not add billing as a Desk choice.

--- a/.cursor/skills/de-desk-ui/SKILL.md
+++ b/.cursor/skills/de-desk-ui/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: de-desk-ui
 description: >-
-  Designs and restyles the DE Desk support widget (Desk / Ticket / Resources)
-  as one paper theme. Use when editing ZohoASAPWidget, DE Desk, Ask DE, ASAP
-  widget, support modal tabs, desk resources copy, or when DE attaches DE Desk
-  mockups / asks for Desk UI polish.
+  Designs and restyles the DE Desk support widget (Ask DE / Get Support /
+  Client Tools) as one paper theme. Use when editing ZohoASAPWidget, DE Desk,
+  Ask DE, ASAP widget, support modal tabs, desk client-tools copy, or when DE
+  attaches DE Desk mockups / asks for Desk UI polish.
 ---
 
 # DE Desk UI
@@ -18,13 +18,26 @@ description: >-
 ## Non-negotiables
 
 - **One paper theme** for the whole widget: header, tabs, hero, rows, inputs, composer, and footer. No charcoal hero. No black footer. No white/black stripe.
-- **Desk / Ticket / Resources** share that language. Do not put a second nested theme per tab.
-- Magenta `#D3126A` is the only loud color (avatar, active tab, send, submit, user bubbles).
-- **Function labels**, not vendor names (`Remote session` not `Zoho Assist`). Keep hrefs.
-- Do **not** remove tabs, CTAs, disclaimers, or resource rows without asking DE.
+- **Ask DE / Get Support / Client Tools** share that language. Do not put a second nested theme per tab.
+- Magenta `#D3126A` is the only loud color (avatar, active tab, send, submit, user bubbles, incident rail).
+- **Function labels**, not vendor names (`Start remote support` not `Zoho Assist`). Keep hrefs.
+- Do **not** remove tabs, CTAs, disclaimers, or tool rows without asking DE.
 - Do **not** invent `//login`; use `PORTAL_LOGIN`.
+- Do **not** add Pay Invoice / Billing as a Desk choice. Billing lives in Client Portal.
 - Preserve advisor chat, poll, agent live, ticket API, analytics, ASAP bootstrap.
-- Composer is one shared Desk thread on all three tabs. Do not force a tab switch on send. Incoming replies on Ticket/Resources use the heads-up toast + Desk badge.
+- Composer is one shared Ask DE thread on all three tabs. Do not force a tab switch on send. Incoming replies on Get Support / Client Tools use the heads-up toast + Ask DE badge.
+
+## Architecture
+
+The modal is **Ask → Support → Tools**, not a miniature site nav.
+
+| Tab (label) | Internal id | Purpose |
+|-------------|-------------|---------|
+| **Ask DE** | `chat` | Visitors and clients who do not yet know what they need |
+| **Get Support** | `ticket` | Technical support + security incident routing |
+| **Client Tools** | `resources` | Portal, remote support, knowledge base, system status |
+
+**Possible security incident** is visually dominant on Get Support (featured Urgent card + magenta left rail). From Ask DE it switches to Get Support and applies that chip — it does not stay a chat prompt.
 
 ## Workflow
 
@@ -33,7 +46,8 @@ DE Desk UI checklist:
 - [ ] One paper field for the whole chrome
 - [ ] White raised cards for hero, rows, and form
 - [ ] Paper composer + footer (not charcoal)
-- [ ] Copy is function-based
+- [ ] Copy is function-based and intent-based
+- [ ] Security incident is unmistakable
 - [ ] Contrast checked (dark ink on paper)
 - [ ] Browser screenshot
 - [ ] Logic untouched unless requested
@@ -43,11 +57,15 @@ DE Desk UI checklist:
 
 1. Change layout/classes in `client/src/components/ZohoASAPWidget.tsx` only as needed.
 2. Keep `RESOURCE_LINKS` titles functional; tags describe capability.
+3. Remote support guide is a **sublink** under Start remote support, not a fourth major card.
 
 ## Anti-patterns
 
 - Dual-tone stripe (light header + charcoal cards + black footer)
 - Dark boxes on a light body
 - Muddy mid-gradient chat backgrounds
-- Product/vendor branding in client-facing resource titles
+- Product/vendor branding in client-facing tool titles
 - Purple-on-cream / generic AI SaaS aesthetics unrelated to DE magenta brand
+- Saying “online” when only AI is available
+- Vague “Need help now?” as the status CTA
+- Billing / Pay Invoice as a prominent Desk choice

--- a/.cursor/skills/de-desk-ui/tokens-and-structure.md
+++ b/.cursor/skills/de-desk-ui/tokens-and-structure.md
@@ -6,43 +6,49 @@ One paper sheet. Magenta pops because the field stays cream.
 
 | Token | Value | Use |
 |-------|-------|-----|
-| Magenta | `#D3126A` | Avatar, active underline, send, CTAs, user bubbles |
+| Magenta | `#D3126A` | Avatar, active underline, send, CTAs, user bubbles, incident rail, Urgent badge |
 | Violet | `#8B5CF6` | Icon-well accent only — never a wash fill or CTA gradient |
 | Field | paper `#F7F5F2` | Entire chrome: header, body, composer, footer |
 | Raised | `#FFFFFF` | Hero, rows, form card, composer input |
 | Hairline | `rgba(20,16,30,0.10)` | Paper borders |
 | Ink | `#17141F` / `#5C5668` | Titles and body on every tab |
-| Online | Emerald pip | Availability |
+| Available | Emerald pip | Availability — say “available”, not “online” |
 
 Do **not** use charcoal hero/rows, black footer, plum washes, or magenta→violet CTA gradients.
 
 ## Shared chrome (top → bottom)
 
-1. **Header** — magenta DE mark + green pip; title “DE Desk”; subtitle “Answers · Tickets · Assist”; Expand (desktop) + close. On `sm+` the header moves the window; double-click resets size and position. Drag any edge or the south-east grip to resize. Expand grows toward the page from a bottom-right dock.
-2. **Tabs** — Desk | Ticket | Resources; active = dark label + magenta underline
-3. **Status row** — paper field; green/sky/amber dot + “DE Desk is online” | “Need help now?”
+1. **Header** — magenta DE mark + green pip; title “DE Desk”; subtitle “Ask · Support · Tools”; Expand (desktop) + close. On `sm+` the header moves the window; double-click resets size and position. Drag any edge or the south-east grip to resize. Expand grows toward the page from a bottom-right dock.
+2. **Tabs** — Ask DE | Get Support | Client Tools; active = dark label + magenta underline
+3. **Status row** — paper field; green/sky/amber dot + “DE Desk available” | “Open a support ticket” / on Get Support: “Ask DE instead”. When a person joins: “{name} joined the conversation”.
 4. **Content** — paper body; white raised hero + white raised rows / light inputs
 5. **Composer** — paper ask bar + white input + solid magenta send
-6. **Footer** — paper; “DE Desk · Ticket · Resources · Assist” (Assist → remote session) | Create ticket
+6. **Footer** — paper; “Ask DE · Get Support · Client Tools · Assist” (Assist → remote session) | Open a support ticket
 
-## Resources
+## Ask DE
 
-- Hero: “Get where you need to go”
-- Rows: colored icon well + title + description + external + chevron
-- Assessment highlight + security alert with Create ticket
-- Labels are **functions** (Remote session, Remote support guide, Knowledge base, Client portal)
-
-## Desk
-
-- Paper hero “Talk to DE Desk” + paper prompt rows (all four visible)
-- After send: magenta user bubbles, paper assistant bubbles
+- Paper hero “How can we help?”
+- Intent prompts (all four visible): Something isn't working · Possible security incident · Help me choose IT/security services · I have an IT or security question
+- Security prompt switches to Get Support and applies the incident chip
+- After send: magenta user bubbles, paper assistant bubbles labeled “Ask DE”
 - Shared paper composer under all tabs
 
-## Ticket
+## Get Support
 
-- Paper hero “Create a support ticket”
-- Subject chips in a 2×2 grid (Email or Microsoft 365, Can't sign in, Computer or printer, Possible security incident). Clicking one selects it, fills subject/category/priority, seeds a prompt, and moves focus into the form.
+- Paper hero “Get technical support” / “Tell us what's happening and we'll route it to the right place.”
+- Featured full-width **Possible security incident** (Urgent badge, magenta left rail, phishing/malware blurb)
+- Then 2×2: Email or Microsoft 365 · Can't sign in / MFA · Computer or device · Something else
+- Clicking a chip selects it, fills subject/category/priority, seeds a prompt, and moves focus into the form
+- Taxonomy under the form stays: Email, Access & Security, Network & VPN, Software & Applications, Hardware & Devices, Backup & Recovery, Collaboration, Other
 - Form on paper: Secure & private pill; light fields; solid magenta submit
+
+## Client Tools
+
+- Hero: “Client tools”
+- Major rows: Client portal · Start remote support · Knowledge base · System status
+- Remote support guide is a small sibling link under Start remote support
+- Assessment highlight + security alert with Create ticket stay
+- Do not add Pay Invoice / Billing here
 
 ## Primary file
 

--- a/.cursor/skills/de-desk-ui/tokens-and-structure.md
+++ b/.cursor/skills/de-desk-ui/tokens-and-structure.md
@@ -28,7 +28,7 @@ Do **not** use charcoal hero/rows, black footer, plum washes, or magenta→viole
 ## Ask DE
 
 - Paper hero “How can we help?”
-- Intent prompts (all four visible): Something isn't working · Possible security incident · Help me choose IT/security services · I have an IT or security question
+- Intent prompts in a 2×2 (all four visible): Something isn't working · Possible security incident · Help me choose services · Ask an IT/security question
 - Security prompt switches to Get Support and applies the incident chip
 - After send: magenta user bubbles, paper assistant bubbles labeled “Ask DE”
 - Shared paper composer under all tabs

--- a/client/src/components/ZohoASAPWidget.tsx
+++ b/client/src/components/ZohoASAPWidget.tsx
@@ -98,8 +98,8 @@ const QUICK_CHAT_PROMPTS: Array<{
 }> = [
   { label: "Something isn't working", icon: Monitor, tone: "blue" },
   { label: "Possible security incident", icon: AlertTriangle, tone: "red", ticketChip: "security-incident" },
-  { label: "Help me choose IT/security services", icon: Scale, tone: "violet" },
-  { label: "I have an IT or security question", icon: MessageCircle, tone: "teal" },
+  { label: "Help me choose services", icon: Scale, tone: "violet" },
+  { label: "Ask an IT/security question", icon: MessageCircle, tone: "teal" },
 ];
 
 function DeskHeroArt({ variant }: { variant: "desk" | "ticket" | "resources" }) {
@@ -1086,7 +1086,7 @@ export const ZohoASAPWidget = ({
                           </div>
                           <DeskHeroArt variant="desk" />
                         </div>
-                        <div className="de-desk-rows">
+                        <div className="de-desk-rows is-grid">
                           {QUICK_CHAT_PROMPTS.map(({ label, icon: Icon, tone, ticketChip }) => (
                             <button
                               key={label}
@@ -1440,17 +1440,12 @@ export const ZohoASAPWidget = ({
                           <BookOpen aria-hidden="true" />
                         </div>
                         <h3>Client tools</h3>
-                        <p>Portal, remote support, knowledge base, and system status — not a generic resource library.</p>
+                        <p>Open the portal, start remote support, check status, or browse the knowledge base.</p>
                       </div>
                       <DeskHeroArt variant="resources" />
                     </div>
 
-                    <div className="de-desk-section-head">
-                      <h4>Client tools</h4>
-                      <a href="/support/knowledge-base">Browse knowledge base →</a>
-                    </div>
-
-                    <div className="de-desk-rows">
+                    <div className="de-desk-rows is-grid">
                       {RESOURCE_LINKS.map(({ title, description, href, icon: Icon, external, guide }, index) => (
                         <div key={title} className="de-desk-tool-block">
                           <a
@@ -1459,7 +1454,7 @@ export const ZohoASAPWidget = ({
                             {...(external || href.startsWith("http")
                               ? { target: "_blank", rel: "noopener noreferrer" }
                               : {})}
-                            className="de-desk-row is-lg"
+                            className="de-desk-row"
                             data-testid={`resource-link-${title.toLowerCase().replace(/\s+/g, "-")}`}
                           >
                             <span className="de-desk-row-ic">
@@ -1483,7 +1478,9 @@ export const ZohoASAPWidget = ({
                           ) : null}
                         </div>
                       ))}
+                    </div>
 
+                    <div className="de-desk-rows">
                       <a
                         href="/book"
                         data-tone="pink"
@@ -1919,18 +1916,19 @@ export const ZohoASAPWidget = ({
               border-radius: 5px; padding: 2px 6px;
               vertical-align: middle; margin-left: 8px;
             }
-            .de-desk-tool-block { display: flex; flex-direction: column; gap: 2px; }
+            .de-desk-tool-block { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
             .de-desk-sublink {
               align-self: flex-start;
-              margin: 0 0 4px 46px;
-              padding: 4px 0;
+              margin: 0 0 2px 42px;
+              padding: 2px 0 4px;
               font-size: 12.5px; font-weight: 600;
               color: #D3126A; text-decoration: none;
             }
             .de-desk-sublink:hover,
             .de-desk-sublink:focus-visible { text-decoration: underline; }
-            .de-desk-rows.is-grid .de-desk-row { padding: 9px 10px; }
+            .de-desk-rows.is-grid .de-desk-row { padding: 9px 10px; align-items: flex-start; }
             .de-desk-rows.is-grid .de-desk-row-t { font-size: 13.5px; line-height: 1.3; }
+            .de-desk-rows.is-grid .de-desk-tool-block .de-desk-row-actions { display: none; }
             .de-desk-row[data-tone="violet"] { --c: var(--desk-violet); }
             .de-desk-row[data-tone="blue"] { --c: var(--desk-blue); }
             .de-desk-row[data-tone="teal"] { --c: var(--desk-teal); }
@@ -2299,6 +2297,9 @@ export const ZohoASAPWidget = ({
             }
             @media (min-width: 640px) {
               .de-desk-foot { padding-right: 36px; }
+            }
+            @media (max-width: 480px) {
+              .de-desk-foot-cta { display: none; }
             }
             @media (max-width: 420px) {
               .de-desk-grid2 { grid-template-columns: 1fr; }

--- a/client/src/components/ZohoASAPWidget.tsx
+++ b/client/src/components/ZohoASAPWidget.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import {
+  Activity,
   AlertTriangle,
   BookOpen,
   Building2,
@@ -93,11 +94,12 @@ const QUICK_CHAT_PROMPTS: Array<{
   label: string;
   icon: typeof Shield;
   tone: "violet" | "blue" | "teal" | "red";
+  ticketChip?: DeskTicketChipId;
 }> = [
-  { label: "We need stronger cybersecurity", icon: Shield, tone: "violet" },
-  { label: "Compare managed IT options", icon: Scale, tone: "blue" },
-  { label: "Microsoft 365 feels messy", icon: Monitor, tone: "teal" },
-  { label: "Possible security incident", icon: AlertTriangle, tone: "red" },
+  { label: "Something isn't working", icon: Monitor, tone: "blue" },
+  { label: "Possible security incident", icon: AlertTriangle, tone: "red", ticketChip: "security-incident" },
+  { label: "Help me choose IT/security services", icon: Scale, tone: "violet" },
+  { label: "I have an IT or security question", icon: MessageCircle, tone: "teal" },
 ];
 
 function DeskHeroArt({ variant }: { variant: "desk" | "ticket" | "resources" }) {
@@ -191,10 +193,11 @@ function BookMagnifier({ className }: { className?: string }) {
 }
 
 const TICKET_CHIP_ICONS: Record<DeskTicketChipId, typeof Shield> = {
+  "security-incident": AlertTriangle,
   "email-m365": Mail,
   "sign-in": KeyRound,
   device: Monitor,
-  "security-incident": Shield,
+  "something-else": ClipboardList,
 };
 
 const RESOURCE_LINKS: Array<{
@@ -203,17 +206,30 @@ const RESOURCE_LINKS: Array<{
   href: string;
   icon: typeof BookOpen | typeof BookMagnifier;
   external?: boolean;
+  guide?: { title: string; href: string };
   tags: [string, string];
   cta: string;
   accent: string;
   iconBg: string;
 }> = [
   {
-    title: "Remote session",
-    description: "Join a secure live session so a technician can help on your screen",
+    title: "Client portal",
+    description: "Tickets, services, approvals, and account management.",
+    href: PORTAL_LOGIN,
+    icon: ShieldCheck,
+    tags: ["Account access", "Self-service"],
+    cta: "Open portal",
+    accent: "text-[#fed7aa]",
+    iconBg:
+      "bg-gradient-to-br from-[#fb923c]/45 to-[#ea580c]/25 ring-[#fdba74]/55 shadow-[0_0_20px_rgba(251,146,60,0.3)]",
+  },
+  {
+    title: "Start remote support",
+    description: "Connect securely with a technician.",
     href: "https://assist.zoho.com/",
     icon: Monitor,
     external: true,
+    guide: { title: "Remote support guide", href: "/support/remote-support" },
     tags: ["Live help", "Screen share"],
     cta: "Start session",
     accent: "text-[#e9d5ff]",
@@ -221,19 +237,8 @@ const RESOURCE_LINKS: Array<{
       "bg-gradient-to-br from-[#a855f7]/45 to-[#7c3aed]/30 ring-[#c084fc]/55 shadow-[0_0_20px_rgba(168,85,247,0.35)]",
   },
   {
-    title: "Remote support guide",
-    description: "How remote sessions work and what to expect",
-    href: "/support/remote-support",
-    icon: LifeBuoy,
-    tags: ["Support process", "Quick guide"],
-    cta: "View guide",
-    accent: "text-[#bae6fd]",
-    iconBg:
-      "bg-gradient-to-br from-[#38bdf8]/40 to-[#0284c7]/25 ring-[#7dd3fc]/50 shadow-[0_0_20px_rgba(56,189,248,0.3)]",
-  },
-  {
     title: "Knowledge base",
-    description: "Setup guides, troubleshooting, and security help",
+    description: "Guides and troubleshooting.",
     href: "/support/knowledge-base",
     icon: BookMagnifier,
     tags: ["Guides", "Troubleshooting"],
@@ -243,15 +248,15 @@ const RESOURCE_LINKS: Array<{
       "bg-gradient-to-br from-[#4ade80]/40 to-[#16a34a]/25 ring-[#86efac]/50 shadow-[0_0_20px_rgba(74,222,128,0.28)]",
   },
   {
-    title: "Client portal",
-    description: "Tickets, services, billing, approvals, and account tools",
-    href: PORTAL_LOGIN,
-    icon: ShieldCheck,
-    tags: ["Account access", "Self-service"],
-    cta: "Open portal",
-    accent: "text-[#fed7aa]",
+    title: "System status",
+    description: "Service advisories and known issues.",
+    href: "/portal/status",
+    icon: Activity,
+    tags: ["Advisories", "Known issues"],
+    cta: "View status",
+    accent: "text-[#bae6fd]",
     iconBg:
-      "bg-gradient-to-br from-[#fb923c]/45 to-[#ea580c]/25 ring-[#fdba74]/55 shadow-[0_0_20px_rgba(251,146,60,0.3)]",
+      "bg-gradient-to-br from-[#38bdf8]/40 to-[#0284c7]/25 ring-[#7dd3fc]/50 shadow-[0_0_20px_rgba(56,189,248,0.3)]",
   },
 ];
 
@@ -918,7 +923,7 @@ export const ZohoASAPWidget = ({
                   <p data-testid="text-widget-status">
                     {agentLive
                       ? `${agentName || "Specialist"} joined · live handoff`
-                      : "Answers · Tickets · Assist"}
+                      : "Ask · Support · Tools"}
                   </p>
                 </div>
               </div>
@@ -953,9 +958,9 @@ export const ZohoASAPWidget = ({
             <nav className="de-desk-tabs" aria-label="Support options">
               {(
                 [
-                  { id: "chat" as const, label: "Desk", icon: MessageCircle },
-                  { id: "ticket" as const, label: "Ticket", icon: FileText },
-                  { id: "resources" as const, label: "Resources", icon: BookOpen },
+                  { id: "chat" as const, label: "Ask DE", icon: MessageCircle },
+                  { id: "ticket" as const, label: "Get Support", icon: FileText },
+                  { id: "resources" as const, label: "Client Tools", icon: BookOpen },
                 ]
               ).map(({ id, label, icon: Icon }) => {
                 const isActive = activeTab === id;
@@ -971,7 +976,7 @@ export const ZohoASAPWidget = ({
                     aria-current={isActive ? "page" : undefined}
                     aria-label={
                       id === "chat" && unreadChatCount > 0
-                        ? `Desk, ${unreadChatCount} new ${unreadChatCount === 1 ? "message" : "messages"}`
+                        ? `Ask DE, ${unreadChatCount} new ${unreadChatCount === 1 ? "message" : "messages"}`
                         : undefined
                     }
                   >
@@ -1001,11 +1006,11 @@ export const ZohoASAPWidget = ({
                   }`}
                 />
                 {agentLive
-                  ? `${agentName || "Specialist"} on desk`
+                  ? `${agentName || "Support specialist"} joined the conversation`
                   : assistantAvailable === true
-                    ? "DE Desk is online"
+                    ? "DE Desk available"
                     : assistantAvailable === false
-                      ? "Ticket desk available"
+                      ? "Get Support available"
                       : "Connecting…"}
               </div>
               <button
@@ -1013,7 +1018,7 @@ export const ZohoASAPWidget = ({
                 onClick={() => selectTab(activeTab === "ticket" ? "chat" : "ticket")}
                 className="de-desk-status-r"
               >
-                Need help now?
+                {activeTab === "ticket" ? "Ask DE instead" : "Open a support ticket"}
                 <span className="de-desk-status-ic">
                   <Headset aria-hidden="true" />
                 </span>
@@ -1045,7 +1050,7 @@ export const ZohoASAPWidget = ({
                       </span>
                       <span className="de-desk-heads-up-preview">{headsUp.preview}</span>
                       <span className="de-desk-heads-up-hint">
-                        Reply below — or open Desk
+                        Reply below — or open Ask DE
                       </span>
                     </span>
                   </button>
@@ -1073,7 +1078,7 @@ export const ZohoASAPWidget = ({
                             <div className="de-desk-hero-ring">
                               <MessageCircle aria-hidden="true" />
                             </div>
-                            <h3>Talk to DE Desk</h3>
+                            <h3>How can we help?</h3>
                             <p>
                               Tell me what broke, what you&apos;re evaluating, or what you&apos;re trying to
                               protect — I&apos;ll give you a clear read and the sensible next step.
@@ -1082,13 +1087,21 @@ export const ZohoASAPWidget = ({
                           <DeskHeroArt variant="desk" />
                         </div>
                         <div className="de-desk-rows">
-                          {QUICK_CHAT_PROMPTS.map(({ label, icon: Icon, tone }) => (
+                          {QUICK_CHAT_PROMPTS.map(({ label, icon: Icon, tone, ticketChip }) => (
                             <button
                               key={label}
                               type="button"
                               data-tone={tone}
-                              onClick={() => void handleSendChat(label)}
-                              className="de-desk-row"
+                              data-testid={`ask-prompt-${label.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`}
+                              onClick={() => {
+                                if (ticketChip) {
+                                  selectTab("ticket");
+                                  applyTicketChip(ticketChip);
+                                  return;
+                                }
+                                void handleSendChat(label);
+                              }}
+                              className={`de-desk-row${ticketChip ? " is-incident" : ""}`}
                             >
                               <span className="de-desk-row-ic">
                                 <Icon aria-hidden="true" />
@@ -1116,7 +1129,7 @@ export const ZohoASAPWidget = ({
                               {!isUser && (
                                 <div className="de-desk-bubble-meta">
                                   <span>{isAgent ? "AG" : "DE"}</span>
-                                  {isAgent ? chatMessage.senderName || agentName || "Agent" : "Desk"}
+                                  {isAgent ? chatMessage.senderName || agentName || "Agent" : "Ask DE"}
                                 </div>
                               )}
                               <p className="whitespace-pre-wrap">{chatMessage.content}</p>
@@ -1163,7 +1176,7 @@ export const ZohoASAPWidget = ({
                             }}
                             className="de-desk-row"
                           >
-                            <span className="de-desk-row-t">Back to desk</span>
+                            <span className="de-desk-row-t">Back to Ask DE</span>
                           </button>
                           <button type="button" onClick={() => setTicketResult(null)} className="de-desk-btn-grad">
                             Create another ticket
@@ -1178,14 +1191,14 @@ export const ZohoASAPWidget = ({
                             <div className="de-desk-hero-ring">
                               <FileText aria-hidden="true" />
                             </div>
-                            <h3>Create a support ticket</h3>
-                            <p>Tell us what happened and we&apos;ll route it to the right team.</p>
+                            <h3>Get technical support</h3>
+                            <p>Tell us what&apos;s happening and we&apos;ll route it to the right place.</p>
                           </div>
                           <DeskHeroArt variant="ticket" />
                         </div>
 
-                        <div className="de-desk-rows is-grid" role="group" aria-label="Common support issues">
-                          {DESK_TICKET_CHIPS.map((chip) => {
+                        <div className="de-desk-rows" role="group" aria-label="Common support issues">
+                          {DESK_TICKET_CHIPS.filter((chip) => chip.featured).map((chip) => {
                             const Icon = TICKET_CHIP_ICONS[chip.id];
                             const selected = selectedTicketChip === chip.id;
                             return (
@@ -1196,16 +1209,45 @@ export const ZohoASAPWidget = ({
                                 data-testid={`ticket-chip-${chip.id}`}
                                 aria-pressed={selected}
                                 onClick={() => applyTicketChip(chip.id)}
-                                className={`de-desk-row${selected ? " is-selected" : ""}`}
+                                className={`de-desk-row is-lg is-incident${selected ? " is-selected" : ""}`}
                               >
                                 <span className="de-desk-row-ic">
                                   <Icon aria-hidden="true" />
                                 </span>
-                                <span className="de-desk-row-t">{chip.label}</span>
+                                <span className="de-desk-row-body">
+                                  <span className="de-desk-row-t">
+                                    {chip.label}
+                                    <span className="de-desk-badge-urgent">Urgent</span>
+                                  </span>
+                                  {chip.blurb ? <span className="de-desk-row-d">{chip.blurb}</span> : null}
+                                </span>
                                 <ChevronRight className="de-desk-row-chev" aria-hidden="true" />
                               </button>
                             );
                           })}
+                          <div className="de-desk-rows is-grid">
+                            {DESK_TICKET_CHIPS.filter((chip) => !chip.featured).map((chip) => {
+                              const Icon = TICKET_CHIP_ICONS[chip.id];
+                              const selected = selectedTicketChip === chip.id;
+                              return (
+                                <button
+                                  key={chip.id}
+                                  type="button"
+                                  data-tone={chip.tone}
+                                  data-testid={`ticket-chip-${chip.id}`}
+                                  aria-pressed={selected}
+                                  onClick={() => applyTicketChip(chip.id)}
+                                  className={`de-desk-row${selected ? " is-selected" : ""}`}
+                                >
+                                  <span className="de-desk-row-ic">
+                                    <Icon aria-hidden="true" />
+                                  </span>
+                                  <span className="de-desk-row-t">{chip.label}</span>
+                                  <ChevronRight className="de-desk-row-chev" aria-hidden="true" />
+                                </button>
+                              );
+                            })}
+                          </div>
                         </div>
 
                         <div className="de-desk-details-head" ref={ticketDetailsRef}>
@@ -1397,43 +1439,49 @@ export const ZohoASAPWidget = ({
                         <div className="de-desk-hero-ring">
                           <BookOpen aria-hidden="true" />
                         </div>
-                        <h3>Get where you need to go</h3>
-                        <p>Quick access to the most used support tools and resources.</p>
+                        <h3>Client tools</h3>
+                        <p>Portal, remote support, knowledge base, and system status — not a generic resource library.</p>
                       </div>
                       <DeskHeroArt variant="resources" />
                     </div>
 
                     <div className="de-desk-section-head">
-                      <h4>Resources</h4>
-                      <a href="/support/knowledge-base">Browse all →</a>
+                      <h4>Client tools</h4>
+                      <a href="/support/knowledge-base">Browse knowledge base →</a>
                     </div>
 
                     <div className="de-desk-rows">
-                      {RESOURCE_LINKS.map(({ title, description, href, icon: Icon, external }, index) => (
-                        <a
-                          key={title}
-                          href={href}
-                          data-tone={index === 0 ? "pink" : "violet"}
-                          {...(external || href.startsWith("http")
-                            ? { target: "_blank", rel: "noopener noreferrer" }
-                            : {})}
-                          className="de-desk-row is-lg"
-                          data-testid={`resource-link-${title.toLowerCase().replace(/\s+/g, "-")}`}
-                        >
-                          <span className="de-desk-row-ic">
-                            <Icon aria-hidden="true" />
-                          </span>
-                          <span className="de-desk-row-body">
-                            <span className="de-desk-row-t">{title}</span>
-                            <span className="de-desk-row-d">{description}</span>
-                          </span>
-                          <span className="de-desk-row-actions">
-                            <span className="de-desk-row-ext">
-                              <ExternalLink aria-hidden="true" />
+                      {RESOURCE_LINKS.map(({ title, description, href, icon: Icon, external, guide }, index) => (
+                        <div key={title} className="de-desk-tool-block">
+                          <a
+                            href={href}
+                            data-tone={index === 0 ? "pink" : "violet"}
+                            {...(external || href.startsWith("http")
+                              ? { target: "_blank", rel: "noopener noreferrer" }
+                              : {})}
+                            className="de-desk-row is-lg"
+                            data-testid={`resource-link-${title.toLowerCase().replace(/\s+/g, "-")}`}
+                          >
+                            <span className="de-desk-row-ic">
+                              <Icon aria-hidden="true" />
                             </span>
-                            <ChevronRight className="de-desk-row-chev" aria-hidden="true" />
-                          </span>
-                        </a>
+                            <span className="de-desk-row-body">
+                              <span className="de-desk-row-t">{title}</span>
+                              <span className="de-desk-row-d">{description}</span>
+                            </span>
+                            <span className="de-desk-row-actions">
+                              <span className="de-desk-row-ext">
+                                <ExternalLink aria-hidden="true" />
+                              </span>
+                              <ChevronRight className="de-desk-row-chev" aria-hidden="true" />
+                            </span>
+                          </a>
+                          {guide ? (
+                            <a href={guide.href} className="de-desk-sublink" data-testid="resource-link-remote-support-guide">
+                              {guide.title}
+                            </a>
+                          ) : null}
+                        </div>
                       ))}
 
                       <a
@@ -1494,9 +1542,9 @@ export const ZohoASAPWidget = ({
                 maxLength={2000}
                 placeholder={
                   activeTab === "ticket"
-                    ? "Reply to Desk without leaving this ticket…"
+                    ? "Reply to Ask DE without leaving this ticket…"
                     : activeTab === "resources"
-                      ? "Reply to Desk while you browse…"
+                      ? "Reply to Ask DE while you browse tools…"
                       : agentLive
                         ? `Message ${agentName || "the specialist"}…`
                         : "Ask about risk, stack, pricing, or an outage..."
@@ -1505,8 +1553,8 @@ export const ZohoASAPWidget = ({
                 data-testid="input-support-chat"
                 aria-label={
                   activeTab === "chat"
-                    ? "Chat message"
-                    : "Reply to Desk from this tab"
+                    ? "Ask DE message"
+                    : "Reply to Ask DE from this tab"
                 }
               />
               <button
@@ -1523,7 +1571,7 @@ export const ZohoASAPWidget = ({
             <p className="de-desk-composer-caption">
               <Lock aria-hidden="true" />
               {activeTab !== "chat"
-                ? "Same Desk thread on every tab — reply here without switching."
+                ? "Same Ask DE thread on every tab — reply here without switching."
                 : agentLive
                   ? "A Digerati agent is in this thread. Never share passwords or MFA codes."
                   : "Never share passwords, MFA codes, or private keys."}
@@ -1536,7 +1584,7 @@ export const ZohoASAPWidget = ({
                   className={activeTab === "chat" ? "is-active" : undefined}
                   onClick={() => selectTab("chat")}
                 >
-                  DE Desk
+                  Ask DE
                 </button>
                 <span aria-hidden="true">·</span>
                 <button
@@ -1544,7 +1592,7 @@ export const ZohoASAPWidget = ({
                   className={activeTab === "ticket" ? "is-active" : undefined}
                   onClick={() => selectTab("ticket")}
                 >
-                  Ticket
+                  Get Support
                 </button>
                 <span aria-hidden="true">·</span>
                 <button
@@ -1552,7 +1600,7 @@ export const ZohoASAPWidget = ({
                   className={activeTab === "resources" ? "is-active" : undefined}
                   onClick={() => selectTab("resources")}
                 >
-                  Resources
+                  Client Tools
                 </button>
                 <span aria-hidden="true">·</span>
                 <a
@@ -1565,7 +1613,7 @@ export const ZohoASAPWidget = ({
                 </a>
               </p>
               <button type="button" onClick={() => selectTab("ticket")} className="de-desk-foot-cta">
-                Create ticket
+                Open a support ticket
                 <ExternalLink aria-hidden="true" />
               </button>
             </footer>
@@ -1821,6 +1869,7 @@ export const ZohoASAPWidget = ({
             .de-desk-rows.is-grid {
               display: grid; grid-template-columns: 1fr 1fr; gap: 6px;
             }
+            .de-desk-rows > .de-desk-rows.is-grid { margin-top: 0; }
             .de-desk-row {
               display: flex; align-items: center; gap: 10px;
               padding: 9px 11px; border-radius: 12px;
@@ -1841,6 +1890,45 @@ export const ZohoASAPWidget = ({
               box-shadow: inset 0 0 0 1px rgba(211,18,106,0.16);
             }
             .de-desk-row.is-selected .de-desk-row-chev { color: #D3126A; }
+            .de-desk-row.is-incident {
+              background: #fff;
+              border-color: rgba(211,18,106,0.42);
+              box-shadow: inset 3px 0 0 #D3126A;
+              align-items: flex-start;
+            }
+            .de-desk-row.is-incident .de-desk-row-ic {
+              border-color: #D3126A;
+              color: #D3126A;
+              background: rgba(211,18,106,0.06);
+            }
+            .de-desk-row.is-incident .de-desk-row-t {
+              display: flex;
+              flex-wrap: wrap;
+              align-items: center;
+              gap: 6px 0;
+            }
+            .de-desk-row.is-incident:hover {
+              background: #fff;
+              border-color: #D3126A;
+            }
+            .de-desk-badge-urgent {
+              display: inline-block;
+              font-size: 9.5px; font-weight: 700; letter-spacing: 0.04em;
+              text-transform: uppercase;
+              color: #fff; background: #D3126A;
+              border-radius: 5px; padding: 2px 6px;
+              vertical-align: middle; margin-left: 8px;
+            }
+            .de-desk-tool-block { display: flex; flex-direction: column; gap: 2px; }
+            .de-desk-sublink {
+              align-self: flex-start;
+              margin: 0 0 4px 46px;
+              padding: 4px 0;
+              font-size: 12.5px; font-weight: 600;
+              color: #D3126A; text-decoration: none;
+            }
+            .de-desk-sublink:hover,
+            .de-desk-sublink:focus-visible { text-decoration: underline; }
             .de-desk-rows.is-grid .de-desk-row { padding: 9px 10px; }
             .de-desk-rows.is-grid .de-desk-row-t { font-size: 13.5px; line-height: 1.3; }
             .de-desk-row[data-tone="violet"] { --c: var(--desk-violet); }

--- a/client/src/lib/deskTicketChips.test.ts
+++ b/client/src/lib/deskTicketChips.test.ts
@@ -6,26 +6,30 @@ import {
 } from "./deskTicketChips";
 
 describe("DE Desk ticket chips", () => {
-  it("covers the four most common DE helpdesk paths", () => {
+  it("leads with a security incident, then the common helpdesk paths", () => {
     expect(DESK_TICKET_CHIPS.map((chip) => chip.id)).toEqual([
+      "security-incident",
       "email-m365",
       "sign-in",
       "device",
-      "security-incident",
+      "something-else",
     ]);
     expect(DESK_TICKET_CHIPS.map((chip) => chip.category)).toEqual([
+      "Access & Security",
       "Email",
       "Access & Security",
       "Hardware & Devices",
-      "Access & Security",
+      "Other",
     ]);
-    expect(DESK_TICKET_CHIPS.find((chip) => chip.id === "security-incident")?.priority).toBe(
-      "Urgent",
-    );
+    const incident = DESK_TICKET_CHIPS.find((chip) => chip.id === "security-incident");
+    expect(incident?.priority).toBe("Urgent");
+    expect(incident?.featured).toBe(true);
+    expect(incident?.blurb).toMatch(/Phishing/);
+    expect(DESK_TICKET_CHIPS.find((chip) => chip.id === "device")?.label).toBe("Computer or device");
   });
 
   it("fills subject, category, and priority, and seeds a prompt", () => {
-    const email = DESK_TICKET_CHIPS[0];
+    const email = DESK_TICKET_CHIPS.find((chip) => chip.id === "email-m365")!;
     const next = applyDeskTicketChip(email, { message: "" });
     expect(next.subject).toBe("Email or Microsoft 365 issue");
     expect(next.category).toBe("Email");
@@ -35,8 +39,8 @@ describe("DE Desk ticket chips", () => {
   });
 
   it("replaces a previous chip prompt but keeps visitor-written details", () => {
-    const email = DESK_TICKET_CHIPS[0];
-    const signIn = DESK_TICKET_CHIPS[1];
+    const email = DESK_TICKET_CHIPS.find((chip) => chip.id === "email-m365")!;
+    const signIn = DESK_TICKET_CHIPS.find((chip) => chip.id === "sign-in")!;
     const fromEmail = applyDeskTicketChip(email, { message: "" });
     const switched = applyDeskTicketChip(signIn, { message: fromEmail.message });
     expect(switched.subject).toBe("Sign-in or MFA issue");

--- a/client/src/lib/deskTicketChips.ts
+++ b/client/src/lib/deskTicketChips.ts
@@ -1,8 +1,9 @@
 /**
- * Ticket issue chips for DE Desk.
- * Four paths that match the most common MSP/MSSP work DE actually handles:
- * email/M365, identity/sign-in, endpoint/printer, and security incidents.
+ * Ticket issue chips for DE Desk Get Support.
+ * Paths that match the most common MSP/MSSP work DE actually handles:
+ * security incidents first, then email/M365, identity/sign-in, devices, and other.
  */
+
 export const DESK_TICKET_PRIORITIES = ["Low", "Medium", "High", "Urgent"] as const;
 export type DeskTicketPriority = (typeof DESK_TICKET_PRIORITIES)[number];
 
@@ -18,11 +19,18 @@ export const DESK_TICKET_CATEGORIES = [
 ] as const;
 export type DeskTicketCategory = (typeof DESK_TICKET_CATEGORIES)[number];
 
-export type DeskTicketChipId = "email-m365" | "sign-in" | "device" | "security-incident";
+export type DeskTicketChipId =
+  | "security-incident"
+  | "email-m365"
+  | "sign-in"
+  | "device"
+  | "something-else";
 
 export type DeskTicketChip = {
   id: DeskTicketChipId;
   label: string;
+  blurb?: string;
+  featured?: boolean;
   tone: "red" | "blue" | "violet";
   category: DeskTicketCategory;
   priority: DeskTicketPriority;
@@ -31,6 +39,18 @@ export type DeskTicketChip = {
 };
 
 export const DESK_TICKET_CHIPS: DeskTicketChip[] = [
+  {
+    id: "security-incident",
+    label: "Possible security incident",
+    blurb: "Phishing, suspicious login, compromised account, malware or ransomware.",
+    featured: true,
+    tone: "red",
+    category: "Access & Security",
+    priority: "Urgent",
+    subject: "Possible security incident",
+    prompt:
+      "What did you notice (phishing email, unusual login, ransomware warning, or something else):\nWho is affected:\nWhen you first saw it:\nDo not include passwords or MFA codes.\n",
+  },
   {
     id: "email-m365",
     label: "Email or Microsoft 365",
@@ -43,7 +63,7 @@ export const DESK_TICKET_CHIPS: DeskTicketChip[] = [
   },
   {
     id: "sign-in",
-    label: "Can't sign in",
+    label: "Can't sign in / MFA",
     tone: "violet",
     category: "Access & Security",
     priority: "High",
@@ -53,23 +73,23 @@ export const DESK_TICKET_CHIPS: DeskTicketChip[] = [
   },
   {
     id: "device",
-    label: "Computer or printer",
+    label: "Computer or device",
     tone: "blue",
     category: "Hardware & Devices",
     priority: "Medium",
-    subject: "Computer or printer issue",
+    subject: "Computer or device issue",
     prompt:
-      "Which device (computer, laptop, or printer):\nWhat's happening:\nWhen it started:\nWhat you already tried:\n",
+      "Which device (computer, laptop, phone, or other):\nWhat's happening:\nWhen it started:\nWhat you already tried:\n",
   },
   {
-    id: "security-incident",
-    label: "Possible security incident",
-    tone: "red",
-    category: "Access & Security",
-    priority: "Urgent",
-    subject: "Possible security incident",
+    id: "something-else",
+    label: "Something else",
+    tone: "blue",
+    category: "Other",
+    priority: "Medium",
+    subject: "Support request",
     prompt:
-      "What did you notice (phishing email, unusual login, ransomware warning, or something else):\nWho is affected:\nWhen you first saw it:\nDo not include passwords or MFA codes.\n",
+      "What's happening:\nWho is affected:\nWhen it started:\nWhat you already tried:\n",
   },
 ];
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Keep the DE Desk modal, but make the hierarchy decisive: **Ask → Support → Tools**, with security incident handling visually dominant.

## What changed

- Tabs: **Ask DE** | **Get Support** | **Client Tools** (internal ids stay `chat` / `ticket` / `resources`)
- Ask DE prompts are intent-based in a 2×2. **Possible security incident** switches to Get Support and applies the Urgent chip
- Get Support leads with a featured incident card (Urgent badge, magenta left rail, phishing/malware blurb), then Email / MFA / device / Something else
- Client Tools: Client portal, Start remote support, Knowledge base, System status. Remote support guide is a small sibling link, not a fourth major card
- Status copy says **DE Desk available** (not “online”). CTA is **Open a support ticket** / **Ask DE instead**
- No billing / Pay Invoice choice
- Narrow viewports hide the duplicate footer ticket CTA; the status row still offers it

## Preserved

- Ticket taxonomy, chip routing, composer on all tabs, Assist href, portal login via `PORTAL_LOGIN`, assessment row, security-sensitive alert, resize/expand

## Verification

- Unit tests for ticket chips
- Browser check of Ask DE, Get Support, and Client Tools at 1440 / 768 / 390
- Confirmed Ask DE security prompt applies the Urgent ticket chip and diagnostic questions

[Ask DE at 1440](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdesk_ask_de_1440.png)
[Get Support at 1440](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdesk_get_support_1440.png)
[Client Tools at 1440](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdesk_client_tools_1440.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55eac13a-e87f-4a00-9c34-f63bb77c3080&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

