### PR TITLE
fix(quote): readable quote wizard on paper, not slate-on-black

### DIFF
--- a/client/src/pages/LeadQuoteWizard.tsx
+++ b/client/src/pages/LeadQuoteWizard.tsx
@@ -393,7 +393,7 @@ export default function LeadQuoteWizard() {
                 )}
               />
 
-              <div className="grid grid-cols-2 gap-4">
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                 <FormField
                   control={form.control}
                   name="firstName"

--- a/client/src/pages/LeadQuoteWizard.tsx
+++ b/client/src/pages/LeadQuoteWizard.tsx
@@ -41,6 +41,16 @@ const step3Schema = z.object({
 const fullFormSchema = step1Schema.merge(step2Schema).merge(step3Schema);
 type FormData = z.infer<typeof fullFormSchema>;
 
+/** Same paper-field recipe as the contact form — dark ink on white inputs. */
+const paperFieldClass =
+  "h-11 bg-white border-[var(--de-paper-hairline)] text-[#1A1228] placeholder:text-black/55 focus-visible:ring-2 focus-visible:ring-[#D3126A]/40 focus-visible:border-[#D3126A]";
+
+const paperSelectClass =
+  "h-11 bg-white border-[var(--de-paper-hairline)] text-[#1A1228] focus:ring-[#D3126A]/40";
+
+const paperOutlineClass =
+  "border-[var(--de-paper-hairline)] text-[#1A1228] hover:border-[#D3126A] hover:bg-de-paper hover:text-[#1A1228]";
+
 const getPlanMatch = (data: {
   seats: number;
   enterpriseToggle: boolean;
@@ -213,20 +223,21 @@ export default function LeadQuoteWizard() {
   };
 
   return (
-    <div className="w-full max-w-2xl mx-auto p-6">
+    <div className="min-h-screen bg-de-bg px-4 py-16 md:py-20">
+      <div className="de-paper-lift-lg mx-auto w-full max-w-2xl rounded-2xl p-6 text-[#1A1228] md:p-8">
       {/* Progress indicator */}
       <div className="flex items-center justify-between mb-8">
-        <div className="flex items-center gap-2">
+        <div className="flex flex-1 items-center gap-2">
           {[1, 2, 3].map((step) => (
             <div
               key={step}
               className={`h-2 flex-1 rounded-full transition-colors ${
-                step <= currentStep ? 'bg-de-accent' : 'bg-gray-200'
+                step <= currentStep ? 'bg-[#D3126A]' : 'bg-gray-200'
               }`}
             />
           ))}
         </div>
-        <span className="text-sm text-white/70 ml-4">Step {currentStep} of 3</span>
+        <span className="ml-4 text-sm text-black/55">Step {currentStep} of 3</span>
       </div>
 
       <Form {...form}>
@@ -235,8 +246,8 @@ export default function LeadQuoteWizard() {
           {currentStep === 1 && (
             <div className="space-y-6">
               <div>
-                <h2 className="text-2xl font-bold text-gray-900 mb-2">How many users?</h2>
-                <p className="text-white/70">Includes employees and shared devices.</p>
+                <h1 className="mb-2 text-2xl font-bold text-[#1A1228]">How many users?</h1>
+                <p className="text-black/55">Includes employees and shared devices.</p>
               </div>
 
               <FormField
@@ -244,7 +255,7 @@ export default function LeadQuoteWizard() {
                 name="seats"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>User Count: {field.value}</FormLabel>
+                    <FormLabel className="text-[#1A1228]">User Count: {field.value}</FormLabel>
                     <FormControl>
                       <input
                         type="range"
@@ -274,16 +285,16 @@ export default function LeadQuoteWizard() {
                         className="h-4 w-4 rounded border-gray-300"
                       />
                     </FormControl>
-                    <FormLabel className="!mt-0">More than 100 users? We'll tailor enterprise sizing.</FormLabel>
+                    <FormLabel className="!mt-0 text-[#1A1228]">More than 100 users? We'll tailor enterprise sizing.</FormLabel>
                   </FormItem>
                 )}
               />
 
               <div className="flex gap-3">
-                <Button variant="outline" type="button" onClick={() => setLocation('/')}>
+                <Button variant="outline" type="button" className={paperOutlineClass} onClick={() => setLocation('/')}>
                   Skip and talk to us
                 </Button>
-                <Button className="ml-auto" onClick={handleStep1Next}>
+                <Button variant="brand" type="button" className="ml-auto" onClick={handleStep1Next}>
                   Next <ArrowRight className="ml-2 h-4 w-4" />
                 </Button>
               </div>
@@ -294,8 +305,8 @@ export default function LeadQuoteWizard() {
           {currentStep === 2 && (
             <div className="space-y-6">
               <div>
-                <h2 className="text-2xl font-bold text-gray-900 mb-2">What do you need?</h2>
-                <p className="text-white/70">Help us understand your infrastructure needs.</p>
+                <h1 className="mb-2 text-2xl font-bold text-[#1A1228]">What do you need?</h1>
+                <p className="text-black/55">Help us understand your infrastructure needs.</p>
               </div>
 
               <FormField
@@ -303,10 +314,10 @@ export default function LeadQuoteWizard() {
                 name="connectivity"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Do you need secure connectivity and cloud storage?</FormLabel>
+                    <FormLabel className="text-[#1A1228]">Do you need secure connectivity and cloud storage?</FormLabel>
                     <Select value={field.value} onValueChange={field.onChange}>
                       <FormControl>
-                        <SelectTrigger>
+                        <SelectTrigger className={paperSelectClass}>
                           <SelectValue />
                         </SelectTrigger>
                       </FormControl>
@@ -326,10 +337,10 @@ export default function LeadQuoteWizard() {
                 name="devices"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Do you need desktops and laptops managed?</FormLabel>
+                    <FormLabel className="text-[#1A1228]">Do you need desktops and laptops managed?</FormLabel>
                     <Select value={field.value} onValueChange={field.onChange}>
                       <FormControl>
-                        <SelectTrigger>
+                        <SelectTrigger className={paperSelectClass}>
                           <SelectValue />
                         </SelectTrigger>
                       </FormControl>
@@ -345,10 +356,10 @@ export default function LeadQuoteWizard() {
               />
 
               <div className="flex gap-3">
-                <Button variant="outline" onClick={() => setCurrentStep(1)}>
+                <Button variant="outline" type="button" className={paperOutlineClass} onClick={() => setCurrentStep(1)}>
                   <ChevronLeft className="mr-2 h-4 w-4" /> Back
                 </Button>
-                <Button className="ml-auto" onClick={handleStep2Next}>
+                <Button variant="brand" type="button" className="ml-auto" onClick={handleStep2Next}>
                   See My Best Plan <ArrowRight className="ml-2 h-4 w-4" />
                 </Button>
               </div>
@@ -359,8 +370,8 @@ export default function LeadQuoteWizard() {
           {currentStep === 3 && (
             <div className="space-y-6">
               <div>
-                <h2 className="text-2xl font-bold text-gray-900 mb-2">Show Me The Best Plan!</h2>
-                <p className="text-white/70">We'll need a few details to confirm your perfect fit.</p>
+                <h1 className="mb-2 text-2xl font-bold text-[#1A1228]">Show Me The Best Plan!</h1>
+                <p className="text-black/55">We'll need a few details to confirm your perfect fit.</p>
               </div>
 
               <FormField
@@ -368,11 +379,12 @@ export default function LeadQuoteWizard() {
                 name="email"
                 render={({ field }) => (
                   <FormItem required>
-                    <FormLabel>Company Email *</FormLabel>
+                    <FormLabel className="text-[#1A1228]">Company Email *</FormLabel>
                     <FormControl>
                       <Input
                         type="email"
                         placeholder="your.name@company.com"
+                        className={paperFieldClass}
                         {...field}
                       />
                     </FormControl>
@@ -387,9 +399,9 @@ export default function LeadQuoteWizard() {
                   name="firstName"
                   render={({ field }) => (
                     <FormItem required>
-                      <FormLabel>First Name *</FormLabel>
+                      <FormLabel className="text-[#1A1228]">First Name *</FormLabel>
                       <FormControl>
-                        <Input placeholder="First name" {...field} />
+                        <Input placeholder="First name" className={paperFieldClass} {...field} />
                       </FormControl>
                       <FormMessage />
                     </FormItem>
@@ -401,9 +413,9 @@ export default function LeadQuoteWizard() {
                   name="lastName"
                   render={({ field }) => (
                     <FormItem required>
-                      <FormLabel>Last Name *</FormLabel>
+                      <FormLabel className="text-[#1A1228]">Last Name *</FormLabel>
                       <FormControl>
-                        <Input placeholder="Last name" {...field} />
+                        <Input placeholder="Last name" className={paperFieldClass} {...field} />
                       </FormControl>
                       <FormMessage />
                     </FormItem>
@@ -416,9 +428,9 @@ export default function LeadQuoteWizard() {
                 name="company"
                 render={({ field }) => (
                   <FormItem required>
-                    <FormLabel>Company Name *</FormLabel>
+                    <FormLabel className="text-[#1A1228]">Company Name *</FormLabel>
                     <FormControl>
-                      <Input placeholder="Your company" {...field} />
+                      <Input placeholder="Your company" className={paperFieldClass} {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -438,17 +450,17 @@ export default function LeadQuoteWizard() {
                         className="h-4 w-4 rounded border-gray-300"
                       />
                     </FormControl>
-                    <FormLabel className="!mt-0 text-sm">I agree to be contacted about my plan match</FormLabel>
+                    <FormLabel className="!mt-0 text-sm text-[#1A1228]">I agree to be contacted about my plan match</FormLabel>
                     <FormMessage />
                   </FormItem>
                 )}
               />
 
               <div className="flex gap-3">
-                <Button variant="outline" onClick={() => setCurrentStep(2)}>
+                <Button variant="outline" type="button" className={paperOutlineClass} onClick={() => setCurrentStep(2)}>
                   <ChevronLeft className="mr-2 h-4 w-4" /> Back
                 </Button>
-                <Button type="submit" className="ml-auto" disabled={isSubmitting}>
+                <Button type="submit" variant="brand" className="ml-auto" disabled={isSubmitting}>
                   {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                   Get My Instant Match
                 </Button>
@@ -457,6 +469,7 @@ export default function LeadQuoteWizard() {
           )}
         </form>
       </Form>
+      </div>
     </div>
   );
 }

--- a/client/src/pages/QuoteConfirmation.tsx
+++ b/client/src/pages/QuoteConfirmation.tsx
@@ -48,7 +48,7 @@ export default function QuoteConfirmation() {
           <div className="flex justify-center mb-6">
             <CheckCircle className="h-16 w-16 text-green-500" />
           </div>
-          <h1 className="text-4xl font-bold text-gray-900 mb-4">Perfect! We've Got Your Match</h1>
+          <h1 className="mb-4 text-4xl font-bold text-white">Perfect! We've Got Your Match</h1>
           <p className="text-lg text-white/70 mb-2">Hi {data.firstName},</p>
           <p className="text-lg text-white/70">We've analyzed your needs and found the ideal plan for {data.company}.</p>
         </div>
@@ -57,11 +57,11 @@ export default function QuoteConfirmation() {
         <Card className="mb-12 p-8 border-2 border-de-hairline bg-white shadow-lg">
           <div className="mb-6">
             <h2 className="text-3xl font-bold text-de-accent mb-2">{data.plan}</h2>
-            <p className="text-white/70">Your personalized recommendation</p>
+            <p className="text-black/55">Your personalized recommendation</p>
           </div>
 
           <div className="space-y-4 mb-8">
-            <p className="text-sm text-white/70 font-semibold uppercase">Why this fits you:</p>
+            <p className="text-sm font-semibold uppercase text-black/55">Why this fits you:</p>
             {data.reasons.map((reason, idx) => (
               <div key={idx} className="flex items-start gap-3">
                 <div className="w-6 h-6 rounded-full bg-de-paper-raised flex items-center justify-center flex-shrink-0 mt-0.5">
@@ -73,7 +73,7 @@ export default function QuoteConfirmation() {
           </div>
 
           <div className="border-t pt-6">
-            <p className="text-sm text-white/70 mb-4">
+            <p className="mb-4 text-sm text-black/55">
               Next steps: Our team will review your profile and reach out within 24 hours with:
             </p>
             <ul className="space-y-2 text-gray-700">
@@ -96,7 +96,7 @@ export default function QuoteConfirmation() {
             <Calendar className="mr-2 h-5 w-5" />
             Schedule 15-Minute Fit Call
           </Button>
-          <Button size="lg" variant="outline" className="h-12 border-de-hairline text-de-accent hover:bg-de-paper-raised hover:text-de-accent" data-testid="button-email-details">
+          <Button size="lg" variant="outline" className="h-12 border-de-hairline text-de-magenta-ink hover:bg-de-paper-raised hover:text-[#1A1228]" data-testid="button-email-details">
             <Mail className="mr-2 h-5 w-5" />
             Email Me These Details
           </Button>
@@ -105,15 +105,15 @@ export default function QuoteConfirmation() {
         {/* Footer CTA */}
         <div className="text-center">
           <p className="text-white/70 mb-4">Questions before we reach out?</p>
-          <Button variant="outline" className="border-de-hairline text-de-accent hover:bg-de-paper-raised hover:text-de-accent" onClick={() => setLocation('/#contact')}>
+          <Button variant="outline" className="border-de-hairline text-de-magenta-ink hover:bg-de-paper-raised hover:text-[#1A1228]" onClick={() => setLocation('/#contact')}>
             Contact Us Now <ArrowRight className="ml-2 h-4 w-4" />
           </Button>
         </div>
 
         {/* Trust Message */}
         <div className="mt-12 p-6 bg-white rounded-lg border border-gray-200">
-          <p className="text-center text-sm text-white/70">
-            <span className="font-semibold">We respect your privacy:</span> Your information is secure and you'll only hear from our team about your specific plan match. <a href="/legal/privacy-policy" className="text-de-accent hover:underline">View our privacy policy</a>.
+          <p className="text-center text-sm text-black/55">
+            <span className="font-semibold text-[#1A1228]">We respect your privacy:</span> Your information is secure and you'll only hear from our team about your specific plan match. <a href="/legal/privacy-policy" className="font-medium text-[#1A1228] underline hover:no-underline">View our privacy policy</a>.
           </p>
         </div>
       </div>

--- a/docs/BRAND-SWEEP-NEXT.md
+++ b/docs/BRAND-SWEEP-NEXT.md
@@ -21,7 +21,7 @@ The audit (`scripts/brand-audit.mjs`) is a regression detector, not a requiremen
 | Item | Where | Why it is parked | Next move |
 |------|--------|------------------|-----------|
 | Magenta as text on paper (~3.6:1) | `ComplianceCertifications.tsx` outline buttons; `SecurityUpdates.tsx` source / severity labels | `#D3126A` as a **fill** on dark is fine. As **text on paper** it fails AA. | Add a darker paper-ink token. Do not darken the CTA fill. |
-| Quote wizard 1.14:1 on slate-900 | `/quote-wizard` | Almost certainly a backdrop-measurement miss in the audit, not a purple regression. | Confirm in the browser, then fix `behind()` in `brand-audit.mjs` if the form is actually readable. |
+| Quote wizard 1.14:1 on slate-900 | `/quote-wizard` | Not an audit miss. Labels, headings, and outline buttons were `slate-900` / `gray-900` on `--de-bg` `#050312` (~1.14:1). The form was a light-theme recipe dropped on the dark canvas. | Settled on `cursor/quote-wizard-contrast-3080`: existing fields sit on `de-paper-lift-lg` (same recipe as contact). `behind()` left alone. |
 | `#5034ff` “Sign Up” | `/de-ecosystem-matrix-offical`, `/official-network-planner` | Official-tool pages, not the marketing/store system. | DE decides whether those tools join the accent system. |
 | Yellow star glyphs | `/thank-you-success-page` | Rating affordance, not brand chrome. | Leave unless DE wants a different rating treatment. |
 | Legacy unused purple | `Homepage.tsx` + `HeroSection`, `PricingSection`, `ServicesSection`, `BlogSection`, `FooterSection`, `CallToActionSection`, `ContactSection` | Not reachable. | Delete only if DE approves removing dead code; do not restyle in place. |
@@ -30,6 +30,5 @@ The audit (`scripts/brand-audit.mjs`) is a regression detector, not a requiremen
 ## Optional later
 
 1. Paper-ink token for magenta-on-white text.
-2. Quote-wizard contrast investigation (audit vs rendered).
-3. Official-tool hue decision (`#5034ff` vs electric vs magenta).
-4. Portal UI pass — only if requested.
+2. Official-tool hue decision (`#5034ff` vs electric vs magenta).
+3. Portal UI pass — only if requested.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Brand-audit leftover #2 from `docs/BRAND-SWEEP-NEXT.md`.

The 1.14:1 report on `/quote-wizard` was **not** a `behind()` measurement miss. Browser measurement before the fix:

- Heading / labels / “Skip and talk to us”: `rgb(15, 23, 42)` (slate-900)
- Canvas: `rgb(5, 3, 18)` (`--de-bg`)
- Ratio ~1.14:1 — light-theme form dropped on the dark marketing canvas

`behind()` is left alone. The existing form now sits on the same `de-paper-lift-lg` paper card as the contact form.

After:

- Heading / labels / Skip: `rgb(26, 18, 40)` on `rgb(255, 255, 255)` — **18.09:1**
- Next CTA: white on `rgb(211, 18, 106)` (`#D3126A`) — **5.17:1**
- `node scripts/brand-audit.mjs --routes /quote-wizard` → **1/1 clean**, contrast 0

Also fixed the confirmation page in the same flow: white-card copy that was `text-white/70` (invisible on white) and the dark-field H1 that was `text-gray-900`. Name fields stack on small screens.

Preserved: all fields, validation, analytics, plan-match logic, copy, CTAs. Store / blog / taxonomy pills / Desk untouched. No `//login`.

[Quote wizard before — dark-on-dark](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fquote_wizard_1440_before.png)
[Quote wizard after — paper card 1440](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fquote_wizard_1440_after.png)
[Step 2](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fquote_wizard_step2_1440.png)
[Step 3](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fquote_wizard_step3_1440.png)
[390](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fquote_wizard_390_after.png)
[quote_wizard_contrast_walkthrough.mp4](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fquote_wizard_contrast_walkthrough.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55eac13a-e87f-4a00-9c34-f63bb77c3080&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

