### PR TITLE
Add paper-ink magenta for text on paper

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -144,17 +144,19 @@ html {
   /*
    * Brand magenta only reaches ~3.6:1 on the dark ladder, which clears WCAG's
    * 3:1 bar for icons and large headings but fails the 4.5:1 bar for body-size
-   * text and inline links. This lighter tint holds the same hue and clears
+   * text and inline links. The lighter tint holds the same hue and clears
    * 4.5:1 on --de-bg, --de-surface, and --de-raised. Fills stay --de-magenta;
-   * this is for small text / links / icons on dark only.
+   * that lighter tint is for small text / links / icons on dark only.
    *
-   * Accent pink budget (Talos): only two magenta variants —
-   *   fill / CTA  → --de-magenta (+ --de-magenta-hover)
-   *   ink on dark → --de-magenta-ink
+   * Accent pink budget:
+   *   fill / CTA        → --de-magenta (+ --de-magenta-hover)  Do not darken.
+   *   ink on dark       → --de-magenta-ink
+   *   ink on paper      → --de-magenta-paper-ink
    * Do not invent #FF477F, #F9A8D4, pink-300, or fuchsia→rose CTA gradients
    * for marketing chrome. Store category pills keep their locked hues.
    */
   --de-magenta-ink: #F04C97;
+  --de-magenta-paper-ink: #A30E52;
   --de-magenta-hover: #e01874;
   --de-violet: #5B45E0;
 

--- a/client/src/lib/designTokens.contrast.test.ts
+++ b/client/src/lib/designTokens.contrast.test.ts
@@ -3,9 +3,9 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 /**
- * Talos asked to consolidate pink variants. DE keeps exactly two marketing
- * magenta tokens: fill (#D3126A) and ink (#F04C97). Space Grotesk + Inter +
- * Oxanium remain intentional brand roles — not “extra display fonts” to remove.
+ * Marketing magenta has three jobs, not one hue used everywhere:
+ * fill on any field, light ink on dark, dark ink on paper.
+ * Space Grotesk + Inter + Oxanium remain intentional brand roles.
  */
 describe("DE magenta accent tokens", () => {
   const css = readFileSync(
@@ -13,14 +13,34 @@ describe("DE magenta accent tokens", () => {
     "utf8"
   );
 
-  it("defines magenta fill, ink, and hover tokens", () => {
+  it("defines magenta fill, dark-ink, paper-ink, and hover tokens", () => {
     expect(css).toMatch(/--de-magenta:\s*#D3126A/i);
     expect(css).toMatch(/--de-magenta-ink:\s*#F04C97/i);
+    expect(css).toMatch(/--de-magenta-paper-ink:\s*#A30E52/i);
     expect(css).toMatch(/--de-magenta-hover:\s*#e01874/i);
   });
 
   it("keeps muted text floors high enough for body contrast", () => {
     expect(css).toMatch(/--de-muted:\s*rgba\(255,\s*255,\s*255,\s*0\.88\)/);
     expect(css).toMatch(/--de-muted-soft:\s*rgba\(255,\s*255,\s*255,\s*0\.78\)/);
+  });
+
+  it("gives paper-ink at least 4.5:1 on paper and white without darkening the CTA fill", () => {
+    const lin = (channel: number) => {
+      const c = channel / 255;
+      return c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+    };
+    const luminance = (hex: string) => {
+      const n = Number.parseInt(hex.slice(1), 16);
+      return 0.2126 * lin(n >> 16) + 0.7152 * lin((n >> 8) & 255) + 0.0722 * lin(n & 255);
+    };
+    const contrast = (a: string, b: string) => {
+      const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+      return (hi + 0.05) / (lo + 0.05);
+    };
+
+    expect(contrast("#A30E52", "#f7f5f2")).toBeGreaterThanOrEqual(4.5);
+    expect(contrast("#A30E52", "#ffffff")).toBeGreaterThanOrEqual(4.5);
+    expect(css).toMatch(/--de-magenta:\s*#D3126A/i);
   });
 });

--- a/client/src/pages/about/ComplianceCertifications.tsx
+++ b/client/src/pages/about/ComplianceCertifications.tsx
@@ -202,7 +202,7 @@ export default function ComplianceCertifications() {
                   asChild
                   size="lg"
                   variant="outline"
-                  className="border-de-hairline text-de-magenta hover:bg-de-paper-raised"
+                  className="border-de-hairline text-de-magenta-ink hover:bg-de-paper-raised hover:text-de-magenta-paper-ink"
                   data-testid="button-download-guide"
                 >
                   <Link href="/resources/security-checklist">
@@ -387,7 +387,7 @@ export default function ComplianceCertifications() {
                   asChild
                   size="lg"
                   variant="outline"
-                  className="border-de-hairline text-de-magenta hover:bg-de-paper-raised"
+                  className="border-de-hairline text-de-magenta-ink hover:bg-de-paper-raised hover:text-de-magenta-paper-ink"
                   data-testid="button-contact-us"
                 >
                   <Link href="/#contact">

--- a/client/src/pages/resources/SecurityUpdates.tsx
+++ b/client/src/pages/resources/SecurityUpdates.tsx
@@ -118,7 +118,7 @@ export default function SecurityUpdates() {
           <div className="rounded-2xl border border-de-hairline bg-de-raised p-6 mb-12">
             <div className="flex items-start gap-4">
               <div className="p-3 rounded-lg border border-de-hairline bg-[var(--de-bg)]">
-                <AlertCircle className="h-6 w-6 text-[#D3126A]" />
+                <AlertCircle className="h-6 w-6 text-de-magenta-ink" />
               </div>
               <div>
                 <h2 className="text-lg font-semibold text-white mb-2">Authoritative sources, scored for SMBs</h2>
@@ -151,7 +151,7 @@ export default function SecurityUpdates() {
                         {formatThreatDate(update.publishedAt, "short")}
                       </span>
                     </div>
-                    <p className="mb-2 text-sm font-semibold uppercase tracking-[0.14em] text-[#D3126A]">
+                    <p className="mb-2 text-sm font-semibold uppercase tracking-[0.14em] text-de-magenta-ink">
                       {update.kicker}
                     </p>
                     <CardTitle className="text-lg text-white line-clamp-2">{update.title}</CardTitle>
@@ -169,7 +169,7 @@ export default function SecurityUpdates() {
                         href={update.sourceUrl}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="text-[#D3126A] hover:text-[#f0187a] font-medium text-sm flex items-center gap-1 shrink-0"
+                        className="text-de-magenta-ink hover:text-de-magenta-ink/90 font-medium text-sm flex items-center gap-1 shrink-0"
                       >
                         Source
                         <ExternalLink className="h-3 w-3" />
@@ -225,7 +225,7 @@ export default function SecurityUpdates() {
                         href={update.sourceUrl}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="text-[#D3126A] hover:text-[#f0187a] font-medium text-sm inline-flex items-center gap-1"
+                        className="text-de-magenta-ink hover:text-de-magenta-ink/90 font-medium text-sm inline-flex items-center gap-1"
                       >
                         {update.sourceName}
                         <ExternalLink className="h-3 w-3" />

--- a/docs/BRAND-SWEEP-NEXT.md
+++ b/docs/BRAND-SWEEP-NEXT.md
@@ -20,7 +20,7 @@ The audit (`scripts/brand-audit.mjs`) is a regression detector, not a requiremen
 
 | Item | Where | Why it is parked | Next move |
 |------|--------|------------------|-----------|
-| Magenta as text on paper (~3.6:1) | `ComplianceCertifications.tsx` outline buttons; `SecurityUpdates.tsx` source / severity labels | `#D3126A` as a **fill** on dark is fine. As **text on paper** it fails AA. | Add a darker paper-ink token. Do not darken the CTA fill. |
+| Magenta as text on paper (~3.6:1) | `ComplianceCertifications.tsx` outline buttons; `SecurityUpdates.tsx` source / severity labels | Settled: `--de-magenta-paper-ink` `#A30E52` for magenta text on paper. Dark-field labels use `--de-magenta-ink`. CTA fill stays `#D3126A`. | Done on `cursor/paper-magenta-ink-3080`. |
 | Quote wizard 1.14:1 on slate-900 | `/quote-wizard` | Almost certainly a backdrop-measurement miss in the audit, not a purple regression. | Confirm in the browser, then fix `behind()` in `brand-audit.mjs` if the form is actually readable. |
 | `#5034ff` “Sign Up” | `/de-ecosystem-matrix-offical`, `/official-network-planner` | Official-tool pages, not the marketing/store system. | DE decides whether those tools join the accent system. |
 | Yellow star glyphs | `/thank-you-success-page` | Rating affordance, not brand chrome. | Leave unless DE wants a different rating treatment. |

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -53,6 +53,7 @@ module.exports = {
         de: {
           magenta: "var(--de-magenta)",
           "magenta-ink": "var(--de-magenta-ink)",
+          "magenta-paper-ink": "var(--de-magenta-paper-ink)",
           "magenta-hover": "var(--de-magenta-hover)",
           accent: "rgb(var(--de-accent-rgb) / <alpha-value>)",
           "accent-ink": "rgb(var(--de-accent-ink-rgb) / <alpha-value>)",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Paper-ink leftover from `docs/BRAND-SWEEP-NEXT.md` item 1.

`#D3126A` stays the CTA fill. It is not darkened.

What actually failed AA was magenta **text** on dark graphite, not magenta on paper. The leftover named it “paper-ink,” so this PR adds both roles:

- `--de-magenta` `#D3126A` — fill / CTA (unchanged)
- `--de-magenta-ink` `#F04C97` — readable magenta text on dark
- `--de-magenta-paper-ink` `#A30E52` — readable magenta text on paper (~7:1 on `#f7f5f2`)

Applied only where the leftover called out:

- `/compliance-certifications` outline buttons: ink on dark, paper-ink on hover paper fill
- `/security-updates` kickers, Source links, alert icon: ink on dark
- Primary “Get My Cyber Risk Assessment” stays `#D3126A`

Verified in browser:

- Compliance outline rest: `rgb(240, 76, 151)`
- Compliance outline hover: `rgb(163, 14, 82)` on `rgb(255, 255, 255)`
- Primary CTA fill: `rgb(211, 18, 106)`
- Security Updates kicker/Source: `rgb(240, 76, 151)`
- Contrast unit tests: 3 passed

Store / blog / taxonomy pills / Desk are untouched.

[paper_ink_magenta_walkthrough.mp4](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpaper_ink_magenta_walkthrough.mp4)
[Compliance 1440](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcompliance_hero_1440.png)
[Compliance outline hover](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcompliance_outline_hover.png)
[Security Updates 1440](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsecurity_updates_1440.png)
[Compliance 390](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcompliance_hero_390.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55eac13a-e87f-4a00-9c34-f63bb77c3080&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

