### PR TITLE
Restore three store category-pill colors

### DIFF
--- a/.cursor/rules/blog-store-color-lock.mdc
+++ b/.cursor/rules/blog-store-color-lock.mdc
@@ -27,8 +27,9 @@ Ask DE before changing any value below.
 - Page accent: `data-accent="electric"`.
 - Tokens: `--de-accent-rgb: 29 111 242`; `--de-accent-ink-rgb: 111 179 255`.
 - Category pills stay **pill-only** with the 14 distinct hues in `categoryAccent` (`StoreProductCard.tsx`). Guard: `categoryAccent.test.ts`.
-  - `comanaged_subscriptions` teal-300, `comanaged_onboarding` lime-300, `digital_templates` yellow-300, `professional_services` pink-300.
-- Do not paint cards, rails, or the catalog field with those pill hues. Do not collapse pills onto violet/purple/indigo or onto one store-wide color.
+  - `comanaged_subscriptions` violet-300, `comanaged_onboarding` purple-300, `digital_templates` indigo-300. Those three are intentional taxonomy colours from before the sweep — do not collapse them, and do not restyle them under the marketing-page “remove purple” rule.
+  - `professional_services` pink-300. Blues, cyan, green, orange, and the other current pill hues stay as they are.
+- Do not paint cards, rails, or the catalog field with those pill hues. Do not collapse any two categories onto one store-wide color.
 - Vendor marks stay vendor colors. Do not recolor logos.
 
 ## Shared

--- a/client/src/components/store/StoreProductCard.tsx
+++ b/client/src/components/store/StoreProductCard.tsx
@@ -25,14 +25,17 @@ import { ProductMedia } from "@/components/store/ProductMedia";
  * This is wayfinding, not decoration: every category has to stay tellable from
  * every other one, so no two entries may share a hue. The pill also prints its
  * category label, which keeps colour as reinforcement rather than the only
