### PR TITLE
Store polish: atmosphere, quieter chrome, mobile CTA fit

### DIFF
--- a/client/src/components/store/MerchandisingRails.tsx
+++ b/client/src/components/store/MerchandisingRails.tsx
@@ -83,6 +83,15 @@ function RailScroller({
           </Button>
         </div>
       </div>
+      <div className="relative">
+        <div
+          className="pointer-events-none absolute inset-y-0 left-0 z-10 w-8 bg-gradient-to-r from-[#0a0a0a] to-transparent"
+          aria-hidden="true"
+        />
+        <div
+          className="pointer-events-none absolute inset-y-0 right-0 z-10 w-8 bg-gradient-to-l from-[#0a0a0a] to-transparent"
+          aria-hidden="true"
+        />
       <div
         ref={scrollerRef}
         className="de-store-h-rail flex gap-5 pb-2 scrollbar-thin"
@@ -110,6 +119,7 @@ function RailScroller({
             </div>
           );
         })}
+      </div>
       </div>
     </div>
   );

--- a/client/src/components/store/MerchandisingRails.tsx
+++ b/client/src/components/store/MerchandisingRails.tsx
@@ -85,11 +85,11 @@ function RailScroller({
       </div>
       <div className="relative">
         <div
-          className="pointer-events-none absolute inset-y-0 left-0 z-10 w-8 bg-gradient-to-r from-[#0a0a0a] to-transparent"
+          className="pointer-events-none absolute inset-y-0 left-0 z-10 w-6 bg-gradient-to-r from-[#0a0a0a] to-transparent sm:w-10"
           aria-hidden="true"
         />
         <div
-          className="pointer-events-none absolute inset-y-0 right-0 z-10 w-8 bg-gradient-to-l from-[#0a0a0a] to-transparent"
+          className="pointer-events-none absolute inset-y-0 right-0 z-10 w-6 bg-gradient-to-l from-[#0a0a0a] to-transparent sm:w-10"
           aria-hidden="true"
         />
       <div

--- a/client/src/components/store/ShopByOutcome.tsx
+++ b/client/src/components/store/ShopByOutcome.tsx
@@ -26,7 +26,7 @@ export function ShopByOutcome({ selected, onSelect }: ShopByOutcomeProps) {
               key={outcome.id}
               type="button"
               onClick={() => onSelect(isActive ? null : outcome.id)}
-              className={`group rounded-xl border p-5 md:p-6 text-left transition-all duration-200 ${
+              className={`group rounded-xl border p-3.5 text-left transition-all duration-200 sm:p-5 md:p-6 ${
                 isActive
                   ? "border-[#D3126A]/55 bg-[#D3126A]/10 shadow-[0_0_24px_rgba(211,18,106,0.12)]"
                   : "border-white/10 bg-[#121212] hover:border-white/20 hover:bg-[#161616]"

--- a/client/src/components/store/ShopByOutcome.tsx
+++ b/client/src/components/store/ShopByOutcome.tsx
@@ -42,7 +42,7 @@ export function ShopByOutcome({ selected, onSelect }: ShopByOutcomeProps) {
                 <img
                   src={outcomeCardUrl(outcome.id)}
                   alt=""
-                  className="h-14 w-full object-cover"
+                  className="h-24 w-full object-cover object-center sm:h-28"
                   loading="lazy"
                   decoding="async"
                 />

--- a/client/src/components/store/StoreAssessmentPanel.tsx
+++ b/client/src/components/store/StoreAssessmentPanel.tsx
@@ -2,6 +2,7 @@ import { Link } from "wouter";
 import { ArrowRight, Calendar, ClipboardList, MessageCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { openMspAdvisor } from "@/lib/openMspAdvisor";
+import { CTA } from "@/lib/ctaCopy";
 
 interface StoreAssessmentPanelProps {
   variant?: "sticky" | "inline";
@@ -32,12 +33,13 @@ export function StoreAssessmentPanel({
         </p>
         <div className="mt-4 flex flex-col gap-2">
           <Button asChild
-              className="h-10 w-full bg-de-accent text-white hover:bg-[#6548ff]"
+              variant="brand"
+              className="h-10 w-full"
               data-testid="button-assessment-book"
             >
                   <a href="/book">
                     <Calendar className="mr-2 h-4 w-4" />
-              Book assessment
+              {CTA.primaryShort}
                   </a>
                 </Button>
           {onFilterAssessments && (

--- a/client/src/components/store/StoreClientBar.tsx
+++ b/client/src/components/store/StoreClientBar.tsx
@@ -1,0 +1,57 @@
+import { LogOut, User } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { CartButton } from "@/components/store/CartButton";
+import { useStoreAuth } from "@/hooks/useStoreAuth";
+
+/**
+ * Quiet store utility row. Electric stays the store accent;
+ * the button is outline so it does not compete with hero CTAs.
+ */
+export function StoreClientBar() {
+  const { isLoggedIn, user, clientType, logout, loginRedirect } = useStoreAuth();
+
+  return (
+    <div className="mb-6 flex items-center justify-between gap-3">
+      {isLoggedIn && user ? (
+        <div className="flex min-w-0 items-center gap-2 sm:gap-3">
+          <div className="flex min-w-0 items-center gap-2 rounded-lg border border-de-accent/20 bg-de-accent/10 px-3 py-2">
+            <User className="h-4 w-4 shrink-0 text-de-accent-ink" />
+            <span className="truncate text-sm text-white" data-testid="text-user-greeting">
+              Welcome,{" "}
+              <span className="font-semibold text-de-accent-ink">{user.fullName || user.username}</span>
+            </span>
+            {clientType !== "public" && (
+              <span className="ml-1 hidden rounded-full bg-de-accent/20 px-2 py-0.5 text-xs font-medium text-de-accent-ink sm:inline">
+                {clientType === "managed" ? "Managed Client" : "Co-Managed Client"}
+              </span>
+            )}
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={logout}
+            className="shrink-0 text-white/60 hover:bg-de-accent/10 hover:text-white"
+            data-testid="button-store-logout"
+          >
+            <LogOut className="mr-1 h-4 w-4" />
+            <span className="hidden sm:inline">Logout</span>
+          </Button>
+        </div>
+      ) : (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={loginRedirect}
+          className="h-11 border-de-accent/40 bg-transparent px-3 text-sm text-de-accent-ink hover:border-de-accent hover:bg-de-accent/10 sm:px-4 sm:text-base"
+          data-testid="button-store-login"
+        >
+          <User className="mr-2 h-4 w-4" />
+          <span className="sm:hidden">Client login</span>
+          <span className="hidden sm:inline">Login for Client Pricing</span>
+        </Button>
+      )}
+      <CartButton />
+    </div>
+  );
+}

--- a/client/src/components/store/StorePageAtmosphere.tsx
+++ b/client/src/components/store/StorePageAtmosphere.tsx
@@ -1,0 +1,46 @@
+import { useRef } from "react";
+import { motion, useReducedMotion, useScroll, useTransform } from "framer-motion";
+import atmosphere from "@assets/de-section-atmosphere.png";
+
+/**
+ * Store field depth — electric lighting only (store accent lock).
+ * Parallax is a few percent of travel and stops for reduced motion.
+ */
+export function StorePageAtmosphere() {
+  const ref = useRef<HTMLDivElement>(null);
+  const prefersReducedMotion = useReducedMotion();
+  const { scrollYProgress } = useScroll({
+    target: ref,
+    offset: ["start start", "end start"],
+  });
+  const y = useTransform(scrollYProgress, [0, 1], prefersReducedMotion ? ["0%", "0%"] : ["0%", "9%"]);
+
+  return (
+    <div
+      ref={ref}
+      className="pointer-events-none absolute inset-0 overflow-hidden"
+      aria-hidden="true"
+    >
+      <motion.img
+        src={atmosphere}
+        alt=""
+        className="absolute inset-x-0 top-0 h-[70vh] min-h-[28rem] w-full object-cover object-center"
+        style={{ y, opacity: 0.32 }}
+      />
+      <div
+        className="absolute inset-0"
+        style={{
+          background:
+            "linear-gradient(180deg, rgba(10,10,10,0.35) 0%, rgba(10,10,10,0.72) 42%, #0a0a0a 78%), linear-gradient(90deg, rgba(10,10,10,0.55) 0%, rgba(10,10,10,0.12) 48%, rgba(10,10,10,0.45) 100%)",
+        }}
+      />
+      <div
+        className="absolute -right-[12%] top-[8%] h-[28rem] w-[28rem]"
+        style={{
+          background:
+            "radial-gradient(circle at 60% 40%, rgba(29, 111, 242, 0.16) 0%, rgba(29, 111, 242, 0.04) 42%, transparent 68%)",
+        }}
+      />
+    </div>
+  );
+}

--- a/client/src/components/store/StorePageAtmosphere.tsx
+++ b/client/src/components/store/StorePageAtmosphere.tsx
@@ -13,7 +13,16 @@ export function StorePageAtmosphere() {
     target: ref,
     offset: ["start start", "end start"],
   });
-  const y = useTransform(scrollYProgress, [0, 1], prefersReducedMotion ? ["0%", "0%"] : ["0%", "9%"]);
+  const y = useTransform(
+    scrollYProgress,
+    [0, 1],
+    prefersReducedMotion ? ["0%", "0%"] : ["0%", "8%"],
+  );
+  const bloomY = useTransform(
+    scrollYProgress,
+    [0, 1],
+    prefersReducedMotion ? ["0%", "0%"] : ["0%", "14%"],
+  );
 
   return (
     <div
@@ -24,21 +33,22 @@ export function StorePageAtmosphere() {
       <motion.img
         src={atmosphere}
         alt=""
-        className="absolute inset-x-0 top-0 h-[70vh] min-h-[28rem] w-full object-cover object-center"
-        style={{ y, opacity: 0.32 }}
+        className="absolute inset-x-0 top-0 h-[78vh] min-h-[32rem] w-full object-cover object-center"
+        style={{ y, opacity: 0.44 }}
       />
       <div
         className="absolute inset-0"
         style={{
           background:
-            "linear-gradient(180deg, rgba(10,10,10,0.35) 0%, rgba(10,10,10,0.72) 42%, #0a0a0a 78%), linear-gradient(90deg, rgba(10,10,10,0.55) 0%, rgba(10,10,10,0.12) 48%, rgba(10,10,10,0.45) 100%)",
+            "linear-gradient(180deg, rgba(10,10,10,0.18) 0%, rgba(10,10,10,0.52) 46%, #0a0a0a 84%), linear-gradient(90deg, rgba(10,10,10,0.38) 0%, rgba(10,10,10,0.08) 50%, rgba(10,10,10,0.34) 100%)",
         }}
       />
-      <div
-        className="absolute -right-[12%] top-[8%] h-[28rem] w-[28rem]"
+      <motion.div
+        className="absolute -right-[12%] top-[6%] h-[30rem] w-[30rem]"
         style={{
+          y: bloomY,
           background:
-            "radial-gradient(circle at 60% 40%, rgba(29, 111, 242, 0.16) 0%, rgba(29, 111, 242, 0.04) 42%, transparent 68%)",
+            "radial-gradient(circle at 60% 40%, rgba(29, 111, 242, 0.2) 0%, rgba(29, 111, 242, 0.05) 42%, transparent 68%)",
         }}
       />
     </div>

--- a/client/src/pages/store/CoManagedStore.tsx
+++ b/client/src/pages/store/CoManagedStore.tsx
@@ -586,9 +586,9 @@ const CoManagedStore = () => {
               Shop by outcome, build a recommended stack with Ask Digerati, then buy from the live
               catalog when you know what you need.
             </p>
-            <div className="mt-6 flex flex-wrap gap-3">
+            <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
               <Button
-                className="h-12 bg-de-accent px-6 text-base text-white hover:bg-[#6548ff]"
+                className="h-12 w-full bg-de-accent px-6 text-base text-white hover:bg-[#6548ff] sm:w-auto"
                 onClick={() => setGuidedOpen(true)}
                 data-testid="button-build-solution"
               >
@@ -597,7 +597,7 @@ const CoManagedStore = () => {
               </Button>
               <Button
                 variant="outline"
-                className="h-12 border-white/20 bg-transparent px-6 text-base text-white hover:bg-white/5"
+                className="h-12 w-full border-white/20 bg-transparent px-6 text-base text-white hover:bg-white/5 sm:w-auto"
                 onClick={() => openMspAdvisor({ context: "store" })}
                 data-testid="button-ask-digerati"
               >
@@ -606,7 +606,7 @@ const CoManagedStore = () => {
               </Button>
               <Button
                 variant="ghost"
-                className="h-12 text-base text-white/70 hover:bg-white/5 hover:text-white"
+                className="h-12 w-full text-base text-white/70 hover:bg-white/5 hover:text-white sm:w-auto"
                 onClick={scrollToCatalog}
                 data-testid="button-browse-everything"
               >

--- a/client/src/pages/store/CoManagedStore.tsx
+++ b/client/src/pages/store/CoManagedStore.tsx
@@ -10,8 +10,6 @@ import {
   ShoppingCart,
   Lock,
   Phone,
-  User,
-  LogOut,
   MessageCircle,
   Sparkles,
 } from "lucide-react";
@@ -54,7 +52,6 @@ import {
 } from "@/data/storeMerchandising";
 import { useToast } from "@/hooks/use-toast";
 import { useCart } from "@/contexts/CartContext";
-import { CartButton } from "@/components/store/CartButton";
 import { useStoreAuth } from "@/hooks/useStoreAuth";
 import { PORTAL_LOGIN } from "@/lib/portalUrls";
 import { openMspAdvisor } from "@/lib/openMspAdvisor";
@@ -77,6 +74,8 @@ import {
   MAX_COMPARE,
 } from "@/components/store/ProductCompare";
 import { CoverageScorePanel } from "@/components/store/CoverageScorePanel";
+import { StorePageAtmosphere } from "@/components/store/StorePageAtmosphere";
+import { StoreClientBar } from "@/components/store/StoreClientBar";
 
 const SORT_OPTIONS: StoreSortOption[] = ["recommended", "popular", "price_asc", "price_desc"];
 const PRICE_BAND_IDS = new Set(storePriceBandFilters.map((b) => b.id));
@@ -141,12 +140,9 @@ const CoManagedStore = () => {
   const { addToCart, openCart, setClientPricing, items } = useCart();
   const {
     isLoggedIn,
-    user,
-    clientType,
     clientPricing,
     getProductPrice,
     loginRedirect,
-    logout,
   } = useStoreAuth();
 
   const catalogRef = useRef<HTMLDivElement>(null);
@@ -555,54 +551,13 @@ const CoManagedStore = () => {
       };
 
   return (
-    <div className="min-h-screen bg-[#0a0a0a]">
+    <div className="relative min-h-screen bg-[#0a0a0a]">
+      <StorePageAtmosphere />
       <MegaMenu />
 
-      <main className="pb-20 de-nav-clear">
+      <main className="relative z-10 pb-20 de-nav-clear">
         <div className="mx-auto max-w-[var(--de-canvas)] px-3 sm:px-4 lg:px-6">
-          {/* Auth & Cart */}
-          <div className="mb-4 flex items-center justify-between">
-            {isLoggedIn && user ? (
-              <div className="flex items-center gap-3">
-                <div className="flex items-center gap-2 rounded-lg border border-de-accent/20 bg-de-accent/10 px-3 py-2">
-                  <User className="h-4 w-4 text-de-accent-ink" />
-                  <span className="text-sm text-white" data-testid="text-user-greeting">
-                    Welcome,{" "}
-                    <span className="font-semibold text-de-accent-ink">
-                      {user.fullName || user.username}
-                    </span>
-                  </span>
-                  {clientType !== "public" && (
-                    <span className="ml-2 rounded-full bg-emerald-500/20 px-2 py-0.5 text-xs font-medium text-emerald-300">
-                      {clientType === "managed" ? "Managed Client" : "Co-Managed Client"}
-                    </span>
-                  )}
-                </div>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={logout}
-                  className="text-white/60 hover:bg-de-accent/10 hover:text-white"
-                  data-testid="button-store-logout"
-                >
-                  <LogOut className="mr-1 h-4 w-4" />
-                  Logout
-                </Button>
-              </div>
-            ) : (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={loginRedirect}
-                className="h-11 border-none bg-de-accent px-5 text-base text-white hover:bg-[#6548ff]"
-                data-testid="button-store-login"
-              >
-                <User className="mr-2 h-4 w-4" />
-                Login for Client Pricing
-              </Button>
-            )}
-            <CartButton />
-          </div>
+          <StoreClientBar />
 
           <div className="mb-8 flex items-center gap-2 text-base text-white/50">
             <Link href="/store" className="transition-colors hover:text-white">
@@ -623,7 +578,7 @@ const CoManagedStore = () => {
               <Users className="h-4 w-4 text-de-accent-ink" />
               <span className="text-sm text-de-accent-ink">Guided IT Storefront</span>
             </div>
-            <h1 className="mb-4 text-4xl font-bold text-white md:text-5xl lg:text-6xl">
+            <h1 className="mb-4 text-[clamp(2rem,6vw,3.25rem)] font-bold leading-[1.12] tracking-[-0.03em] text-white">
               Tell us what you&apos;re trying to{" "}
               <span className="text-de-accent-ink">accomplish.</span>
             </h1>

--- a/client/src/pages/store/ManagedStore.tsx
+++ b/client/src/pages/store/ManagedStore.tsx
@@ -15,6 +15,7 @@ import {
   type StoreProduct
 } from "@/data/storeProducts";
 import { CartButton } from "@/components/store/CartButton";
+import { StorePageAtmosphere } from "@/components/store/StorePageAtmosphere";
 import { pricing, getPricingFooterText } from "@/data/pricing";
 import { ProductMedia } from "@/components/store/ProductMedia";
 import { getProductVisual } from "@/data/productImages";
@@ -131,10 +132,11 @@ const ManagedStore = () => {
   };
 
   return (
-    <div className="min-h-screen bg-[#0a0a0a]">
+    <div className="relative min-h-screen bg-[#0a0a0a]">
+      <StorePageAtmosphere />
       <MegaMenu />
       
-      <main className="de-nav-clear pb-20">
+      <main className="relative z-10 de-nav-clear pb-20">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           
           {/* Breadcrumb with Cart Button */}
@@ -158,7 +160,7 @@ const ManagedStore = () => {
               <Building className="w-4 h-4 text-de-accent-ink" />
               <span className="text-sm text-de-accent-ink">Managed IT Services</span>
             </div>
-            <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6">
+            <h1 className="mb-6 text-[clamp(2rem,6vw,3.25rem)] font-bold leading-[1.12] tracking-[-0.03em] text-white">
               Full-Service{" "}
               <span className="text-de-accent-ink">
                 Managed IT

--- a/client/src/pages/store/ManagedStore.tsx
+++ b/client/src/pages/store/ManagedStore.tsx
@@ -14,8 +14,9 @@ import {
   formatPrice,
   type StoreProduct
 } from "@/data/storeProducts";
-import { CartButton } from "@/components/store/CartButton";
+import { StoreClientBar } from "@/components/store/StoreClientBar";
 import { StorePageAtmosphere } from "@/components/store/StorePageAtmosphere";
+import { CTA } from "@/lib/ctaCopy";
 import { pricing, getPricingFooterText } from "@/data/pricing";
 import { ProductMedia } from "@/components/store/ProductMedia";
 import { getProductVisual } from "@/data/productImages";
@@ -56,9 +57,9 @@ const ManagedStore = () => {
       <motion.div
         variants={itemVariants}
         className={`relative overflow-hidden rounded-2xl border transition-all duration-300 hover:-translate-y-1 cursor-pointer ${
-          featured 
-            ? 'bg-de-raised border-de-hairline shadow-[0_0_40px_rgba(139,92,246,0.2)]' 
-            : 'bg-white/[0.03] border-white/10 hover:border-de-hairline'
+          featured
+            ? "bg-de-raised border-de-accent/35"
+            : "border-white/10 bg-white/[0.03] hover:border-de-hairline"
         }`}
         data-testid={`product-${product.id}`}
       >
@@ -139,14 +140,11 @@ const ManagedStore = () => {
       <main className="relative z-10 de-nav-clear pb-20">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           
-          {/* Breadcrumb with Cart Button */}
-          <div className="mb-8 flex items-center justify-between">
-            <div className="flex items-center gap-2 text-sm text-white/50">
-              <Link href="/store" className="hover:text-white transition-colors">Store</Link>
-              <span>/</span>
-              <span className="text-white">Managed Clients</span>
-            </div>
-            <CartButton />
+          <StoreClientBar />
+          <div className="mb-8 flex items-center gap-2 text-sm text-white/50">
+            <Link href="/store" className="transition-colors hover:text-white">Store</Link>
+            <span>/</span>
+            <span className="text-white">Managed Clients</span>
           </div>
 
           {/* Hero Section */}
@@ -278,34 +276,37 @@ const ManagedStore = () => {
             viewport={{ once: true }}
             transition={{ duration: 0.5 }}
           >
-            <h2 className="text-2xl md:text-3xl font-bold text-white mb-4">
-              Ready to Get Started?
+            <h2 className="mb-4 text-2xl font-bold text-white md:text-3xl">
+              Need a package recommendation?
             </h2>
-            <p className="text-white/60 mb-8 max-w-xl mx-auto">
-              Schedule a free 15-minute call to discuss your needs. We'll help you choose the right plan 
-              and provide a customized quote for your organization.
+            <p className="mx-auto mb-8 max-w-xl text-white/60">
+              Start with a cyber risk assessment. We map the right ProActive tier to your users,
+              sites, and compliance needs — then quote the contract.
             </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Button asChild 
-                  size="lg"
-                  className="h-14 px-8 text-lg font-semibold bg-de-accent hover:bg-de-accent text-white shadow-lg shadow-none"
-                  data-testid="button-final-cta"
-                >
-                  <a href="/book">
-                    <Calendar className="w-5 h-5 mr-2" />
-                  Schedule Consultation
-                  </a>
-                </Button>
-              <Button asChild 
-                  size="lg"
-                  className="h-14 px-8 text-lg font-semibold bg-transparent border-2 border-white/30 text-white hover:bg-white/10"
-                  data-testid="button-call-us"
-                >
-                  <a href="tel:+13254809870">
-                    <Phone className="w-5 h-5 mr-2" />
+            <div className="flex flex-col justify-center gap-4 sm:flex-row">
+              <Button
+                asChild
+                size="lg"
+                variant="brand"
+                className="h-14 px-8 text-lg font-semibold"
+                data-testid="button-final-cta"
+              >
+                <a href="/book">
+                  <Calendar className="mr-2 h-5 w-5" />
+                  {CTA.primary}
+                </a>
+              </Button>
+              <Button
+                asChild
+                size="lg"
+                className="h-14 border-2 border-white/30 bg-transparent px-8 text-lg font-semibold text-white hover:bg-white/10"
+                data-testid="button-call-us"
+              >
+                <a href="tel:+13254809870">
+                  <Phone className="mr-2 h-5 w-5" />
                   325-480-9870
-                  </a>
-                </Button>
+                </a>
+              </Button>
             </div>
             
             <div className="mt-8">

--- a/client/src/pages/store/ProductDetail.tsx
+++ b/client/src/pages/store/ProductDetail.tsx
@@ -34,7 +34,6 @@ import {
   Check,
   ExternalLink,
   User,
-  LogOut,
   Tag,
   Lock,
   Settings2,
@@ -43,7 +42,8 @@ import {
   Sparkles,
 } from "lucide-react";
 import { useStoreAuth } from "@/hooks/useStoreAuth";
-import { CartButton } from "@/components/store/CartButton";
+import { StoreClientBar } from "@/components/store/StoreClientBar";
+import { StorePageAtmosphere } from "@/components/store/StorePageAtmosphere";
 import { ProductMedia } from "@/components/store/ProductMedia";
 import {
   ConfigureProductDrawer,
@@ -57,8 +57,7 @@ const ProductDetail = () => {
   const { toast } = useToast();
   const [quantity, setQuantity] = useState(1);
   const [configureOpen, setConfigureOpen] = useState(false);
-  const { isLoggedIn, user, clientType, clientPricing, getProductPrice, loginRedirect, logout } =
-    useStoreAuth();
+  const { isLoggedIn, clientPricing, getProductPrice, loginRedirect } = useStoreAuth();
 
   useEffect(() => {
     if (clientPricing.length > 0) {
@@ -154,7 +153,8 @@ const ProductDetail = () => {
   };
 
   return (
-    <div className="min-h-screen bg-[#0a0a0a]">
+    <div className="relative min-h-screen bg-[#0a0a0a]">
+      <StorePageAtmosphere />
       <ProductJsonLd
         name={product.name}
         description={product.description}
@@ -174,50 +174,9 @@ const ProductDetail = () => {
       />
       <MegaMenu />
 
-      <main className="de-nav-clear pb-28 lg:pb-20">
+      <main className="relative z-10 de-nav-clear pb-28 lg:pb-20">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-          <div className="mb-4 flex items-center justify-between">
-            {isLoggedIn && user ? (
-              <div className="flex items-center gap-3">
-                <div className="flex items-center gap-2 rounded-lg border border-de-accent/20 bg-de-accent/10 px-3 py-2">
-                  <User className="h-4 w-4 text-de-accent-ink" />
-                  <span className="text-sm text-white" data-testid="text-user-greeting">
-                    Welcome,{" "}
-                    <span className="font-semibold text-de-accent-ink">
-                      {user.fullName || user.username}
-                    </span>
-                  </span>
-                  {clientType !== "public" && (
-                    <span className="ml-2 rounded-full bg-emerald-500/20 px-2 py-0.5 text-xs font-medium text-emerald-300">
-                      {clientType === "managed" ? "Managed Client" : "Co-Managed Client"}
-                    </span>
-                  )}
-                </div>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={logout}
-                  className="text-white/60 hover:bg-de-accent/10 hover:text-white"
-                  data-testid="button-store-logout"
-                >
-                  <LogOut className="mr-1 h-4 w-4" />
-                  Logout
-                </Button>
-              </div>
-            ) : (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={loginRedirect}
-                className="border-none bg-de-accent text-white hover:bg-[#6548ff]"
-                data-testid="button-store-login"
-              >
-                <User className="mr-2 h-4 w-4" />
-                Login for Client Pricing
-              </Button>
-            )}
-            <CartButton />
-          </div>
+          <StoreClientBar />
 
           <nav className="mb-8" aria-label="Breadcrumb">
             <ol className="flex items-center gap-2 text-sm text-white/50">

--- a/client/src/pages/store/StoreLanding.tsx
+++ b/client/src/pages/store/StoreLanding.tsx
@@ -163,9 +163,9 @@ const StoreLanding = () => {
                   Guided storefront for managed packages and à la carte services — shop by outcome,
                   ask Digerati to build a stack, then buy from the live catalog.
                 </p>
-                <div className="mt-7 flex flex-wrap gap-3">
+                <div className="mt-7 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
                   <Button
-                    className="h-12 bg-de-accent px-6 text-base text-white hover:bg-[#6548ff]"
+                    className="h-12 w-full bg-de-accent px-6 text-base text-white hover:bg-[#6548ff] sm:w-auto"
                     onClick={() => setGuidedOpen(true)}
                     data-testid="button-build-solution"
                   >
@@ -174,7 +174,7 @@ const StoreLanding = () => {
                   </Button>
                   <Button
                     variant="outline"
-                    className="h-12 border-white/20 bg-transparent px-6 text-base text-white hover:bg-white/5"
+                    className="h-12 w-full border-white/20 bg-transparent px-6 text-base text-white hover:bg-white/5 sm:w-auto"
                     onClick={() => openMspAdvisor({ context: "store" })}
                     data-testid="button-ask-digerati"
                   >
@@ -184,7 +184,7 @@ const StoreLanding = () => {
                   <Link href="/store/co-managed">
                     <Button
                       variant="ghost"
-                      className="h-12 px-6 text-base text-white/70 hover:bg-white/5 hover:text-white"
+                      className="h-12 w-full px-6 text-base text-white/70 hover:bg-white/5 hover:text-white sm:w-auto"
                       data-testid="button-browse-catalog"
                     >
                       Browse full catalog
@@ -241,13 +241,13 @@ const StoreLanding = () => {
                     <Lock className="h-4 w-4" />
                     <span>Contract-based services · Schedule a consultation</span>
                   </div>
-                  <div className="flex items-center justify-between">
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                     <span className="text-base text-white/50">
                       {contractOnlyProducts.length} packages available
                     </span>
                     <Link href="/store/managed">
                       <Button
-                        className="h-11 bg-de-accent px-5 text-base text-white hover:bg-[#6548ff]"
+                        className="h-11 w-full bg-de-accent px-5 text-base text-white hover:bg-[#6548ff] sm:w-auto"
                         data-testid="button-view-managed"
                       >
                         View Packages
@@ -276,13 +276,13 @@ const StoreLanding = () => {
                     <Shield className="h-4 w-4" />
                     <span>Checkout enabled · Purchase directly</span>
                   </div>
-                  <div className="flex items-center justify-between">
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                     <span className="text-base text-white/50">
                       {checkoutProducts.length} products available
                     </span>
                     <Link href="/store/co-managed">
                       <Button
-                        className="h-11 border-none bg-de-accent px-5 text-base text-white hover:bg-[#6548ff]"
+                        className="h-11 w-full border-none bg-de-accent px-5 text-base text-white hover:bg-[#6548ff] sm:w-auto"
                         data-testid="button-view-comanaged"
                       >
                         Browse Products
@@ -375,15 +375,15 @@ const StoreLanding = () => {
             viewport={{ once: true }}
             transition={{ duration: 0.5 }}
           >
-            <div className="mb-8 flex items-center justify-between">
+            <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
               <div>
                 <h2 className="mb-2 text-2xl font-bold text-white md:text-3xl">Available for checkout</h2>
-                <p className="text-white/60">Catalog items you can configure or add now — not a second popularity rail.</p>
+                <p className="text-white/60">Configure or add these catalog items now.</p>
               </div>
               <Link href="/store/co-managed">
                 <Button
                   variant="outline"
-                  className="border-white/20 text-white hover:bg-white/10"
+                  className="w-full border-white/20 text-white hover:bg-white/10 sm:w-auto"
                   data-testid="button-view-all-products"
                 >
                   View All
@@ -426,43 +426,44 @@ const StoreLanding = () => {
             viewport={{ once: true }}
             transition={{ duration: 0.5 }}
           >
-            <h2 className="mb-4 text-2xl font-bold text-white md:text-3xl">Need Help Choosing?</h2>
+            <h2 className="mb-4 text-2xl font-bold text-white md:text-3xl">Need a recommendation, not a catalog?</h2>
             <p className="mx-auto mb-8 max-w-xl text-white/60">
-              Not sure which services fit your business? Schedule a free consultation with our team
-              to discuss your IT needs and find the right solution.
+              Start with a cyber risk assessment or compare ProActive plans. We map gaps to real
+              SKUs — no obligation to buy from the storefront.
             </p>
             <div className="flex flex-col justify-center gap-4 sm:flex-row">
-              <Button asChild
-                  size="lg"
-                  variant="brand"
-                  className="h-12 px-6"
-                  data-testid="button-schedule-consult"
-                >
-                  <a href="/book">
-                    {CTA.primary}
+              <Button
+                asChild
+                size="lg"
+                variant="brand"
+                className="h-12 px-6"
+                data-testid="button-schedule-consult"
+              >
+                <a href="/book">
+                  {CTA.primary}
                   <ArrowRight className="ml-2 h-4 w-4" />
-                  </a>
-                </Button>
-              <Button asChild
-                  size="lg"
-                  variant="outline"
-                  className="h-12 border-white/30 bg-transparent px-6 text-white hover:bg-white/10"
-                  data-testid="button-see-plans"
-                >
-                  <Link href={CTA.secondaryHref}>
-                    {CTA.secondary}
-                  </Link>
-                </Button>
-              <Button asChild
-                  size="lg"
-                  className="h-12 border-2 border-white/30 bg-transparent px-6 text-white hover:bg-white/10"
-                  data-testid="button-call-us"
-                >
-                  <a href="tel:+13254809870">
-                    <Phone className="mr-2 h-4 w-4" />
+                </a>
+              </Button>
+              <Button
+                asChild
+                size="lg"
+                variant="outline"
+                className="h-12 border-white/30 bg-transparent px-6 text-white hover:bg-white/10"
+                data-testid="button-see-plans"
+              >
+                <Link href={CTA.secondaryHref}>{CTA.secondary}</Link>
+              </Button>
+              <Button
+                asChild
+                size="lg"
+                className="h-12 border-2 border-white/30 bg-transparent px-6 text-white hover:bg-white/10"
+                data-testid="button-call-us"
+              >
+                <a href="tel:+13254809870">
+                  <Phone className="mr-2 h-4 w-4" />
                   325-480-9870
-                  </a>
-                </Button>
+                </a>
+              </Button>
             </div>
           </motion.section>
         </div>

--- a/client/src/pages/store/StoreLanding.tsx
+++ b/client/src/pages/store/StoreLanding.tsx
@@ -21,8 +21,6 @@ import {
   Package,
   Settings,
   Server,
-  User,
-  LogOut,
   MessageCircle,
   Sparkles,
 } from "lucide-react";
@@ -39,11 +37,9 @@ import {
   isConfigurableProduct,
   type StoreOutcomeId,
 } from "@/data/storeMerchandising";
-import { CartButton } from "@/components/store/CartButton";
 import { useStoreAuth } from "@/hooks/useStoreAuth";
 import { useCart } from "@/contexts/CartContext";
 import { useToast } from "@/hooks/use-toast";
-import { PORTAL_LOGIN } from "@/lib/portalUrls";
 import { openMspAdvisor } from "@/lib/openMspAdvisor";
 import { StoreTrustStrip } from "@/components/store/StoreTrustStrip";
 import { ShopByOutcome } from "@/components/store/ShopByOutcome";
@@ -53,6 +49,9 @@ import { StoreBundlesSection } from "@/components/store/StoreBundlesSection";
 import { StoreProductCard } from "@/components/store/StoreProductCard";
 import { ConfigureProductDrawer } from "@/components/store/ConfigureProductDrawer";
 import { GuidedBuyingWizard } from "@/components/store/GuidedBuyingWizard";
+import { StorePageAtmosphere } from "@/components/store/StorePageAtmosphere";
+import { StoreClientBar } from "@/components/store/StoreClientBar";
+import { CTA } from "@/lib/ctaCopy";
 
 const categoryIcons: Record<ProductCategory, typeof Shield> = {
   contract_services: Building,
@@ -73,7 +72,7 @@ const categoryIcons: Record<ProductCategory, typeof Shield> = {
 
 const StoreLanding = () => {
   const prefersReducedMotion = useReducedMotion();
-  const { isLoggedIn, user, clientType, logout, getProductPrice, loginRedirect } = useStoreAuth();
+  const { isLoggedIn, getProductPrice, loginRedirect } = useStoreAuth();
   const { addToCart, openCart } = useCart();
   const { toast } = useToast();
   const [, setLocation] = useLocation();
@@ -136,72 +135,31 @@ const StoreLanding = () => {
   };
 
   return (
-    <div className="min-h-screen bg-[#0a0a0a]">
+    <div className="relative min-h-screen bg-[#0a0a0a]">
+      <StorePageAtmosphere />
       <MegaMenu />
 
-      <main className="pb-20 de-nav-clear">
+      <main className="relative z-10 pb-20 de-nav-clear">
         <div className="mx-auto max-w-[var(--de-canvas)] px-3 sm:px-4 lg:px-6">
-          <div className="mb-4 flex items-center justify-between">
-            {isLoggedIn && user ? (
-              <div className="flex items-center gap-3">
-                <div className="flex items-center gap-2 rounded-lg border border-de-accent/20 bg-de-accent/10 px-3 py-2">
-                  <User className="h-4 w-4 text-de-accent-ink" />
-                  <span className="text-sm text-white" data-testid="text-user-greeting">
-                    Welcome,{" "}
-                    <span className="font-semibold text-de-accent-ink">
-                      {user.fullName || user.username}
-                    </span>
-                  </span>
-                  {clientType !== "public" && (
-                    <span className="ml-2 rounded-full bg-de-accent/20 px-2 py-0.5 text-xs font-medium text-de-accent-ink">
-                      {clientType === "managed" ? "Managed Client" : "Co-Managed Client"}
-                    </span>
-                  )}
-                </div>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={logout}
-                  className="text-white/60 hover:bg-de-accent/10 hover:text-white"
-                  data-testid="button-store-logout"
-                >
-                  <LogOut className="mr-1 h-4 w-4" />
-                  Logout
-                </Button>
-              </div>
-            ) : (
-              <Link href={PORTAL_LOGIN}>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="h-11 border-none bg-de-accent px-5 text-base text-white hover:bg-[#6548ff]"
-                  data-testid="button-store-login"
-                >
-                  <User className="mr-2 h-4 w-4" />
-                  Login for Client Pricing
-                </Button>
-              </Link>
-            )}
-            <CartButton />
-          </div>
+          <StoreClientBar />
 
           <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_300px]">
             <div>
               <motion.div
                 className="mb-10"
-                initial={{ opacity: 0, y: 20 }}
+                initial={prefersReducedMotion ? false : { opacity: 0, y: 16 }}
                 animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.5 }}
+                transition={{ duration: prefersReducedMotion ? 0 : 0.45 }}
               >
-                <div className="mb-6 inline-flex items-center gap-2 rounded-full border border-de-accent/25 bg-de-accent/10 px-4 py-2">
+                <div className="mb-5 inline-flex items-center gap-2 rounded-full border border-de-accent/25 bg-de-accent/10 px-4 py-2">
                   <Package className="h-4 w-4 text-de-accent-ink" />
                   <span className="text-sm text-de-accent-ink">IT Services & Solutions</span>
                 </div>
-                <h1 className="mb-4 text-4xl font-bold text-white md:text-5xl lg:text-6xl xl:text-7xl">
+                <h1 className="mb-4 text-[clamp(2rem,6vw,3.5rem)] font-bold leading-[1.12] tracking-[-0.03em] text-white">
                   Tell us what you&apos;re trying to{" "}
                   <span className="text-de-accent-ink">accomplish</span>
                 </h1>
-                <p className="max-w-3xl text-xl leading-relaxed text-white/70 md:text-2xl">
+                <p className="max-w-2xl text-lg leading-relaxed text-white/70 md:text-xl">
                   Guided storefront for managed packages and à la carte services — shop by outcome,
                   ask Digerati to build a stack, then buy from the live catalog.
                 </p>
@@ -369,13 +327,13 @@ const StoreLanding = () => {
             viewport={{ once: true }}
             transition={{ duration: 0.5 }}
           >
-            <div className="mb-10 text-center">
-              <h2 className="mb-3 text-2xl font-bold text-white md:text-3xl">Browse by Category</h2>
+            <div className="mb-8">
+              <h2 className="mb-2 text-2xl font-bold text-white md:text-3xl">Browse by Category</h2>
               <p className="text-white/60">Explore our complete catalog of IT services and products.</p>
             </div>
 
             <motion.div
-              className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5"
+              className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3"
               variants={containerVariants}
               initial="hidden"
               whileInView="visible"
@@ -388,16 +346,19 @@ const StoreLanding = () => {
                   <motion.div key={category} variants={itemVariants}>
                     <Link href={`/store/co-managed?category=${category}`}>
                       <div
-                        className="group h-full cursor-pointer rounded-xl border border-white/10 bg-[#141414] p-4 text-center transition-all duration-300 hover:border-de-accent/30 hover:bg-[#171717]"
+                        className="group flex h-full cursor-pointer items-center gap-3 rounded-xl border border-white/10 bg-[#141414] px-3.5 py-3 text-left transition-colors duration-200 hover:border-de-accent/30 hover:bg-[#171717]"
                         data-testid={`category-${category}`}
                       >
-                        <div className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-lg border border-white/10 bg-white/[0.04] transition-colors group-hover:border-de-accent/30 group-hover:bg-de-accent/15">
+                        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-white/10 bg-white/[0.04] transition-colors group-hover:border-de-accent/30 group-hover:bg-de-accent/15">
                           <Icon className="h-5 w-5 text-de-accent-ink" />
                         </div>
-                        <h3 className="mb-1 text-sm font-medium text-white">
-                          {categoryLabels[category]}
-                        </h3>
-                        <p className="text-xs text-white/55">{productCount} items</p>
+                        <div className="min-w-0 flex-1">
+                          <h3 className="truncate text-sm font-medium text-white">
+                            {categoryLabels[category]}
+                          </h3>
+                          <p className="text-xs text-white/55">{productCount} items</p>
+                        </div>
+                        <ArrowRight className="h-4 w-4 shrink-0 text-white/30 group-hover:text-de-accent-ink" />
                       </div>
                     </Link>
                   </motion.div>
@@ -416,8 +377,8 @@ const StoreLanding = () => {
           >
             <div className="mb-8 flex items-center justify-between">
               <div>
-                <h2 className="mb-2 text-2xl font-bold text-white md:text-3xl">Featured Products</h2>
-                <p className="text-white/60">Popular items available for immediate purchase.</p>
+                <h2 className="mb-2 text-2xl font-bold text-white md:text-3xl">Available for checkout</h2>
+                <p className="text-white/60">Catalog items you can configure or add now — not a second popularity rail.</p>
               </div>
               <Link href="/store/co-managed">
                 <Button
@@ -473,13 +434,24 @@ const StoreLanding = () => {
             <div className="flex flex-col justify-center gap-4 sm:flex-row">
               <Button asChild
                   size="lg"
-                  className="h-12 bg-de-accent px-6 text-white hover:bg-[#6548ff]"
+                  variant="brand"
+                  className="h-12 px-6"
                   data-testid="button-schedule-consult"
                 >
                   <a href="/book">
-                    Schedule Free Consultation
+                    {CTA.primary}
                   <ArrowRight className="ml-2 h-4 w-4" />
                   </a>
+                </Button>
+              <Button asChild
+                  size="lg"
+                  variant="outline"
+                  className="h-12 border-white/30 bg-transparent px-6 text-white hover:bg-white/10"
+                  data-testid="button-see-plans"
+                >
+                  <Link href={CTA.secondaryHref}>
+                    {CTA.secondary}
+                  </Link>
                 </Button>
               <Button asChild
                   size="lg"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
No major store rebuild. This keeps the existing catalog, rails, outcomes, pills, and electric store accent, and fixes the things that currently look flat or fight the viewer.

## What changed
- Parallax atmosphere on store landing, catalog, managed packages, and product pages (electric lighting only; reduced-motion stays static)
- Outline client login instead of a filled electric button competing with hero / product CTAs
- Outcome images have a real crop; category wall is a directory, not a second card grid
- Featured block is “Available for checkout,” not a second Popular rail
- Assessment / closer CTAs use the canonical magenta assessment label
- Mobile hero and path buttons stack full-width so they stop wrapping awkwardly
- Leftover purple glow on featured managed packages is gone

## Preserved
- Category pill hues and vendor marks
- Electric store-family buttons (`#6548ff` hover)
- How do you buy, outcomes, rails, bundles, catalog filters
- Portal login stays `https://portal.digeratiexperts.com/portal/login`

## Verification
- Vitest: `categoryAccent`, `storeChromeGestures`, `storeCatalog` — 10/10 passed
- Browser: `/store`, `/store/co-managed`, `/store/managed`, PDP at 390 / 768 / 1440
- No horizontal overflow
- Store login lands on `https://portal.digeratiexperts.com/portal/login?returnTo=...` (not `//login`)

[Store hero at 1440](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstore-landing-hero-1440.png)
[Store hero at 390](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstore-landing-hero-390.png)
[Managed packages hero](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstore-managed-hero-1440.png)
[store_epic_polish_walkthrough.mp4](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstore_epic_polish_walkthrough.mp4)

## Still needs a human look
- Managed “Why Choose Managed IT?” still shows existing SLA / savings figures that were already on the page
- Atmosphere is restrained on purpose — this is not a neon rebuild


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55eac13a-e87f-4a00-9c34-f63bb77c3080&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

