### PR TITLE
Give the store first claim on trackpad Back/Forward swipes

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -16,6 +16,7 @@ import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { PageLoadingSkeleton } from "@/components/LoadingSkeleton";
 import { AnnouncerProvider } from "@/components/AccessibleAnnouncer";
 import { useGlobalShortcuts } from "@/hooks/useKeyboardShortcuts";
+import { useStoreChromeGestures } from "@/hooks/useStoreChromeGestures";
 import { CartProvider } from "@/contexts/CartContext";
 import { BookingProvider } from "@/contexts/BookingContext";
 import { BookingModal } from "@/components/BookingModal";
@@ -903,6 +904,7 @@ function accentFor(location: string): string | undefined {
 function AppContent() {
   useGlobalShortcuts();
   const [location] = useLocation();
+  useStoreChromeGestures(location);
   const isPortal = location.startsWith("/portal");
   const isHome = location === "/";
   const accent = isPortal ? undefined : accentFor(location);

--- a/client/src/components/store/MerchandisingRails.tsx
+++ b/client/src/components/store/MerchandisingRails.tsx
@@ -85,7 +85,7 @@ function RailScroller({
       </div>
       <div
         ref={scrollerRef}
-        className="flex gap-5 overflow-x-auto pb-2 scrollbar-thin"
+        className="de-store-h-rail flex gap-5 pb-2 scrollbar-thin"
         style={{ scrollSnapType: "x mandatory" }}
       >
         {products.map((product) => {

--- a/client/src/hooks/useStoreChromeGestures.ts
+++ b/client/src/hooks/useStoreChromeGestures.ts
@@ -1,0 +1,95 @@
+import { useEffect, useRef } from "react";
+import {
+  STORE_GESTURE_LOCK_CLASS,
+  findHorizontalScroller,
+  getNavigationApi,
+  isHorizontalDominantDelta,
+  isStorePath,
+  isTraverseNavigateEvent,
+  shouldInterceptTraverse,
+} from "@/lib/storeChromeGestures";
+
+/**
+ * While the visitor is in the store, claim horizontal trackpad / touch
+ * swipes so Chrome and Safari do not fire Back / Forward. Rails keep
+ * GPU-composited scrolling; the real back button still leaves the store.
+ */
+export function useStoreChromeGestures(location: string) {
+  const lastHorizontalAt = useRef(0);
+  const touchStart = useRef<{ x: number; y: number } | null>(null);
+  const active = isStorePath(location);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.toggle(STORE_GESTURE_LOCK_CLASS, active);
+    if (!active) {
+      return () => root.classList.remove(STORE_GESTURE_LOCK_CLASS);
+    }
+
+    const markHorizontal = () => {
+      lastHorizontalAt.current = performance.now();
+    };
+
+    const onWheel = (event: WheelEvent) => {
+      if (event.ctrlKey || event.metaKey) return;
+      if (!isHorizontalDominantDelta(event.deltaX, event.deltaY)) return;
+      markHorizontal();
+      event.preventDefault();
+      const scroller = findHorizontalScroller(event.target);
+      if (scroller) scroller.scrollLeft += event.deltaX;
+    };
+
+    const onTouchStart = (event: TouchEvent) => {
+      const touch = event.touches[0];
+      if (!touch) return;
+      touchStart.current = { x: touch.clientX, y: touch.clientY };
+    };
+
+    const onTouchMove = (event: TouchEvent) => {
+      const start = touchStart.current;
+      const touch = event.touches[0];
+      if (!start || !touch) return;
+      const deltaX = touch.clientX - start.x;
+      const deltaY = touch.clientY - start.y;
+      if (!isHorizontalDominantDelta(deltaX, deltaY, 8)) return;
+      markHorizontal();
+      const scroller = findHorizontalScroller(event.target);
+      if (scroller) {
+        event.preventDefault();
+        scroller.scrollLeft -= deltaX;
+        touchStart.current = { x: touch.clientX, y: touch.clientY };
+        return;
+      }
+      event.preventDefault();
+    };
+
+    const onTouchEnd = () => {
+      touchStart.current = null;
+    };
+
+    const onNavigate = (event: Event) => {
+      if (!isTraverseNavigateEvent(event)) return;
+      if (!shouldInterceptTraverse(performance.now(), lastHorizontalAt.current)) return;
+      event.preventDefault();
+    };
+
+    window.addEventListener("wheel", onWheel, { capture: true, passive: false });
+    window.addEventListener("touchstart", onTouchStart, { capture: true, passive: true });
+    window.addEventListener("touchmove", onTouchMove, { capture: true, passive: false });
+    window.addEventListener("touchend", onTouchEnd, { capture: true, passive: true });
+    window.addEventListener("touchcancel", onTouchEnd, { capture: true, passive: true });
+
+    const navigation = getNavigationApi();
+    navigation?.addEventListener("navigate", onNavigate);
+
+    return () => {
+      root.classList.remove(STORE_GESTURE_LOCK_CLASS);
+      window.removeEventListener("wheel", onWheel, true);
+      window.removeEventListener("touchstart", onTouchStart, true);
+      window.removeEventListener("touchmove", onTouchMove, true);
+      window.removeEventListener("touchend", onTouchEnd, true);
+      window.removeEventListener("touchcancel", onTouchEnd, true);
+      navigation?.removeEventListener("navigate", onNavigate);
+    };
+  }, [active]);
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -22,6 +22,28 @@ html {
 }
 
 /*
+ * Store owns horizontal trackpad / swipe so Chrome and Safari do not
+ * treat it as Back / Forward. Scoped to /store* via .de-store-gesture-lock.
+ */
+html.de-store-gesture-lock,
+html.de-store-gesture-lock body {
+  overscroll-behavior-x: none;
+  overflow-x: clip;
+  touch-action: pan-y pinch-zoom;
+}
+
+.de-store-h-rail {
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  overscroll-behavior-y: auto;
+  touch-action: pan-x pan-y;
+  -webkit-overflow-scrolling: touch;
+  transform: translateZ(0);
+  backface-visibility: hidden;
+  will-change: scroll-position;
+}
+
+/*
  * Large-display type scale.
  * 16px is the laptop/monitor default. TVs and 4K walls need a real step
  * up so the first viewport reads from the couch — not a 1px bump.

--- a/client/src/lib/storeChromeGestures.test.ts
+++ b/client/src/lib/storeChromeGestures.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  isHorizontalDominantDelta,
+  isStorePath,
+  isTraverseNavigateEvent,
+  shouldInterceptTraverse,
+} from "./storeChromeGestures";
+
+describe("store chrome gestures", () => {
+  it("locks only store routes", () => {
+    expect(isStorePath("/store")).toBe(true);
+    expect(isStorePath("/store/managed")).toBe(true);
+    expect(isStorePath("/store/product/de-proactive-office")).toBe(true);
+    expect(isStorePath("/")).toBe(false);
+    expect(isStorePath("/solutions/managed-it-support")).toBe(false);
+    expect(isStorePath("/storage")).toBe(false);
+  });
+
+  it("treats trackpad swipe as horizontal only when X dominates", () => {
+    expect(isHorizontalDominantDelta(40, 8)).toBe(true);
+    expect(isHorizontalDominantDelta(-28, 4)).toBe(true);
+    expect(isHorizontalDominantDelta(2, 24)).toBe(false);
+    expect(isHorizontalDominantDelta(0, 12)).toBe(false);
+    expect(isHorizontalDominantDelta(0.4, 0.1)).toBe(false);
+  });
+
+  it("intercepts history traverse only right after a horizontal gesture", () => {
+    expect(shouldInterceptTraverse(1000, 800)).toBe(true);
+    expect(shouldInterceptTraverse(1000, 549)).toBe(false);
+    expect(shouldInterceptTraverse(1000, 0)).toBe(false);
+  });
+
+  it("recognizes Navigation API traverse events", () => {
+    expect(isTraverseNavigateEvent(new Event("navigate"))).toBe(false);
+    const traverse = new Event("navigate") as Event & { navigationType: string };
+    Object.assign(traverse, { navigationType: "traverse" });
+    expect(isTraverseNavigateEvent(traverse)).toBe(true);
+  });
+});

--- a/client/src/lib/storeChromeGestures.ts
+++ b/client/src/lib/storeChromeGestures.ts
@@ -1,0 +1,57 @@
+/**
+ * Store takes first claim on horizontal trackpad / touch swipes so the
+ * browser does not treat them as Back / Forward. Explicit back-button
+ * and keyboard history still work — we only intercept a traverse that
+ * arrives immediately after a horizontal gesture.
+ */
+
+export const STORE_GESTURE_LOCK_CLASS = "de-store-gesture-lock";
+export const STORE_HORIZONTAL_RAIL_CLASS = "de-store-h-rail";
+export const STORE_TRAVERSE_WINDOW_MS = 450;
+
+export function isStorePath(path: string): boolean {
+  return path === "/store" || path.startsWith("/store/");
+}
+
+export function isHorizontalDominantDelta(deltaX: number, deltaY: number, min = 1): boolean {
+  const absX = Math.abs(deltaX);
+  const absY = Math.abs(deltaY);
+  return absX > absY && absX >= min;
+}
+
+export function shouldInterceptTraverse(
+  nowMs: number,
+  lastHorizontalMs: number,
+  windowMs = STORE_TRAVERSE_WINDOW_MS,
+): boolean {
+  return lastHorizontalMs > 0 && nowMs - lastHorizontalMs < windowMs;
+}
+
+export function findHorizontalScroller(start: EventTarget | null): HTMLElement | null {
+  let node: Element | null = start instanceof Element ? start : null;
+  while (node && node !== document.documentElement && node !== document.body) {
+    if (node instanceof HTMLElement) {
+      const overflowX = getComputedStyle(node).overflowX;
+      const canScrollX =
+        (overflowX === "auto" || overflowX === "scroll" || overflowX === "overlay") &&
+        node.scrollWidth > node.clientWidth + 1;
+      if (canScrollX) return node;
+    }
+    node = node.parentElement;
+  }
+  return null;
+}
+
+type NavigationLike = {
+  addEventListener(type: "navigate", listener: (event: Event) => void): void;
+  removeEventListener(type: "navigate", listener: (event: Event) => void): void;
+};
+
+export function getNavigationApi(): NavigationLike | undefined {
+  if (typeof window === "undefined") return undefined;
+  return (window as Window & { navigation?: NavigationLike }).navigation;
+}
+
+export function isTraverseNavigateEvent(event: Event): boolean {
+  return "navigationType" in event && (event as { navigationType?: string }).navigationType === "traverse";
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
On `/store` routes, a two-finger horizontal trackpad swipe was leaving the catalog because Chrome and Safari treat that gesture as browser Back / Forward.

The store now owns that gesture:

- `overscroll-behavior-x: none` and `overflow-x: clip` on the document while you are in the store
- Non-passive wheel / touch capture: horizontal deltas scroll merchandising rails (GPU-composited) instead of navigating history
- Chromium Navigation API: a `traverse` that arrives immediately after a horizontal gesture is cancelled
- The real Back button and keyboard history still leave the store

Rails use `.de-store-h-rail` (`translateZ(0)`, `contain` overscroll) so catalog browsing stays on the compositor.

Homepage and other routes are unchanged.

Verified locally: lock class + `overscroll-behavior-x: none` on `/store`; horizontal `wheel` is `preventDefault`’d and the path stays `/store`; homepage lock is off (`overscroll-behavior-x: auto`).

[Store merchandising rails with gesture lock](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstore-rails-gesture-lock-1440.png)
[store-rails-scroll-stays-on-store.mp4](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstore-rails-scroll-stays-on-store.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55eac13a-e87f-4a00-9c34-f63bb77c3080&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