- * channel. Violet, purple and indigo are deliberately absent — they read as the
- * retired generic chrome. Colours here are exempt from the site accent sweep;
- * see the store entry in scripts/brand-audit.mjs.
+ * channel.
+ *
+ * Store taxonomy colours are exceptions to the marketing-page accent cleanup.
+ * Do not collapse them onto one hue, and do not strip violet / purple / indigo
+ * from these pills just because those tokens are retired on marketing chrome.
+ * See the store entry in scripts/brand-audit.mjs and blog-store-color-lock.mdc.
  */
 export const categoryAccent: Record<ProductCategory, string> = {
   contract_services: "text-amber-300",
-  comanaged_subscriptions: "text-teal-300",
-  comanaged_onboarding: "text-lime-300",
+  comanaged_subscriptions: "text-violet-300",
+  comanaged_onboarding: "text-purple-300",
   networking_managed: "text-cyan-300",
   networking_projects: "text-sky-300",
   ucaas_subscriptions: "text-green-300",
@@ -41,7 +44,7 @@ export const categoryAccent: Record<ProductCategory, string> = {
   hardware_physical: "text-rose-300",
   hardware_handling: "text-red-300",
   digital_assessments: "text-blue-300",
-  digital_templates: "text-yellow-300",
+  digital_templates: "text-indigo-300",
   digital_training: "text-fuchsia-300",
   professional_services: "text-pink-300",
 };

--- a/client/src/components/store/categoryAccent.test.ts
+++ b/client/src/components/store/categoryAccent.test.ts
@@ -4,8 +4,8 @@ import { categoryAccent } from "./StoreProductCard";
 /**
  * Store category pills are wayfinding, so two categories sharing a hue is a
  * real defect rather than a cosmetic one. A site-wide colour sweep already
- * collapsed three of these into a single accent once; these assertions make
- * that fail loudly instead of shipping.
+ * collapsed three of these into a single accent once; these assertions lock
+ * the pre-sweep distinct tokens and fail if they collapse again.
  */
 describe("store category accents", () => {
   const entries = Object.entries(categoryAccent);
@@ -23,9 +23,10 @@ describe("store category accents", () => {
     expect(shared).toEqual([]);
   });
 
-  it("never reaches for the retired violet chrome", () => {
-    const retired = entries.filter(([, token]) => /-(violet|purple|indigo)-/.test(token));
-    expect(retired).toEqual([]);
+  it("keeps the three pre-sweep taxonomy pills on their distinct hues", () => {
+    expect(categoryAccent.comanaged_subscriptions).toBe("text-violet-300");
+    expect(categoryAccent.comanaged_onboarding).toBe("text-purple-300");
+    expect(categoryAccent.digital_templates).toBe("text-indigo-300");
   });
 
   it("keeps the accents to text tokens so pills stay pills", () => {

--- a/docs/BRAND-SWEEP-NEXT.md
+++ b/docs/BRAND-SWEEP-NEXT.md
@@ -11,7 +11,7 @@ The audit (`scripts/brand-audit.mjs`) is a regression detector, not a requiremen
 - Marketing field stays the charcoal ladder. Primary CTA fill is solid `#D3126A`.
 - Page families keep one topical hue: store → electric, support → cyan, resources → amber, everything else inherits magenta.
 - **Locked (DE):** Blog/Journal and Store keep the colors they have now. Do not restyle those palettes. Rule: `.cursor/rules/blog-store-color-lock.mdc`.
-- Store category pills stay pill-only and use 14 distinct hues. Teal / lime / yellow replaced the three that had collapsed onto violet; `professional_services` moved to pink so teal could stay. Guard: `client/src/components/store/categoryAccent.test.ts`.
+- Store category pills stay pill-only and use 14 distinct hues. `comanaged_subscriptions`, `comanaged_onboarding`, and `digital_templates` keep their pre-sweep taxonomy colours (violet / purple / indigo). Do not apply the marketing-page “remove purple” rule to those pills. Everything else in the store palette stays as it currently looks. Guard: `client/src/components/store/categoryAccent.test.ts`.
 - Portal, login, and signup are out of scope unless DE asks for a separate portal UI pass.
 - Dead `client/src/pages/Homepage.tsx` and the legacy sections it imports are not routed (`/` uses `DigeratiHomepage`). Sweeping them is diff noise.
 - Intentional exceptions live in `EXCEPTIONS` inside `scripts/brand-audit.mjs`: store category pills, vendor marks, hero lighting, semantic status/charts, official city chips.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Preserve the store’s current visual design and all existing colors, especially its blue accents and current category colors.

This does **not** roll back the store palette or recolor `/store/*`.

## Only change

Restore the three category pills that the accent sweep remapped:

| Category | Restored pill color | Computed |
|---|---|---|
| `comanaged_subscriptions` | `text-violet-300` | `rgb(196, 181, 253)` |
| `comanaged_onboarding` | `text-purple-300` | `rgb(216, 180, 254)` |
| `digital_templates` | `text-indigo-300` | `rgb(165, 180, 252)` |

Those are the pre-sweep distinct taxonomy hues. Store taxonomy / semantic / commerce colors stay exceptions to the marketing-page “remove purple” rule.

## Unchanged

- Electric blue store page accent
- `digital_assessments` stays `text-blue-300` (`rgb(147, 197, 253)`)
- All other category pills (cyan, sky, green, orange, rose, red, amber, fuchsia, pink)
- Cards, rails, vendor marks, layout, and copy

## Guard

`categoryAccent.test.ts` now locks those three tokens so they cannot collapse onto one accent again.

[Co-Managed IT pill restored to violet-300](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstore_pill_comanaged_subscriptions.png)
[Co-Managed Onboarding pill restored to purple-300](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstore_pill_comanaged_onboarding.png)
[Templates and Compliance pill restored to indigo-300](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstore_pill_digital_templates.png)
[Security Assessments pill still blue-300](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstore_pill_assessments_blue_unchanged.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55eac13a-e87f-4a00-9c34-f63bb77c3080&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

