### PR TITLE
Solution engine: durable carts, client pricing, quote PDFs

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -22,6 +22,7 @@ import { BookingProvider } from "@/contexts/BookingContext";
 import { BookingModal } from "@/components/BookingModal";
 import { CookieConsentBanner } from "@/components/CookieConsentBanner";
 import { ShoppingCart } from "@/components/store/ShoppingCart";
+import { SolutionMobileBar } from "@/components/store/SolutionMobileBar";
 
 import { DigeratiHomepage } from "@/pages/DigeratiHomepage";
 
@@ -947,6 +948,7 @@ function App() {
               <TooltipProvider>
                 <Toaster />
                 <ShoppingCart />
+                <SolutionMobileBar />
                 <BookingModal />
                 <AppContent />
               </TooltipProvider>

--- a/client/src/components/store/CartButton.tsx
+++ b/client/src/components/store/CartButton.tsx
@@ -1,3 +1,4 @@
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { Layers } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useCart } from "@/contexts/CartContext";
@@ -5,26 +6,33 @@ import { useCart } from "@/contexts/CartContext";
 export function CartButton() {
   const { getItemCount, toggleCart } = useCart();
   const itemCount = getItemCount();
+  const prefersReducedMotion = useReducedMotion();
 
   return (
     <Button
       variant="ghost"
       size="icon"
-      className="relative text-white/70 hover:bg-white/10 hover:text-white"
+      className="relative h-11 w-11 text-white/70 hover:bg-white/10 hover:text-white"
       onClick={toggleCart}
       data-testid="button-cart"
       aria-label={`Your solution with ${itemCount} services`}
       title="Your Solution"
     >
       <Layers className="h-5 w-5" />
-      {itemCount > 0 && (
-        <span
-          className="absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center rounded-full bg-de-accent text-xs font-medium text-white"
-          data-testid="cart-item-count"
-        >
-          {itemCount > 99 ? "99+" : itemCount}
-        </span>
-      )}
+      <AnimatePresence>
+        {itemCount > 0 && (
+          <motion.span
+            key={itemCount}
+            initial={prefersReducedMotion ? false : { scale: 0.7, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={prefersReducedMotion ? undefined : { scale: 0.7, opacity: 0 }}
+            className="absolute -right-1 -top-1 flex h-5 min-w-5 items-center justify-center rounded-full bg-de-accent px-1 text-xs font-medium text-white"
+            data-testid="cart-item-count"
+          >
+            {itemCount > 99 ? "99+" : itemCount}
+          </motion.span>
+        )}
+      </AnimatePresence>
     </Button>
   );
 }

--- a/client/src/components/store/ConfigureProductDrawer.tsx
+++ b/client/src/components/store/ConfigureProductDrawer.tsx
@@ -388,6 +388,13 @@ export function ConfigureProductDrawer({
                     <span className="text-lg font-medium text-white/50">{periodSuffix}</span>
                   ) : null}
                 </p>
+                <p className="mt-2 text-xs text-white/55">
+                  {recurring
+                    ? billingPeriod === "yearly"
+                      ? "Adds to Annual in Your Solution."
+                      : "Adds to Monthly in Your Solution."
+                    : "Adds to Due Today in Your Solution."}
+                </p>
               </div>
             </div>
 

--- a/client/src/components/store/CoverageScorePanel.tsx
+++ b/client/src/components/store/CoverageScorePanel.tsx
@@ -3,6 +3,7 @@ import { Check, Shield } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import type { StoreProduct } from "@/data/storeProducts";
 import { computeCoverageScore } from "@/data/storeMerchandising";
+import { analytics } from "@/lib/analytics";
 
 interface CoverageScorePanelProps {
   products: StoreProduct[];
@@ -72,7 +73,7 @@ export function CoverageScorePanel({
 
       {score.suggestions.length > 0 ? (
         <div className="mt-4 space-y-2 border-t border-white/10 pt-4">
-          <p className="text-xs font-medium text-white/70">Close coverage gaps</p>
+          <p className="text-xs font-medium text-white/70">Recommended because this layer is missing</p>
           {score.suggestions.map((s) =>
             s.product ? (
               <div
@@ -90,7 +91,11 @@ export function CoverageScorePanel({
                   <Button
                     size="sm"
                     className="h-8 shrink-0 bg-de-accent text-xs text-white hover:bg-[#6548ff]"
-                    onClick={() => onAddSuggestion(s.product!)}
+                    onClick={() => {
+                      analytics.storeCoverageGapViewed(s.label);
+                      analytics.storeAcceptRecommendation(s.product!.name, `Closes ${s.label} coverage gap`);
+                      onAddSuggestion(s.product!);
+                    }}
                     data-testid={`button-improve-${s.product.id}`}
                   >
                     Add

--- a/client/src/components/store/MerchandisingRails.tsx
+++ b/client/src/components/store/MerchandisingRails.tsx
@@ -83,6 +83,15 @@ function RailScroller({
           </Button>
         </div>
       </div>
+      <div className="relative">
+        <div
+          className="pointer-events-none absolute inset-y-0 left-0 z-10 w-8 bg-gradient-to-r from-[#0a0a0a] to-transparent"
+          aria-hidden="true"
+        />
+        <div
+          className="pointer-events-none absolute inset-y-0 right-0 z-10 w-8 bg-gradient-to-l from-[#0a0a0a] to-transparent"
+          aria-hidden="true"
+        />
       <div
         ref={scrollerRef}
         className="de-store-h-rail flex gap-5 pb-2 scrollbar-thin"
@@ -110,6 +119,7 @@ function RailScroller({
             </div>
           );
         })}
+      </div>
       </div>
     </div>
   );

--- a/client/src/components/store/MerchandisingRails.tsx
+++ b/client/src/components/store/MerchandisingRails.tsx
@@ -85,11 +85,11 @@ function RailScroller({
       </div>
       <div className="relative">
         <div
-          className="pointer-events-none absolute inset-y-0 left-0 z-10 w-8 bg-gradient-to-r from-[#0a0a0a] to-transparent"
+          className="pointer-events-none absolute inset-y-0 left-0 z-10 w-6 bg-gradient-to-r from-[#0a0a0a] to-transparent sm:w-10"
           aria-hidden="true"
         />
         <div
-          className="pointer-events-none absolute inset-y-0 right-0 z-10 w-8 bg-gradient-to-l from-[#0a0a0a] to-transparent"
+          className="pointer-events-none absolute inset-y-0 right-0 z-10 w-6 bg-gradient-to-l from-[#0a0a0a] to-transparent sm:w-10"
           aria-hidden="true"
         />
       <div

--- a/client/src/components/store/ShopByOutcome.tsx
+++ b/client/src/components/store/ShopByOutcome.tsx
@@ -26,7 +26,7 @@ export function ShopByOutcome({ selected, onSelect }: ShopByOutcomeProps) {
               key={outcome.id}
               type="button"
               onClick={() => onSelect(isActive ? null : outcome.id)}
-              className={`group rounded-xl border p-5 md:p-6 text-left transition-all duration-200 ${
+              className={`group rounded-xl border p-3.5 text-left transition-all duration-200 sm:p-5 md:p-6 ${
                 isActive
                   ? "border-[#D3126A]/55 bg-[#D3126A]/10 shadow-[0_0_24px_rgba(211,18,106,0.12)]"
                   : "border-white/10 bg-[#121212] hover:border-white/20 hover:bg-[#161616]"

--- a/client/src/components/store/ShopByOutcome.tsx
+++ b/client/src/components/store/ShopByOutcome.tsx
@@ -42,7 +42,7 @@ export function ShopByOutcome({ selected, onSelect }: ShopByOutcomeProps) {
                 <img
                   src={outcomeCardUrl(outcome.id)}
                   alt=""
-                  className="h-14 w-full object-cover"
+                  className="h-24 w-full object-cover object-center sm:h-28"
                   loading="lazy"
                   decoding="async"
                 />

--- a/client/src/components/store/ShoppingCart.tsx
+++ b/client/src/components/store/ShoppingCart.tsx
@@ -1,5 +1,5 @@
-import { useMemo, useState } from "react";
-import { motion, AnimatePresence } from "framer-motion";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import {
   X,
   Minus,
@@ -8,60 +8,59 @@ import {
   Layers,
   ArrowRight,
   ChevronDown,
-  Loader2,
-  CreditCard,
   Calendar,
   FileText,
   Phone,
+  BookmarkPlus,
+  RotateCcw,
+  Clock,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useCart, isRecurringPricing } from "@/contexts/CartContext";
-import { formatPrice } from "@/data/storeProducts";
+import { categoryLabels, formatPrice } from "@/data/storeProducts";
 import { solutionGroupFor, getCartComplements } from "@/data/storeMerchandising";
+import { getProductVisual } from "@/data/productImages";
+import { billingLabel } from "@shared/storeCommerce";
+import {
+  getMissingRequirements,
+  recommendationWhy,
+} from "@/lib/storeSolutionIntelligence";
 import { Link, useLocation } from "wouter";
 import { useToast } from "@/hooks/use-toast";
-import { apiRequest } from "@/lib/queryClient";
 import { CoverageScorePanel } from "@/components/store/CoverageScorePanel";
+import { analytics } from "@/lib/analytics";
+import { CTA } from "@/lib/ctaCopy";
 
 export function ShoppingCart() {
   const {
     items,
+    savedForLater,
     isOpen,
     closeCart,
     removeFromCart,
+    undoRemove,
+    canUndoRemove,
     updateQuantity,
-    getCartTotal,
+    saveForLater,
+    moveToSolution,
     getSavings,
     clearCart,
     addToCart,
+    totals,
+    lastUpdated,
+    announcement,
   } = useCart();
   const [isMinimized, setIsMinimized] = useState(false);
-  const [isCheckingOut, setIsCheckingOut] = useState(false);
+  const prefersReducedMotion = useReducedMotion();
   const { toast } = useToast();
   const [, setLocation] = useLocation();
-
-  const total = getCartTotal();
-  const hasRecurring = items.some((item) => isRecurringPricing(item.product.pricingType));
-  const hasOneTime = items.some((item) => !isRecurringPricing(item.product.pricingType));
-
-  const recurringTotal = items
-    .filter((item) => isRecurringPricing(item.product.pricingType))
-    .reduce(
-      (sum, item) => sum + (item.clientPrice ?? item.product.basePrice) * item.quantity,
-      0
-    );
-
-  const oneTimeTotal = items
-    .filter((item) => !isRecurringPricing(item.product.pricingType))
-    .reduce(
-      (sum, item) => sum + (item.clientPrice ?? item.product.basePrice) * item.quantity,
-      0
-    );
+  const closeRef = useRef<HTMLButtonElement>(null);
+  const returnFocusRef = useRef<HTMLElement | null>(null);
 
   const savings = getSavings();
-
-  const cartProducts = useMemo(() => items.map((i) => i.product), [items]);
+  const cartProducts = useMemo(() => items.map((item) => item.product), [items]);
   const complements = useMemo(() => getCartComplements(cartProducts, { limit: 3 }), [cartProducts]);
+  const missing = useMemo(() => getMissingRequirements(cartProducts), [cartProducts]);
 
   const grouped = useMemo(() => {
     const map = new Map<string, typeof items>();
@@ -74,48 +73,35 @@ export function ShoppingCart() {
     return Array.from(map.entries());
   }, [items]);
 
-  const handleCheckout = async () => {
-    if (items.length === 0) return;
+  useEffect(() => {
+    if (!isOpen) return;
+    returnFocusRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    closeRef.current?.focus();
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") closeCart();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      returnFocusRef.current?.focus();
+    };
+  }, [closeCart, isOpen]);
 
-    setIsCheckingOut(true);
-    try {
-      const lineItems = items.map((item) => ({
-        productId: item.product.id,
-        sku: item.product.sku,
-        name: item.product.name,
-        quantity: item.quantity,
-        unitPrice: item.clientPrice ?? item.product.basePrice,
-        pricingType: item.product.pricingType,
-      }));
-
-      const response = await apiRequest("POST", "/api/store/checkout/zoho", { lineItems });
-      const data = await response.json();
-
-      if (data.url) {
-        window.location.href = data.url;
-      } else if (data.error) {
-        toast({
-          title: "Checkout Error",
-          description: data.error,
-          variant: "destructive",
-        });
-      }
-    } catch (error: any) {
-      console.error("Checkout error:", error);
-      toast({
-        title: "Checkout Failed",
-        description: error.message || "Unable to initiate checkout. Please try again.",
-        variant: "destructive",
-      });
-    } finally {
-      setIsCheckingOut(false);
-    }
-  };
-
-  const goQuote = () => {
+  const goCheckout = () => {
+    analytics.storeCheckoutStarted(totals.dueToday + totals.monthly + totals.annual);
     closeCart();
     setLocation("/store/checkout");
   };
+
+  const goQuote = () => {
+    analytics.storeRequestQuote(totals.dueToday + totals.monthly + totals.annual);
+    closeCart();
+    setLocation("/store/checkout");
+  };
+
+  const lastUpdatedLabel = lastUpdated
+    ? new Date(lastUpdated).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })
+    : null;
 
   return (
     <AnimatePresence>
@@ -125,29 +111,37 @@ export function ShoppingCart() {
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
-            transition={{ duration: 0.2 }}
-            className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm"
+            transition={{ duration: prefersReducedMotion ? 0 : 0.2 }}
+            className="fixed inset-0 z-50 bg-black/60"
             onClick={closeCart}
             data-testid="cart-overlay"
           />
 
           <motion.div
-            initial={{ x: "100%" }}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="solution-drawer-title"
+            initial={prefersReducedMotion ? false : { x: "100%" }}
             animate={{ x: 0, height: isMinimized ? "auto" : "100%" }}
-            exit={{ x: "100%" }}
-            transition={{ type: "spring", damping: 25, stiffness: 300 }}
-            className={`fixed right-0 z-50 flex w-full max-w-md flex-col border-l border-white/10 bg-[#0a0a0a] ${
-              isMinimized ? "bottom-0 top-auto rounded-tl-2xl" : "top-0"
+            exit={prefersReducedMotion ? undefined : { x: "100%" }}
+            transition={
+              prefersReducedMotion ? { duration: 0 } : { type: "spring", damping: 26, stiffness: 320 }
+            }
+            className={`fixed right-0 z-50 flex w-full flex-col border-l border-white/10 bg-[#0a0a0a] sm:max-w-md ${
+              isMinimized ? "bottom-0 top-auto rounded-tl-2xl" : "inset-y-0 max-sm:inset-0"
             }`}
             data-testid="shopping-cart-panel"
           >
-            <div className="flex items-center justify-between border-b border-white/10 p-6">
+            <div className="flex items-center justify-between border-b border-white/10 p-5 sm:p-6">
               <div className="flex items-center gap-3">
                 <Layers className="h-5 w-5 text-de-accent-ink" />
                 <div>
-                  <h2 className="text-xl font-semibold text-white">Your Solution</h2>
+                  <h2 id="solution-drawer-title" className="text-xl font-semibold text-white">
+                    Your Solution
+                  </h2>
                   <span className="text-sm text-white/50">
                     {items.length} service{items.length === 1 ? "" : "s"}
+                    {lastUpdatedLabel ? ` · Updated ${lastUpdatedLabel}` : ""}
                   </span>
                 </div>
               </div>
@@ -156,7 +150,7 @@ export function ShoppingCart() {
                   variant="ghost"
                   size="icon"
                   onClick={() => setIsMinimized(!isMinimized)}
-                  className="text-white/60 hover:bg-de-accent/10 hover:text-white"
+                  className="hidden h-11 w-11 text-white/60 hover:bg-de-accent/10 hover:text-white sm:inline-flex"
                   data-testid="button-minimize-cart"
                   title={isMinimized ? "Expand solution" : "Minimize"}
                 >
@@ -165,10 +159,11 @@ export function ShoppingCart() {
                   />
                 </Button>
                 <Button
+                  ref={closeRef}
                   variant="ghost"
                   size="icon"
                   onClick={closeCart}
-                  className="text-white/60 hover:bg-de-accent/10 hover:text-white"
+                  className="h-11 w-11 text-white/60 hover:bg-de-accent/10 hover:text-white"
                   data-testid="button-close-cart"
                 >
                   <X className="h-5 w-5" />
@@ -176,8 +171,12 @@ export function ShoppingCart() {
               </div>
             </div>
 
+            <div className="sr-only" aria-live="polite">
+              {announcement}
+            </div>
+
             {!isMinimized && (
-              <div className="flex-1 space-y-5 overflow-y-auto p-6">
+              <div className="flex-1 space-y-5 overflow-y-auto p-5 sm:p-6">
                 {items.length === 0 ? (
                   <div className="flex h-full flex-col items-center justify-center text-center">
                     <div className="mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-white/5">
@@ -205,12 +204,41 @@ export function ShoppingCart() {
                       products={cartProducts}
                       onAddSuggestion={(product) => {
                         addToCart(product, Math.max(1, product.minimumQuantity), product.basePrice);
-                        toast({
-                          title: "Added to solution",
-                          description: product.name,
-                        });
+                        toast({ title: "Added to solution", description: product.name });
                       }}
                     />
+
+                    {missing.length > 0 && (
+                      <div
+                        className="rounded-xl border border-amber-400/25 bg-amber-400/5 p-4"
+                        data-testid="solution-missing-requirements"
+                      >
+                        <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-amber-200">
+                          Missing prerequisites
+                        </p>
+                        {missing.map((warning) => (
+                          <div key={`${warning.forSku}-${warning.sku}`} className="mb-2 last:mb-0">
+                            <p className="text-sm text-white/80">{warning.message}</p>
+                            {warning.product && (
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                className="mt-2 h-10 border-white/15 bg-transparent text-white hover:bg-white/5"
+                                onClick={() =>
+                                  addToCart(
+                                    warning.product!,
+                                    Math.max(1, warning.product!.minimumQuantity),
+                                    warning.product!.basePrice,
+                                  )
+                                }
+                              >
+                                Add required item
+                              </Button>
+                            )}
+                          </div>
+                        ))}
+                      </div>
+                    )}
 
                     {grouped.map(([group, groupItems]) => (
                       <div key={group}>
@@ -218,79 +246,147 @@ export function ShoppingCart() {
                           {group}
                         </h3>
                         <div className="space-y-3">
-                          {groupItems.map((item) => (
+                          {groupItems.map((item) => {
+                            const visual = getProductVisual(item.product);
+                            const recurring = isRecurringPricing(item.product.pricingType);
+                            return (
+                              <div
+                                key={item.product.id}
+                                className="rounded-lg border border-white/10 bg-white/[0.03] p-4"
+                                data-testid={`cart-item-${item.product.id}`}
+                              >
+                                <div className="mb-3 flex items-start gap-3">
+                                  <img
+                                    src={visual.logoUrl || visual.cardUrl}
+                                    alt=""
+                                    className="h-12 w-12 shrink-0 rounded-md border border-white/10 bg-white object-contain p-1"
+                                  />
+                                  <div className="min-w-0 flex-1">
+                                    <h4 className="line-clamp-2 font-medium text-white">
+                                      {item.product.name}
+                                    </h4>
+                                    <p className="text-xs text-white/50">
+                                      {categoryLabels[item.product.category]} ·{" "}
+                                      {billingLabel(item.product.pricingType, item.product.pricingUnit)}
+                                    </p>
+                                    <p className="text-sm text-white/50">{formatPrice(item.product)}</p>
+                                  </div>
+                                </div>
+
+                                <div className="flex items-center justify-between gap-2">
+                                  <div className="flex items-center gap-1">
+                                    <Button
+                                      variant="outline"
+                                      size="icon"
+                                      onClick={() => updateQuantity(item.product.id, item.quantity - 1)}
+                                      disabled={item.quantity <= item.product.minimumQuantity}
+                                      className="h-11 w-11 border-de-accent/30 bg-de-accent/10 text-white hover:bg-de-accent/20"
+                                      data-testid={`button-decrease-${item.product.id}`}
+                                      aria-label={`Decrease ${item.product.name}`}
+                                    >
+                                      <Minus className="h-3 w-3" />
+                                    </Button>
+                                    <input
+                                      type="number"
+                                      min={item.product.minimumQuantity}
+                                      value={item.quantity}
+                                      onChange={(event) =>
+                                        updateQuantity(item.product.id, Number(event.target.value))
+                                      }
+                                      className="h-11 w-14 rounded-md border border-white/10 bg-transparent text-center text-sm text-white"
+                                      data-testid={`quantity-${item.product.id}`}
+                                      aria-label={`${item.product.name} quantity`}
+                                    />
+                                    <Button
+                                      variant="outline"
+                                      size="icon"
+                                      onClick={() => updateQuantity(item.product.id, item.quantity + 1)}
+                                      className="h-11 w-11 border-de-accent/30 bg-de-accent/10 text-white hover:bg-de-accent/20"
+                                      data-testid={`button-increase-${item.product.id}`}
+                                      aria-label={`Increase ${item.product.name}`}
+                                    >
+                                      <Plus className="h-3 w-3" />
+                                    </Button>
+                                  </div>
+                                  <span className="text-sm font-semibold text-de-accent-ink">
+                                    $
+                                    {(
+                                      (item.clientPrice ?? item.product.basePrice) * item.quantity
+                                    ).toFixed(2)}
+                                    {recurring
+                                      ? item.product.pricingType === "yearly"
+                                        ? "/yr"
+                                        : "/mo"
+                                      : ""}
+                                  </span>
+                                </div>
+
+                                <div className="mt-3 flex flex-wrap gap-2">
+                                  <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    className="h-10 px-2 text-white/60 hover:text-white"
+                                    onClick={() => saveForLater(item.product.id)}
+                                    data-testid={`button-save-later-${item.product.id}`}
+                                  >
+                                    <BookmarkPlus className="mr-1 h-3.5 w-3.5" />
+                                    Save for later
+                                  </Button>
+                                  <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    onClick={() => removeFromCart(item.product.id)}
+                                    className="h-10 px-2 text-red-300 hover:bg-red-500/10"
+                                    data-testid={`button-remove-${item.product.id}`}
+                                  >
+                                    <Trash2 className="mr-1 h-3.5 w-3.5" />
+                                    Remove
+                                  </Button>
+                                </div>
+                              </div>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    ))}
+
+                    {canUndoRemove && (
+                      <Button
+                        variant="outline"
+                        className="h-11 w-full border-white/15 bg-transparent text-white hover:bg-white/5"
+                        onClick={undoRemove}
+                        data-testid="button-undo-remove"
+                      >
+                        <RotateCcw className="mr-2 h-4 w-4" />
+                        Undo remove
+                      </Button>
+                    )}
+
+                    {savedForLater.length > 0 && (
+                      <div data-testid="saved-for-later">
+                        <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-white/55">
+                          Saved for later
+                        </h3>
+                        <div className="space-y-2">
+                          {savedForLater.map((item) => (
                             <div
                               key={item.product.id}
-                              className="rounded-lg border border-white/10 bg-white/[0.03] p-4"
-                              data-testid={`cart-item-${item.product.id}`}
+                              className="flex items-center justify-between gap-2 rounded-lg border border-white/10 px-3 py-2"
                             >
-                              <div className="mb-3 flex items-start justify-between gap-3">
-                                <div className="min-w-0 flex-1">
-                                  <h4 className="line-clamp-1 font-medium text-white">
-                                    {item.product.name}
-                                  </h4>
-                                  <p className="truncate text-sm text-white/55">
-                                    {item.product.sku}
-                                  </p>
-                                  <p className="text-sm text-white/50">
-                                    {formatPrice(item.product)}
-                                  </p>
-                                </div>
-                                <Button
-                                  variant="ghost"
-                                  size="icon"
-                                  onClick={() => removeFromCart(item.product.id)}
-                                  className="flex-shrink-0 text-red-400 hover:bg-red-500/10 hover:text-red-300"
-                                  data-testid={`button-remove-${item.product.id}`}
-                                >
-                                  <Trash2 className="h-4 w-4" />
-                                </Button>
-                              </div>
-
-                              <div className="flex items-center justify-between">
-                                <div className="flex items-center gap-2">
-                                  <Button
-                                    variant="outline"
-                                    size="icon"
-                                    onClick={() =>
-                                      updateQuantity(item.product.id, item.quantity - 1)
-                                    }
-                                    disabled={item.quantity <= item.product.minimumQuantity}
-                                    className="h-8 w-8 border-de-accent/30 bg-de-accent/10 text-white hover:bg-de-accent/20"
-                                    data-testid={`button-decrease-${item.product.id}`}
-                                  >
-                                    <Minus className="h-3 w-3" />
-                                  </Button>
-                                  <span
-                                    className="w-10 text-center font-medium text-white"
-                                    data-testid={`quantity-${item.product.id}`}
-                                  >
-                                    {item.quantity}
-                                  </span>
-                                  <Button
-                                    variant="outline"
-                                    size="icon"
-                                    onClick={() =>
-                                      updateQuantity(item.product.id, item.quantity + 1)
-                                    }
-                                    className="h-8 w-8 border-de-accent/30 bg-de-accent/10 text-white hover:bg-de-accent/20"
-                                    data-testid={`button-increase-${item.product.id}`}
-                                  >
-                                    <Plus className="h-3 w-3" />
-                                  </Button>
-                                </div>
-                                <span className="font-semibold text-de-accent-ink">
-                                  $
-                                  {(
-                                    (item.clientPrice ?? item.product.basePrice) * item.quantity
-                                  ).toFixed(2)}
-                                </span>
-                              </div>
+                              <p className="truncate text-sm text-white">{item.product.name}</p>
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                className="h-10 border-white/15 bg-transparent text-white hover:bg-white/5"
+                                onClick={() => moveToSolution(item.product.id)}
+                              >
+                                Move to solution
+                              </Button>
                             </div>
                           ))}
                         </div>
                       </div>
-                    ))}
+                    )}
 
                     {complements.length > 0 && (
                       <div
@@ -298,39 +394,38 @@ export function ShoppingCart() {
                         data-testid="cart-complements"
                       >
                         <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-white/55">
-                          Works with your stack
+                          Recommended because
                         </p>
-                        <div className="space-y-2">
-                          {complements.map((product) => (
-                            <div
-                              key={product.sku}
-                              className="flex items-center justify-between gap-2"
-                            >
-                              <div className="min-w-0">
-                                <p className="truncate text-sm text-white">{product.name}</p>
-                                <p className="text-xs text-white/55">{formatPrice(product)}</p>
+                        <div className="space-y-3">
+                          {complements.map((product) => {
+                            const why = recommendationWhy(product, cartProducts);
+                            return (
+                              <div key={product.sku} className="flex items-start justify-between gap-2">
+                                <div className="min-w-0">
+                                  <p className="truncate text-sm text-white">{product.name}</p>
+                                  <p className="text-xs text-white/55">{why}</p>
+                                  <p className="text-xs text-white/45">{formatPrice(product)}</p>
+                                </div>
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  className="h-10 shrink-0 border-white/15 bg-transparent text-xs text-white hover:bg-white/5"
+                                  onClick={() => {
+                                    addToCart(
+                                      product,
+                                      Math.max(1, product.minimumQuantity),
+                                      product.basePrice,
+                                    );
+                                    analytics.storeAcceptRecommendation(product.name, why);
+                                    toast({ title: "Added to solution", description: product.name });
+                                  }}
+                                  data-testid={`button-complement-${product.id}`}
+                                >
+                                  Add
+                                </Button>
                               </div>
-                              <Button
-                                size="sm"
-                                variant="outline"
-                                className="h-8 shrink-0 border-white/15 bg-transparent text-xs text-white hover:bg-white/5"
-                                onClick={() => {
-                                  addToCart(
-                                    product,
-                                    Math.max(1, product.minimumQuantity),
-                                    product.basePrice
-                                  );
-                                  toast({
-                                    title: "Added to solution",
-                                    description: product.name,
-                                  });
-                                }}
-                                data-testid={`button-complement-${product.id}`}
-                              >
-                                Add
-                              </Button>
-                            </div>
-                          ))}
+                            );
+                          })}
                         </div>
                       </div>
                     )}
@@ -352,77 +447,89 @@ export function ShoppingCart() {
             )}
 
             {items.length > 0 && (
-              <div className="border-t border-white/10 bg-white/[0.02] p-6">
+              <div className="border-t border-white/10 bg-white/[0.02] p-5 sm:p-6">
                 <div className="mb-4 space-y-2">
-                  {hasRecurring && (
+                  {totals.dueToday > 0 && (
                     <div className="flex items-center justify-between text-sm">
-                      <span className="text-white/60">Recurring</span>
-                      <span className="text-white">${recurringTotal.toFixed(2)}/mo</span>
+                      <span className="text-white/60">Due today</span>
+                      <span className="text-white">${totals.dueToday.toFixed(2)}</span>
                     </div>
                   )}
-                  {hasOneTime && (
+                  {totals.monthly > 0 && (
                     <div className="flex items-center justify-between text-sm">
-                      <span className="text-white/60">One-time</span>
-                      <span className="text-white">${oneTimeTotal.toFixed(2)}</span>
+                      <span className="text-white/60">Monthly</span>
+                      <span className="text-white">${totals.monthly.toFixed(2)}/mo</span>
+                    </div>
+                  )}
+                  {totals.annual > 0 && (
+                    <div className="flex items-center justify-between text-sm">
+                      <span className="text-white/60">Annual</span>
+                      <span className="text-white">${totals.annual.toFixed(2)}/yr</span>
                     </div>
                   )}
                   {savings > 0 && (
                     <div className="flex items-center justify-between text-sm">
-                      <span className="text-emerald-400">You save</span>
+                      <span className="text-emerald-400">Client pricing save</span>
                       <span className="font-medium text-emerald-400">-${savings.toFixed(2)}</span>
                     </div>
                   )}
                   <div className="flex items-center justify-between border-t border-white/10 pt-2">
-                    <span className="font-medium text-white">Solution total</span>
-                    <span className="text-lg font-bold text-de-accent-ink">${total.toFixed(2)}</span>
+                    <span className="font-medium text-white">Ongoing equivalent</span>
+                    <span className="text-lg font-bold text-de-accent-ink">
+                      ${totals.recurringMonthlyEquivalent.toFixed(2)}/mo
+                    </span>
                   </div>
+                  <p className="flex items-start gap-1.5 text-xs text-white/45">
+                    <Clock className="mt-0.5 h-3 w-3 shrink-0" />
+                    Recurring services bill on the start date after kickoff. One-time work is due
+                    when the order is placed. Tax is calculated at checkout when applicable.
+                  </p>
                 </div>
 
                 <div className="space-y-2.5">
                   <Button
-                    className="w-full bg-de-accent text-white hover:bg-[#6548ff] disabled:opacity-50"
-                    onClick={handleCheckout}
-                    disabled={isCheckingOut}
+                    className="h-12 w-full bg-de-accent text-white hover:bg-[#6548ff]"
+                    onClick={goCheckout}
                     data-testid="button-checkout"
                   >
-                    {isCheckingOut ? (
-                      <>
-                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                        Processing...
-                      </>
-                    ) : (
-                      <>
-                        <CreditCard className="mr-2 h-4 w-4" />
-                        Checkout
-                        <ArrowRight className="ml-2 h-4 w-4" />
-                      </>
-                    )}
+                    Continue to Checkout
+                    <ArrowRight className="ml-2 h-4 w-4" />
                   </Button>
                   <Button
                     variant="outline"
-                    className="w-full border-white/15 bg-transparent text-white hover:bg-white/5"
+                    className="h-11 w-full border-white/15 bg-transparent text-white hover:bg-white/5"
                     onClick={goQuote}
                     data-testid="button-save-quote"
                   >
                     <FileText className="mr-2 h-4 w-4" />
-                    Save / email quote
+                    Request Formal Quote
                   </Button>
-                  <Button
-                    asChild
-                    variant="ghost"
-                    className="w-full text-white/70 hover:bg-de-accent/10 hover:text-white"
-                    onClick={closeCart}
-                    data-testid="button-schedule-from-cart"
-                  >
-                    <a href="/book" className="block">
-                      <Calendar className="mr-2 h-4 w-4" />
-                      Schedule consultation
-                    </a>
-                  </Button>
+                  <div className="grid grid-cols-2 gap-2">
+                    <Button
+                      variant="ghost"
+                      className="h-11 text-white/70 hover:bg-white/5 hover:text-white"
+                      onClick={closeCart}
+                      data-testid="button-continue-shopping"
+                    >
+                      Continue shopping
+                    </Button>
+                    <Button
+                      asChild
+                      variant="ghost"
+                      className="h-11 text-white/70 hover:bg-de-accent/10 hover:text-white"
+                      onClick={closeCart}
+                      data-testid="button-schedule-from-cart"
+                    >
+                      <a href="/book">
+                        <Calendar className="mr-1 h-4 w-4" />
+                        {CTA.primaryShort}
+                      </a>
+                    </Button>
+                  </div>
                   <Button
                     variant="ghost"
                     onClick={clearCart}
-                    className="w-full text-white/50 hover:bg-white/5 hover:text-white"
+                    className="h-10 w-full text-white/50 hover:bg-white/5 hover:text-white"
                     data-testid="button-clear-cart"
                   >
                     Clear solution

--- a/client/src/components/store/SolutionMobileBar.tsx
+++ b/client/src/components/store/SolutionMobileBar.tsx
@@ -1,0 +1,41 @@
+import { useLocation } from "wouter";
+import { Button } from "@/components/ui/button";
+import { useCart } from "@/contexts/CartContext";
+
+/**
+ * Thumb-reach solution summary on /store only — does not replace the marketing sticky CTA.
+ */
+export function SolutionMobileBar() {
+  const [location] = useLocation();
+  const { items, totals, openCart, isOpen } = useCart();
+
+  if (!location.startsWith("/store") || isOpen || items.length === 0) return null;
+
+  const monthly = totals.monthly > 0 ? `$${totals.monthly.toFixed(0)}/mo` : null;
+  const today = totals.dueToday > 0 ? `$${totals.dueToday.toFixed(0)} today` : null;
+  const summary = [monthly, today].filter(Boolean).join(" + ") || "View solution";
+
+  return (
+    <div
+      className="fixed inset-x-0 bottom-[4.75rem] z-40 px-3 sm:hidden"
+      data-testid="solution-mobile-bar"
+    >
+      <div className="mx-auto flex max-w-lg items-center gap-3 rounded-xl border border-white/10 bg-[#0a0a0a]/95 px-3 py-2.5 shadow-[0_12px_40px_rgba(0,0,0,0.45)]">
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium text-white">{summary}</p>
+          <p className="text-xs text-white/55">
+            {items.length} service{items.length === 1 ? "" : "s"} in your solution
+          </p>
+        </div>
+        <Button
+          type="button"
+          className="h-11 shrink-0 bg-de-accent px-4 text-white hover:bg-[#6548ff]"
+          onClick={openCart}
+          data-testid="button-mobile-view-solution"
+        >
+          View Solution
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/store/StoreAssessmentPanel.tsx
+++ b/client/src/components/store/StoreAssessmentPanel.tsx
@@ -2,6 +2,7 @@ import { Link } from "wouter";
 import { ArrowRight, Calendar, ClipboardList, MessageCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { openMspAdvisor } from "@/lib/openMspAdvisor";
+import { CTA } from "@/lib/ctaCopy";
 
 interface StoreAssessmentPanelProps {
   variant?: "sticky" | "inline";
@@ -32,12 +33,13 @@ export function StoreAssessmentPanel({
         </p>
         <div className="mt-4 flex flex-col gap-2">
           <Button asChild
-              className="h-10 w-full bg-de-accent text-white hover:bg-[#6548ff]"
+              variant="brand"
+              className="h-10 w-full"
               data-testid="button-assessment-book"
             >
                   <a href="/book">
                     <Calendar className="mr-2 h-4 w-4" />
-              Book assessment
+              {CTA.primaryShort}
                   </a>
                 </Button>
           {onFilterAssessments && (

--- a/client/src/components/store/StoreClientBar.tsx
+++ b/client/src/components/store/StoreClientBar.tsx
@@ -1,0 +1,57 @@
+import { LogOut, User } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { CartButton } from "@/components/store/CartButton";
+import { useStoreAuth } from "@/hooks/useStoreAuth";
+
+/**
+ * Quiet store utility row. Electric stays the store accent;
+ * the button is outline so it does not compete with hero CTAs.
+ */
+export function StoreClientBar() {
+  const { isLoggedIn, user, clientType, logout, loginRedirect } = useStoreAuth();
+
+  return (
+    <div className="mb-6 flex items-center justify-between gap-3">
+      {isLoggedIn && user ? (
+        <div className="flex min-w-0 items-center gap-2 sm:gap-3">
+          <div className="flex min-w-0 items-center gap-2 rounded-lg border border-de-accent/20 bg-de-accent/10 px-3 py-2">
+            <User className="h-4 w-4 shrink-0 text-de-accent-ink" />
+            <span className="truncate text-sm text-white" data-testid="text-user-greeting">
+              Welcome,{" "}
+              <span className="font-semibold text-de-accent-ink">{user.fullName || user.username}</span>
+            </span>
+            {clientType !== "public" && (
+              <span className="ml-1 hidden rounded-full bg-de-accent/20 px-2 py-0.5 text-xs font-medium text-de-accent-ink sm:inline">
+                {clientType === "managed" ? "Managed Client" : "Co-Managed Client"}
+              </span>
+            )}
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={logout}
+            className="shrink-0 text-white/60 hover:bg-de-accent/10 hover:text-white"
+            data-testid="button-store-logout"
+          >
+            <LogOut className="mr-1 h-4 w-4" />
+            <span className="hidden sm:inline">Logout</span>
+          </Button>
+        </div>
+      ) : (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={loginRedirect}
+          className="h-11 border-de-accent/40 bg-transparent px-3 text-sm text-de-accent-ink hover:border-de-accent hover:bg-de-accent/10 sm:px-4 sm:text-base"
+          data-testid="button-store-login"
+        >
+          <User className="mr-2 h-4 w-4" />
+          <span className="sm:hidden">Client login</span>
+          <span className="hidden sm:inline">Login for Client Pricing</span>
+        </Button>
+      )}
+      <CartButton />
+    </div>
+  );
+}

--- a/client/src/components/store/StorePageAtmosphere.tsx
+++ b/client/src/components/store/StorePageAtmosphere.tsx
@@ -1,0 +1,46 @@
+import { useRef } from "react";
+import { motion, useReducedMotion, useScroll, useTransform } from "framer-motion";
+import atmosphere from "@assets/de-section-atmosphere.png";
+
+/**
+ * Store field depth — electric lighting only (store accent lock).
+ * Parallax is a few percent of travel and stops for reduced motion.
+ */
+export function StorePageAtmosphere() {
+  const ref = useRef<HTMLDivElement>(null);
+  const prefersReducedMotion = useReducedMotion();
+  const { scrollYProgress } = useScroll({
+    target: ref,
+    offset: ["start start", "end start"],
+  });
+  const y = useTransform(scrollYProgress, [0, 1], prefersReducedMotion ? ["0%", "0%"] : ["0%", "9%"]);
+
+  return (
+    <div
+      ref={ref}
+      className="pointer-events-none absolute inset-0 overflow-hidden"
+      aria-hidden="true"
+    >
+      <motion.img
+        src={atmosphere}
+        alt=""
+        className="absolute inset-x-0 top-0 h-[70vh] min-h-[28rem] w-full object-cover object-center"
+        style={{ y, opacity: 0.32 }}
+      />
+      <div
+        className="absolute inset-0"
+        style={{
+          background:
+            "linear-gradient(180deg, rgba(10,10,10,0.35) 0%, rgba(10,10,10,0.72) 42%, #0a0a0a 78%), linear-gradient(90deg, rgba(10,10,10,0.55) 0%, rgba(10,10,10,0.12) 48%, rgba(10,10,10,0.45) 100%)",
+        }}
+      />
+      <div
+        className="absolute -right-[12%] top-[8%] h-[28rem] w-[28rem]"
+        style={{
+          background:
+            "radial-gradient(circle at 60% 40%, rgba(29, 111, 242, 0.16) 0%, rgba(29, 111, 242, 0.04) 42%, transparent 68%)",
+        }}
+      />
+    </div>
+  );
+}

--- a/client/src/components/store/StorePageAtmosphere.tsx
+++ b/client/src/components/store/StorePageAtmosphere.tsx
@@ -13,7 +13,16 @@ export function StorePageAtmosphere() {
     target: ref,
     offset: ["start start", "end start"],
   });
-  const y = useTransform(scrollYProgress, [0, 1], prefersReducedMotion ? ["0%", "0%"] : ["0%", "9%"]);
+  const y = useTransform(
+    scrollYProgress,
+    [0, 1],
+    prefersReducedMotion ? ["0%", "0%"] : ["0%", "8%"],
+  );
+  const bloomY = useTransform(
+    scrollYProgress,
+    [0, 1],
+    prefersReducedMotion ? ["0%", "0%"] : ["0%", "14%"],
+  );
 
   return (
     <div
@@ -24,21 +33,22 @@ export function StorePageAtmosphere() {
       <motion.img
         src={atmosphere}
         alt=""
-        className="absolute inset-x-0 top-0 h-[70vh] min-h-[28rem] w-full object-cover object-center"
-        style={{ y, opacity: 0.32 }}
+        className="absolute inset-x-0 top-0 h-[78vh] min-h-[32rem] w-full object-cover object-center"
+        style={{ y, opacity: 0.44 }}
       />
       <div
         className="absolute inset-0"
         style={{
           background:
-            "linear-gradient(180deg, rgba(10,10,10,0.35) 0%, rgba(10,10,10,0.72) 42%, #0a0a0a 78%), linear-gradient(90deg, rgba(10,10,10,0.55) 0%, rgba(10,10,10,0.12) 48%, rgba(10,10,10,0.45) 100%)",
+            "linear-gradient(180deg, rgba(10,10,10,0.18) 0%, rgba(10,10,10,0.52) 46%, #0a0a0a 84%), linear-gradient(90deg, rgba(10,10,10,0.38) 0%, rgba(10,10,10,0.08) 50%, rgba(10,10,10,0.34) 100%)",
         }}
       />
-      <div
-        className="absolute -right-[12%] top-[8%] h-[28rem] w-[28rem]"
+      <motion.div
+        className="absolute -right-[12%] top-[6%] h-[30rem] w-[30rem]"
         style={{
+          y: bloomY,
           background:
-            "radial-gradient(circle at 60% 40%, rgba(29, 111, 242, 0.16) 0%, rgba(29, 111, 242, 0.04) 42%, transparent 68%)",
+            "radial-gradient(circle at 60% 40%, rgba(29, 111, 242, 0.2) 0%, rgba(29, 111, 242, 0.05) 42%, transparent 68%)",
         }}
       />
     </div>

--- a/client/src/contexts/CartContext.tsx
+++ b/client/src/contexts/CartContext.tsx
@@ -1,5 +1,16 @@
-import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from "react";
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+  useRef,
+  type ReactNode,
+} from "react";
 import type { StoreProduct, PricingType } from "@/data/storeProducts";
+import { storeProducts } from "@/data/storeProducts";
+import { computeSolutionSnapshot, type SolutionTotals } from "@shared/storeCommerce";
+import { analytics } from "@/lib/analytics";
 
 export interface CartItem {
   product: StoreProduct;
@@ -17,14 +28,23 @@ interface ClientPricing {
 
 interface CartContextType {
   items: CartItem[];
+  savedForLater: CartItem[];
   addToCart: (product: StoreProduct, quantity?: number, clientPrice?: number) => void;
   removeFromCart: (productId: string) => void;
+  undoRemove: () => void;
+  canUndoRemove: boolean;
   updateQuantity: (productId: string, quantity: number) => void;
+  saveForLater: (productId: string) => void;
+  moveToSolution: (productId: string) => void;
   clearCart: () => void;
   getCartTotal: () => number;
   getOriginalTotal: () => number;
   getSavings: () => number;
   getItemCount: () => number;
+  totals: SolutionTotals;
+  lastUpdated: string | null;
+  solutionId: string | null;
+  announcement: string;
   isOpen: boolean;
   openCart: () => void;
   closeCart: () => void;
@@ -36,65 +56,212 @@ interface CartContextType {
 const CartContext = createContext<CartContextType | undefined>(undefined);
 
 const CART_STORAGE_KEY = "digerati-store-cart";
+const SESSION_KEY = "digerati-store-session";
+const SAVED_KEY = "digerati-store-saved";
 
 const isRecurringPricing = (pricingType: PricingType): boolean => {
   return ["monthly", "yearly", "per_user", "per_endpoint", "per_device", "per_location", "per_seat"].includes(pricingType);
 };
 
+function readOrCreateSessionId(): string {
+  try {
+    const existing = localStorage.getItem(SESSION_KEY);
+    if (existing) return existing;
+    const created = crypto.randomUUID();
+    localStorage.setItem(SESSION_KEY, created);
+    return created;
+  } catch {
+    return `anon-${Date.now()}`;
+  }
+}
+
+function migrateItems(parsed: unknown): CartItem[] {
+  if (!Array.isArray(parsed)) return [];
+  return parsed
+    .map((item: any) => {
+      const product = storeProducts.find((candidate) => candidate.id === item?.product?.id);
+      if (!product) return null;
+      return {
+        product,
+        quantity: Math.max(product.minimumQuantity, Number(item.quantity) || product.minimumQuantity),
+        originalPrice: item.originalPrice ?? product.basePrice,
+        hasClientDiscount: item.hasClientDiscount ?? false,
+        clientPrice: item.clientPrice,
+      } satisfies CartItem;
+    })
+    .filter((item): item is CartItem => !!item);
+}
+
+function snapshotFromItems(items: CartItem[]): SolutionTotals {
+  return computeSolutionSnapshot(
+    items.map((item) => ({ productId: item.product.id, sku: item.product.sku, quantity: item.quantity })),
+    storeProducts,
+  ).totals;
+}
+
 export function CartProvider({ children }: { children: ReactNode }) {
   const [items, setItems] = useState<CartItem[]>([]);
+  const [savedForLater, setSavedForLater] = useState<CartItem[]>([]);
   const [isOpen, setIsOpen] = useState(false);
   const [clientPricingMap, setClientPricingMap] = useState<Map<string, ClientPricing>>(new Map());
+  const [lastRemoved, setLastRemoved] = useState<CartItem | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<string | null>(null);
+  const [solutionId, setSolutionId] = useState<string | null>(null);
+  const [announcement, setAnnouncement] = useState("");
+  const [syncReady, setSyncReady] = useState(false);
+  const sessionIdRef = useRef("");
+  const solutionIdRef = useRef<string | null>(null);
+  const hydratedRef = useRef(false);
+  const persistTimer = useRef<number | null>(null);
+  const lastTokenRef = useRef<string | null>(null);
 
-  useEffect(() => {
-    try {
-      const stored = localStorage.getItem(CART_STORAGE_KEY);
-      if (stored) {
-        const parsed = JSON.parse(stored);
-        if (Array.isArray(parsed)) {
-          const migratedItems = parsed.map((item: any) => ({
-            ...item,
-            originalPrice: item.originalPrice ?? item.product.basePrice,
-            hasClientDiscount: item.hasClientDiscount ?? false,
-          }));
-          setItems(migratedItems);
-        }
-      }
-    } catch (e) {
-      console.error("Failed to load cart from localStorage:", e);
-    }
+  const announce = useCallback((message: string) => {
+    setAnnouncement(message);
   }, []);
 
   useEffect(() => {
+    sessionIdRef.current = readOrCreateSessionId();
+    try {
+      setItems(migrateItems(JSON.parse(localStorage.getItem(CART_STORAGE_KEY) || "[]")));
+      setSavedForLater(migrateItems(JSON.parse(localStorage.getItem(SAVED_KEY) || "[]")));
+    } catch (error) {
+      console.error("Failed to load solution from localStorage:", error);
+    }
+
+    const sessionId = sessionIdRef.current;
+    void fetch(`/api/store/solutions/current?sessionId=${encodeURIComponent(sessionId)}`, {
+      credentials: "include",
+      headers: (() => {
+        const headers: Record<string, string> = {};
+        const token = localStorage.getItem("portalToken");
+        if (token) headers.Authorization = `Bearer ${token}`;
+        return headers;
+      })(),
+    })
+      .then((response) => (response.ok ? response.json() : null))
+      .then((payload) => {
+        const remote = payload?.solution;
+        if (!remote?.items) return;
+        setSolutionId(remote.id);
+        solutionIdRef.current = remote.id;
+        setLastUpdated(remote.updatedAt || new Date().toISOString());
+        setItems((local) => {
+          if (local.length === 0 && Array.isArray(remote.items) && remote.items.length > 0) {
+            return migrateItems(
+              remote.items.map((line: { productId: string; quantity: number }) => ({
+                product: storeProducts.find((product) => product.id === line.productId),
+                quantity: line.quantity,
+              })),
+            );
+          }
+          return local;
+        });
+      })
+      .catch(() => {
+        /* localStorage remains the offline cache */
+      })
+      .finally(() => {
+        hydratedRef.current = true;
+        setSyncReady(true);
+      });
+  }, []);
+
+  useEffect(() => {
+    if (!hydratedRef.current && items.length === 0) return;
     try {
       localStorage.setItem(CART_STORAGE_KEY, JSON.stringify(items));
-    } catch (e) {
-      console.error("Failed to save cart to localStorage:", e);
+      localStorage.setItem(SAVED_KEY, JSON.stringify(savedForLater));
+    } catch (error) {
+      console.error("Failed to save solution locally:", error);
     }
-  }, [items]);
+  }, [items, savedForLater]);
+
+  const persistRemote = useCallback((nextItems: CartItem[], nextSaved: CartItem[]) => {
+    if (!hydratedRef.current || !sessionIdRef.current) return;
+    if (persistTimer.current) window.clearTimeout(persistTimer.current);
+    persistTimer.current = window.setTimeout(() => {
+      const token = localStorage.getItem("portalToken");
+      void fetch("/api/store/solutions/current", {
+        method: "PUT",
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({
+          id: solutionIdRef.current,
+          sessionId: sessionIdRef.current,
+          items: nextItems.map((item) => ({
+            productId: item.product.id,
+            sku: item.product.sku,
+            quantity: item.quantity,
+          })),
+          savedForLater: nextSaved.map((item) => ({
+            productId: item.product.id,
+            sku: item.product.sku,
+            quantity: item.quantity,
+          })),
+        }),
+      })
+        .then((response) => (response.ok ? response.json() : null))
+        .then((payload) => {
+          if (payload?.solution?.id) {
+            setSolutionId(payload.solution.id);
+            solutionIdRef.current = payload.solution.id;
+          }
+          setLastUpdated(payload?.solution?.updatedAt || new Date().toISOString());
+        })
+        .catch(() => {
+          setLastUpdated(new Date().toISOString());
+        });
+    }, 400);
+  }, []);
+
+  useEffect(() => {
+    if (!syncReady) return;
+    persistRemote(items, savedForLater);
+  }, [items, savedForLater, persistRemote, syncReady]);
+
+  useEffect(() => {
+    const claimIfLoggedIn = () => {
+      const token = localStorage.getItem("portalToken");
+      if (!token || token === lastTokenRef.current || !sessionIdRef.current) return;
+      lastTokenRef.current = token;
+      void fetch("/api/store/solutions/claim", {
+        method: "POST",
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ sessionId: sessionIdRef.current }),
+      }).catch(() => {
+        /* guest solution stays local until auth is valid */
+      });
+    };
+    claimIfLoggedIn();
+    window.addEventListener("storage", claimIfLoggedIn);
+    return () => window.removeEventListener("storage", claimIfLoggedIn);
+  }, []);
 
   const setClientPricing = useCallback((pricing: ClientPricing[]) => {
     const map = new Map<string, ClientPricing>();
-    pricing.forEach((p) => map.set(p.productId, p));
+    pricing.forEach((entry) => map.set(entry.productId, entry));
     setClientPricingMap(map);
   }, []);
 
   const getItemPrice = useCallback(
     (productId: string): { price: number; hasDiscount: boolean } => {
       const pricing = clientPricingMap.get(productId);
-      if (pricing) {
-        return { price: pricing.customPrice, hasDiscount: true };
-      }
-      const item = items.find((i) => i.product.id === productId);
+      if (pricing) return { price: pricing.customPrice, hasDiscount: true };
+      const item = items.find((entry) => entry.product.id === productId);
       return { price: item?.product.basePrice || 0, hasDiscount: false };
     },
-    [clientPricingMap, items]
+    [clientPricingMap, items],
   );
 
   const addToCart = useCallback((product: StoreProduct, quantity: number = 1, clientPrice?: number) => {
-    if (product.isContractOnly || !product.isCheckoutEnabled) {
-      return;
-    }
+    if (product.isContractOnly || !product.isCheckoutEnabled) return;
 
     const pricing = clientPricingMap.get(product.id);
     const effectiveClientPrice = clientPrice ?? pricing?.customPrice;
@@ -105,44 +272,94 @@ export function CartProvider({ children }: { children: ReactNode }) {
       if (existing) {
         return prev.map((item) =>
           item.product.id === product.id
-            ? { 
-                ...item, 
+            ? {
+                ...item,
                 quantity: item.quantity + quantity,
                 clientPrice: effectiveClientPrice,
                 hasClientDiscount: hasDiscount,
               }
-            : item
+            : item,
         );
       }
-      return [...prev, { 
-        product, 
-        quantity: Math.max(quantity, product.minimumQuantity),
-        clientPrice: effectiveClientPrice,
-        originalPrice: product.basePrice,
-        hasClientDiscount: hasDiscount,
-      }];
+      return [
+        ...prev,
+        {
+          product,
+          quantity: Math.max(quantity, product.minimumQuantity),
+          clientPrice: effectiveClientPrice,
+          originalPrice: product.basePrice,
+          hasClientDiscount: hasDiscount,
+        },
+      ];
     });
-  }, [clientPricingMap]);
+    setSavedForLater((prev) => prev.filter((item) => item.product.id !== product.id));
+    announce(`${product.name} added to your solution`);
+    analytics.storeAddToCart(product.name, product.basePrice, product.id);
+  }, [announce, clientPricingMap]);
 
   const removeFromCart = useCallback((productId: string) => {
-    setItems((prev) => prev.filter((item) => item.product.id !== productId));
-  }, []);
+    setItems((prev) => {
+      const removed = prev.find((item) => item.product.id === productId) || null;
+      setLastRemoved(removed);
+      if (removed) {
+        announce(`${removed.product.name} removed. Undo available.`);
+        analytics.storeRemoveFromCart(removed.product.name, removed.product.id);
+      }
+      return prev.filter((item) => item.product.id !== productId);
+    });
+  }, [announce]);
+
+  const undoRemove = useCallback(() => {
+    if (!lastRemoved) return;
+    setItems((prev) => {
+      if (prev.some((item) => item.product.id === lastRemoved.product.id)) return prev;
+      return [...prev, lastRemoved];
+    });
+    announce(`${lastRemoved.product.name} restored`);
+    setLastRemoved(null);
+  }, [announce, lastRemoved]);
 
   const updateQuantity = useCallback((productId: string, quantity: number) => {
     setItems((prev) =>
       prev.map((item) => {
-        if (item.product.id === productId) {
-          const newQty = Math.max(quantity, item.product.minimumQuantity);
-          return { ...item, quantity: newQty };
-        }
-        return item;
-      })
+        if (item.product.id !== productId) return item;
+        const next = Number.isFinite(quantity) ? quantity : item.quantity;
+        return { ...item, quantity: Math.max(next, item.product.minimumQuantity) };
+      }),
     );
   }, []);
 
+  const saveForLater = useCallback((productId: string) => {
+    setItems((prev) => {
+      const item = prev.find((entry) => entry.product.id === productId);
+      if (item) {
+        setSavedForLater((saved) =>
+          saved.some((entry) => entry.product.id === productId) ? saved : [...saved, item],
+        );
+        announce(`${item.product.name} saved for later`);
+      }
+      return prev.filter((entry) => entry.product.id !== productId);
+    });
+  }, [announce]);
+
+  const moveToSolution = useCallback((productId: string) => {
+    setSavedForLater((prev) => {
+      const item = prev.find((entry) => entry.product.id === productId);
+      if (item) {
+        setItems((current) =>
+          current.some((entry) => entry.product.id === productId) ? current : [...current, item],
+        );
+        announce(`${item.product.name} moved back to your solution`);
+      }
+      return prev.filter((entry) => entry.product.id !== productId);
+    });
+  }, [announce]);
+
   const clearCart = useCallback(() => {
     setItems([]);
-  }, []);
+    setLastRemoved(null);
+    announce("Solution cleared");
+  }, [announce]);
 
   const getCartTotal = useCallback(() => {
     return items.reduce((total, item) => {
@@ -152,35 +369,51 @@ export function CartProvider({ children }: { children: ReactNode }) {
   }, [items]);
 
   const getOriginalTotal = useCallback(() => {
-    return items.reduce((total, item) => {
-      return total + item.originalPrice * item.quantity;
-    }, 0);
+    return items.reduce((total, item) => total + item.originalPrice * item.quantity, 0);
   }, [items]);
 
-  const getSavings = useCallback(() => {
-    return getOriginalTotal() - getCartTotal();
-  }, [getOriginalTotal, getCartTotal]);
+  const getSavings = useCallback(() => getOriginalTotal() - getCartTotal(), [getOriginalTotal, getCartTotal]);
 
-  const getItemCount = useCallback(() => {
-    return items.reduce((count, item) => count + item.quantity, 0);
-  }, [items]);
+  const getItemCount = useCallback(
+    () => items.reduce((count, item) => count + item.quantity, 0),
+    [items],
+  );
 
-  const openCart = useCallback(() => setIsOpen(true), []);
+  const totals = snapshotFromItems(items);
+
+  const openCart = useCallback(() => {
+    setIsOpen(true);
+    analytics.storeViewCart(getCartTotal(), getItemCount());
+  }, [getCartTotal, getItemCount]);
   const closeCart = useCallback(() => setIsOpen(false), []);
-  const toggleCart = useCallback(() => setIsOpen((prev) => !prev), []);
+  const toggleCart = useCallback(() => {
+    setIsOpen((prev) => {
+      if (!prev) analytics.storeViewCart(getCartTotal(), getItemCount());
+      return !prev;
+    });
+  }, [getCartTotal, getItemCount]);
 
   return (
     <CartContext.Provider
       value={{
         items,
+        savedForLater,
         addToCart,
         removeFromCart,
+        undoRemove,
+        canUndoRemove: !!lastRemoved,
         updateQuantity,
+        saveForLater,
+        moveToSolution,
         clearCart,
         getCartTotal,
         getOriginalTotal,
         getSavings,
         getItemCount,
+        totals,
+        lastUpdated,
+        solutionId,
+        announcement,
         isOpen,
         openCart,
         closeCart,

--- a/client/src/lib/analytics.ts
+++ b/client/src/lib/analytics.ts
@@ -320,6 +320,34 @@ export const analytics = {
     });
   },
 
+  storeRemoveFromCart(productName: string, productId: string) {
+    track("remove_from_cart", {
+      item_id: productId,
+      item_name: productName,
+      event_category: "ecommerce",
+    });
+  },
+
+  storeViewCart(value: number, itemCount: number) {
+    track("view_cart", { currency: "USD", value, item_count: itemCount, event_category: "ecommerce" });
+  },
+
+  storeRequestQuote(value: number) {
+    track("request_quote", { currency: "USD", value, event_category: "ecommerce" });
+  },
+
+  storeAcceptRecommendation(productName: string, reason: string) {
+    track("accept_recommendation", {
+      item_name: productName,
+      reason,
+      event_category: "ecommerce",
+    });
+  },
+
+  storeCoverageGapViewed(label: string) {
+    track("coverage_gap_viewed", { coverage_label: label, event_category: "ecommerce" });
+  },
+
   storeCheckoutStarted(value: number) {
     trackMarketing("begin_checkout", "InitiateCheckout", {
       currency: "USD",

--- a/client/src/lib/storeSolutionIntelligence.ts
+++ b/client/src/lib/storeSolutionIntelligence.ts
@@ -1,0 +1,46 @@
+import type { StoreProduct } from "@/data/storeProducts";
+import { getProductBySku, getProductRelationships } from "@/data/storeMerchandising";
+
+export type SolutionWarning = {
+  sku: string;
+  product?: StoreProduct;
+  forSku: string;
+  forName: string;
+  message: string;
+};
+
+export function getMissingRequirements(products: StoreProduct[]): SolutionWarning[] {
+  const inCart = new Set(products.map((product) => product.sku));
+  const warnings: SolutionWarning[] = [];
+  for (const product of products) {
+    const required = getProductRelationships(product.sku)?.required || [];
+    for (const sku of required) {
+      if (inCart.has(sku)) continue;
+      const requiredProduct = getProductBySku(sku);
+      warnings.push({
+        sku,
+        product: requiredProduct,
+        forSku: product.sku,
+        forName: product.name,
+        message: `${requiredProduct?.name || sku} is a prerequisite for ${product.name}.`,
+      });
+    }
+  }
+  return warnings;
+}
+
+export function recommendationWhy(candidate: StoreProduct, cart: StoreProduct[]): string {
+  for (const item of cart) {
+    const rel = getProductRelationships(item.sku);
+    if (rel?.required?.includes(candidate.sku)) {
+      return `Required by ${item.name} — not added automatically.`;
+    }
+    if (rel?.upgradeTo?.includes(candidate.sku)) {
+      return `Upgrade path from ${item.name}.`;
+    }
+    if (rel?.worksWith?.includes(candidate.sku)) {
+      return `Commonly paired with ${item.name}.`;
+    }
+  }
+  return "Closes a detected coverage gap in this solution.";
+}

--- a/client/src/pages/store/CoManagedStore.tsx
+++ b/client/src/pages/store/CoManagedStore.tsx
@@ -586,9 +586,9 @@ const CoManagedStore = () => {
               Shop by outcome, build a recommended stack with Ask Digerati, then buy from the live
               catalog when you know what you need.
             </p>
-            <div className="mt-6 flex flex-wrap gap-3">
+            <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
               <Button
-                className="h-12 bg-de-accent px-6 text-base text-white hover:bg-[#6548ff]"
+                className="h-12 w-full bg-de-accent px-6 text-base text-white hover:bg-[#6548ff] sm:w-auto"
                 onClick={() => setGuidedOpen(true)}
                 data-testid="button-build-solution"
               >
@@ -597,7 +597,7 @@ const CoManagedStore = () => {
               </Button>
               <Button
                 variant="outline"
-                className="h-12 border-white/20 bg-transparent px-6 text-base text-white hover:bg-white/5"
+                className="h-12 w-full border-white/20 bg-transparent px-6 text-base text-white hover:bg-white/5 sm:w-auto"
                 onClick={() => openMspAdvisor({ context: "store" })}
                 data-testid="button-ask-digerati"
               >
@@ -606,7 +606,7 @@ const CoManagedStore = () => {
               </Button>
               <Button
                 variant="ghost"
-                className="h-12 text-base text-white/70 hover:bg-white/5 hover:text-white"
+                className="h-12 w-full text-base text-white/70 hover:bg-white/5 hover:text-white sm:w-auto"
                 onClick={scrollToCatalog}
                 data-testid="button-browse-everything"
               >

--- a/client/src/pages/store/CoManagedStore.tsx
+++ b/client/src/pages/store/CoManagedStore.tsx
@@ -10,8 +10,6 @@ import {
   ShoppingCart,
   Lock,
   Phone,
-  User,
-  LogOut,
   MessageCircle,
   Sparkles,
 } from "lucide-react";
@@ -54,7 +52,6 @@ import {
 } from "@/data/storeMerchandising";
 import { useToast } from "@/hooks/use-toast";
 import { useCart } from "@/contexts/CartContext";
-import { CartButton } from "@/components/store/CartButton";
 import { useStoreAuth } from "@/hooks/useStoreAuth";
 import { PORTAL_LOGIN } from "@/lib/portalUrls";
 import { openMspAdvisor } from "@/lib/openMspAdvisor";
@@ -77,6 +74,8 @@ import {
   MAX_COMPARE,
 } from "@/components/store/ProductCompare";
 import { CoverageScorePanel } from "@/components/store/CoverageScorePanel";
+import { StorePageAtmosphere } from "@/components/store/StorePageAtmosphere";
+import { StoreClientBar } from "@/components/store/StoreClientBar";
 
 const SORT_OPTIONS: StoreSortOption[] = ["recommended", "popular", "price_asc", "price_desc"];
 const PRICE_BAND_IDS = new Set(storePriceBandFilters.map((b) => b.id));
@@ -141,12 +140,9 @@ const CoManagedStore = () => {
   const { addToCart, openCart, setClientPricing, items } = useCart();
   const {
     isLoggedIn,
-    user,
-    clientType,
     clientPricing,
     getProductPrice,
     loginRedirect,
-    logout,
   } = useStoreAuth();
 
   const catalogRef = useRef<HTMLDivElement>(null);
@@ -555,54 +551,13 @@ const CoManagedStore = () => {
       };
 
   return (
-    <div className="min-h-screen bg-[#0a0a0a]">
+    <div className="relative min-h-screen bg-[#0a0a0a]">
+      <StorePageAtmosphere />
       <MegaMenu />
 
-      <main className="pb-20 de-nav-clear">
+      <main className="relative z-10 pb-20 de-nav-clear">
         <div className="mx-auto max-w-[var(--de-canvas)] px-3 sm:px-4 lg:px-6">
-          {/* Auth & Cart */}
-          <div className="mb-4 flex items-center justify-between">
-            {isLoggedIn && user ? (
-              <div className="flex items-center gap-3">
-                <div className="flex items-center gap-2 rounded-lg border border-de-accent/20 bg-de-accent/10 px-3 py-2">
-                  <User className="h-4 w-4 text-de-accent-ink" />
-                  <span className="text-sm text-white" data-testid="text-user-greeting">
-                    Welcome,{" "}
-                    <span className="font-semibold text-de-accent-ink">
-                      {user.fullName || user.username}
-                    </span>
-                  </span>
-                  {clientType !== "public" && (
-                    <span className="ml-2 rounded-full bg-emerald-500/20 px-2 py-0.5 text-xs font-medium text-emerald-300">
-                      {clientType === "managed" ? "Managed Client" : "Co-Managed Client"}
-                    </span>
-                  )}
-                </div>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={logout}
-                  className="text-white/60 hover:bg-de-accent/10 hover:text-white"
-                  data-testid="button-store-logout"
-                >
-                  <LogOut className="mr-1 h-4 w-4" />
-                  Logout
-                </Button>
-              </div>
-            ) : (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={loginRedirect}
-                className="h-11 border-none bg-de-accent px-5 text-base text-white hover:bg-[#6548ff]"
-                data-testid="button-store-login"
-              >
-                <User className="mr-2 h-4 w-4" />
-                Login for Client Pricing
-              </Button>
-            )}
-            <CartButton />
-          </div>
+          <StoreClientBar />
 
           <div className="mb-8 flex items-center gap-2 text-base text-white/50">
             <Link href="/store" className="transition-colors hover:text-white">
@@ -623,7 +578,7 @@ const CoManagedStore = () => {
               <Users className="h-4 w-4 text-de-accent-ink" />
               <span className="text-sm text-de-accent-ink">Guided IT Storefront</span>
             </div>
-            <h1 className="mb-4 text-4xl font-bold text-white md:text-5xl lg:text-6xl">
+            <h1 className="mb-4 text-[clamp(2rem,6vw,3.25rem)] font-bold leading-[1.12] tracking-[-0.03em] text-white">
               Tell us what you&apos;re trying to{" "}
               <span className="text-de-accent-ink">accomplish.</span>
             </h1>

--- a/client/src/pages/store/ManagedStore.tsx
+++ b/client/src/pages/store/ManagedStore.tsx
@@ -15,6 +15,7 @@ import {
   type StoreProduct
 } from "@/data/storeProducts";
 import { CartButton } from "@/components/store/CartButton";
+import { StorePageAtmosphere } from "@/components/store/StorePageAtmosphere";
 import { pricing, getPricingFooterText } from "@/data/pricing";
 import { ProductMedia } from "@/components/store/ProductMedia";
 import { getProductVisual } from "@/data/productImages";
@@ -131,10 +132,11 @@ const ManagedStore = () => {
   };
 
   return (
-    <div className="min-h-screen bg-[#0a0a0a]">
+    <div className="relative min-h-screen bg-[#0a0a0a]">
+      <StorePageAtmosphere />
       <MegaMenu />
       
-      <main className="de-nav-clear pb-20">
+      <main className="relative z-10 de-nav-clear pb-20">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           
           {/* Breadcrumb with Cart Button */}
@@ -158,7 +160,7 @@ const ManagedStore = () => {
               <Building className="w-4 h-4 text-de-accent-ink" />
               <span className="text-sm text-de-accent-ink">Managed IT Services</span>
             </div>
-            <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6">
+            <h1 className="mb-6 text-[clamp(2rem,6vw,3.25rem)] font-bold leading-[1.12] tracking-[-0.03em] text-white">
               Full-Service{" "}
               <span className="text-de-accent-ink">
                 Managed IT

--- a/client/src/pages/store/ManagedStore.tsx
+++ b/client/src/pages/store/ManagedStore.tsx
@@ -14,8 +14,9 @@ import {
   formatPrice,
   type StoreProduct
 } from "@/data/storeProducts";
-import { CartButton } from "@/components/store/CartButton";
+import { StoreClientBar } from "@/components/store/StoreClientBar";
 import { StorePageAtmosphere } from "@/components/store/StorePageAtmosphere";
+import { CTA } from "@/lib/ctaCopy";
 import { pricing, getPricingFooterText } from "@/data/pricing";
 import { ProductMedia } from "@/components/store/ProductMedia";
 import { getProductVisual } from "@/data/productImages";
@@ -56,9 +57,9 @@ const ManagedStore = () => {
       <motion.div
         variants={itemVariants}
         className={`relative overflow-hidden rounded-2xl border transition-all duration-300 hover:-translate-y-1 cursor-pointer ${
-          featured 
-            ? 'bg-de-raised border-de-hairline shadow-[0_0_40px_rgba(139,92,246,0.2)]' 
-            : 'bg-white/[0.03] border-white/10 hover:border-de-hairline'
+          featured
+            ? "bg-de-raised border-de-accent/35"
+            : "border-white/10 bg-white/[0.03] hover:border-de-hairline"
         }`}
         data-testid={`product-${product.id}`}
       >
@@ -139,14 +140,11 @@ const ManagedStore = () => {
       <main className="relative z-10 de-nav-clear pb-20">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           
-          {/* Breadcrumb with Cart Button */}
-          <div className="mb-8 flex items-center justify-between">
-            <div className="flex items-center gap-2 text-sm text-white/50">
-              <Link href="/store" className="hover:text-white transition-colors">Store</Link>
-              <span>/</span>
-              <span className="text-white">Managed Clients</span>
-            </div>
-            <CartButton />
+          <StoreClientBar />
+          <div className="mb-8 flex items-center gap-2 text-sm text-white/50">
+            <Link href="/store" className="transition-colors hover:text-white">Store</Link>
+            <span>/</span>
+            <span className="text-white">Managed Clients</span>
           </div>
 
           {/* Hero Section */}
@@ -278,34 +276,37 @@ const ManagedStore = () => {
             viewport={{ once: true }}
             transition={{ duration: 0.5 }}
           >
-            <h2 className="text-2xl md:text-3xl font-bold text-white mb-4">
-              Ready to Get Started?
+            <h2 className="mb-4 text-2xl font-bold text-white md:text-3xl">
+              Need a package recommendation?
             </h2>
-            <p className="text-white/60 mb-8 max-w-xl mx-auto">
-              Schedule a free 15-minute call to discuss your needs. We'll help you choose the right plan 
-              and provide a customized quote for your organization.
+            <p className="mx-auto mb-8 max-w-xl text-white/60">
+              Start with a cyber risk assessment. We map the right ProActive tier to your users,
+              sites, and compliance needs — then quote the contract.
             </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Button asChild 
-                  size="lg"
-                  className="h-14 px-8 text-lg font-semibold bg-de-accent hover:bg-de-accent text-white shadow-lg shadow-none"
-                  data-testid="button-final-cta"
-                >
-                  <a href="/book">
-                    <Calendar className="w-5 h-5 mr-2" />
-                  Schedule Consultation
-                  </a>
-                </Button>
-              <Button asChild 
-                  size="lg"
-                  className="h-14 px-8 text-lg font-semibold bg-transparent border-2 border-white/30 text-white hover:bg-white/10"
-                  data-testid="button-call-us"
-                >
-                  <a href="tel:+13254809870">
-                    <Phone className="w-5 h-5 mr-2" />
+            <div className="flex flex-col justify-center gap-4 sm:flex-row">
+              <Button
+                asChild
+                size="lg"
+                variant="brand"
+                className="h-14 px-8 text-lg font-semibold"
+                data-testid="button-final-cta"
+              >
+                <a href="/book">
+                  <Calendar className="mr-2 h-5 w-5" />
+                  {CTA.primary}
+                </a>
+              </Button>
+              <Button
+                asChild
+                size="lg"
+                className="h-14 border-2 border-white/30 bg-transparent px-8 text-lg font-semibold text-white hover:bg-white/10"
+                data-testid="button-call-us"
+              >
+                <a href="tel:+13254809870">
+                  <Phone className="mr-2 h-5 w-5" />
                   325-480-9870
-                  </a>
-                </Button>
+                </a>
+              </Button>
             </div>
             
             <div className="mt-8">

--- a/client/src/pages/store/ProductDetail.tsx
+++ b/client/src/pages/store/ProductDetail.tsx
@@ -34,7 +34,6 @@ import {
   Check,
   ExternalLink,
   User,
-  LogOut,
   Tag,
   Lock,
   Settings2,
@@ -43,7 +42,8 @@ import {
   Sparkles,
 } from "lucide-react";
 import { useStoreAuth } from "@/hooks/useStoreAuth";
-import { CartButton } from "@/components/store/CartButton";
+import { StoreClientBar } from "@/components/store/StoreClientBar";
+import { StorePageAtmosphere } from "@/components/store/StorePageAtmosphere";
 import { ProductMedia } from "@/components/store/ProductMedia";
 import {
   ConfigureProductDrawer,
@@ -57,8 +57,7 @@ const ProductDetail = () => {
   const { toast } = useToast();
   const [quantity, setQuantity] = useState(1);
   const [configureOpen, setConfigureOpen] = useState(false);
-  const { isLoggedIn, user, clientType, clientPricing, getProductPrice, loginRedirect, logout } =
-    useStoreAuth();
+  const { isLoggedIn, clientPricing, getProductPrice, loginRedirect } = useStoreAuth();
 
   useEffect(() => {
     if (clientPricing.length > 0) {
@@ -154,7 +153,8 @@ const ProductDetail = () => {
   };
 
   return (
-    <div className="min-h-screen bg-[#0a0a0a]">
+    <div className="relative min-h-screen bg-[#0a0a0a]">
+      <StorePageAtmosphere />
       <ProductJsonLd
         name={product.name}
         description={product.description}
@@ -174,50 +174,9 @@ const ProductDetail = () => {
       />
       <MegaMenu />
 
-      <main className="de-nav-clear pb-28 lg:pb-20">
+      <main className="relative z-10 de-nav-clear pb-28 lg:pb-20">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-          <div className="mb-4 flex items-center justify-between">
-            {isLoggedIn && user ? (
-              <div className="flex items-center gap-3">
-                <div className="flex items-center gap-2 rounded-lg border border-de-accent/20 bg-de-accent/10 px-3 py-2">
-                  <User className="h-4 w-4 text-de-accent-ink" />
-                  <span className="text-sm text-white" data-testid="text-user-greeting">
-                    Welcome,{" "}
-                    <span className="font-semibold text-de-accent-ink">
-                      {user.fullName || user.username}
-                    </span>
-                  </span>
-                  {clientType !== "public" && (
-                    <span className="ml-2 rounded-full bg-emerald-500/20 px-2 py-0.5 text-xs font-medium text-emerald-300">
-                      {clientType === "managed" ? "Managed Client" : "Co-Managed Client"}
-                    </span>
-                  )}
-                </div>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={logout}
-                  className="text-white/60 hover:bg-de-accent/10 hover:text-white"
-                  data-testid="button-store-logout"
-                >
-                  <LogOut className="mr-1 h-4 w-4" />
-                  Logout
-                </Button>
-              </div>
-            ) : (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={loginRedirect}
-                className="border-none bg-de-accent text-white hover:bg-[#6548ff]"
-                data-testid="button-store-login"
-              >
-                <User className="mr-2 h-4 w-4" />
-                Login for Client Pricing
-              </Button>
-            )}
-            <CartButton />
-          </div>
+          <StoreClientBar />
 
           <nav className="mb-8" aria-label="Breadcrumb">
             <ol className="flex items-center gap-2 text-sm text-white/50">

--- a/client/src/pages/store/QuoteConfirmation.tsx
+++ b/client/src/pages/store/QuoteConfirmation.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useRoute, Link } from "wouter";
 import { motion } from "framer-motion";
 import { MegaMenu } from "@/components/MegaMenu";
@@ -16,11 +16,14 @@ import {
   ArrowRight,
   Home,
   Loader2,
+  Download,
 } from "lucide-react";
 
 const QuoteConfirmation = () => {
   const [, params] = useRoute("/store/quote-confirmation/:id");
   const quoteId = params?.id;
+  const [isDownloadingPdf, setIsDownloadingPdf] = useState(false);
+  const [pdfError, setPdfError] = useState<string | null>(null);
 
   useSEO({
     title: "Quote Request Submitted | Digerati Experts Store",
@@ -133,6 +136,55 @@ const QuoteConfirmation = () => {
                 <p className="text-3xl font-mono font-bold text-de-accent-ink" data-testid="text-quote-number">
                   {quoteRequest.quoteNumber}
                 </p>
+                <Button
+                  type="button"
+                  className="mt-6 bg-[#D3126A] hover:bg-[#D3126A] text-white"
+                  data-testid="button-download-quote-pdf"
+                  disabled={isDownloadingPdf}
+                  onClick={async () => {
+                    setPdfError(null);
+                    setIsDownloadingPdf(true);
+                    try {
+                      const token = localStorage.getItem("portalToken");
+                      const response = await fetch(quoteRequest.pdfUrl || `/api/store/quote-requests/${quoteId}/pdf`, {
+                        headers: token ? { Authorization: `Bearer ${token}` } : {},
+                        credentials: "include",
+                      });
+                      if (!response.ok) {
+                        throw new Error("Unable to download the preliminary quote PDF.");
+                      }
+                      const blob = await response.blob();
+                      const url = URL.createObjectURL(blob);
+                      const link = document.createElement("a");
+                      link.href = url;
+                      link.download = `${quoteRequest.quoteNumber}.pdf`;
+                      document.body.appendChild(link);
+                      link.click();
+                      link.remove();
+                      URL.revokeObjectURL(url);
+                    } catch (error: any) {
+                      setPdfError(error?.message || "Unable to download the preliminary quote PDF.");
+                    } finally {
+                      setIsDownloadingPdf(false);
+                    }
+                  }}
+                >
+                  {isDownloadingPdf ? (
+                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                  ) : (
+                    <Download className="w-4 h-4 mr-2" />
+                  )}
+                  Download preliminary quote PDF
+                </Button>
+                {pdfError ? (
+                  <p className="text-sm text-red-300 mt-3" data-testid="text-pdf-error">
+                    {pdfError}
+                  </p>
+                ) : (
+                  <p className="text-sm text-white/50 mt-3">
+                    Catalog pricing for your requested solution. A consultant will confirm commercial terms.
+                  </p>
+                )}
               </div>
 
               <div className="grid md:grid-cols-2 gap-6 mb-8">

--- a/client/src/pages/store/StoreLanding.tsx
+++ b/client/src/pages/store/StoreLanding.tsx
@@ -163,9 +163,9 @@ const StoreLanding = () => {
                   Guided storefront for managed packages and à la carte services — shop by outcome,
                   ask Digerati to build a stack, then buy from the live catalog.
                 </p>
-                <div className="mt-7 flex flex-wrap gap-3">
+                <div className="mt-7 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
                   <Button
-                    className="h-12 bg-de-accent px-6 text-base text-white hover:bg-[#6548ff]"
+                    className="h-12 w-full bg-de-accent px-6 text-base text-white hover:bg-[#6548ff] sm:w-auto"
                     onClick={() => setGuidedOpen(true)}
                     data-testid="button-build-solution"
                   >
@@ -174,7 +174,7 @@ const StoreLanding = () => {
                   </Button>
                   <Button
                     variant="outline"
-                    className="h-12 border-white/20 bg-transparent px-6 text-base text-white hover:bg-white/5"
+                    className="h-12 w-full border-white/20 bg-transparent px-6 text-base text-white hover:bg-white/5 sm:w-auto"
                     onClick={() => openMspAdvisor({ context: "store" })}
                     data-testid="button-ask-digerati"
                   >
@@ -184,7 +184,7 @@ const StoreLanding = () => {
                   <Link href="/store/co-managed">
                     <Button
                       variant="ghost"
-                      className="h-12 px-6 text-base text-white/70 hover:bg-white/5 hover:text-white"
+                      className="h-12 w-full px-6 text-base text-white/70 hover:bg-white/5 hover:text-white sm:w-auto"
                       data-testid="button-browse-catalog"
                     >
                       Browse full catalog
@@ -241,13 +241,13 @@ const StoreLanding = () => {
                     <Lock className="h-4 w-4" />
                     <span>Contract-based services · Schedule a consultation</span>
                   </div>
-                  <div className="flex items-center justify-between">
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                     <span className="text-base text-white/50">
                       {contractOnlyProducts.length} packages available
                     </span>
                     <Link href="/store/managed">
                       <Button
-                        className="h-11 bg-de-accent px-5 text-base text-white hover:bg-[#6548ff]"
+                        className="h-11 w-full bg-de-accent px-5 text-base text-white hover:bg-[#6548ff] sm:w-auto"
                         data-testid="button-view-managed"
                       >
                         View Packages
@@ -276,13 +276,13 @@ const StoreLanding = () => {
                     <Shield className="h-4 w-4" />
                     <span>Checkout enabled · Purchase directly</span>
                   </div>
-                  <div className="flex items-center justify-between">
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                     <span className="text-base text-white/50">
                       {checkoutProducts.length} products available
                     </span>
                     <Link href="/store/co-managed">
                       <Button
-                        className="h-11 border-none bg-de-accent px-5 text-base text-white hover:bg-[#6548ff]"
+                        className="h-11 w-full border-none bg-de-accent px-5 text-base text-white hover:bg-[#6548ff] sm:w-auto"
                         data-testid="button-view-comanaged"
                       >
                         Browse Products
@@ -375,15 +375,15 @@ const StoreLanding = () => {
             viewport={{ once: true }}
             transition={{ duration: 0.5 }}
           >
-            <div className="mb-8 flex items-center justify-between">
+            <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
               <div>
                 <h2 className="mb-2 text-2xl font-bold text-white md:text-3xl">Available for checkout</h2>
-                <p className="text-white/60">Catalog items you can configure or add now — not a second popularity rail.</p>
+                <p className="text-white/60">Configure or add these catalog items now.</p>
               </div>
               <Link href="/store/co-managed">
                 <Button
                   variant="outline"
-                  className="border-white/20 text-white hover:bg-white/10"
+                  className="w-full border-white/20 text-white hover:bg-white/10 sm:w-auto"
                   data-testid="button-view-all-products"
                 >
                   View All
@@ -426,43 +426,44 @@ const StoreLanding = () => {
             viewport={{ once: true }}
             transition={{ duration: 0.5 }}
           >
-            <h2 className="mb-4 text-2xl font-bold text-white md:text-3xl">Need Help Choosing?</h2>
+            <h2 className="mb-4 text-2xl font-bold text-white md:text-3xl">Need a recommendation, not a catalog?</h2>
             <p className="mx-auto mb-8 max-w-xl text-white/60">
-              Not sure which services fit your business? Schedule a free consultation with our team
-              to discuss your IT needs and find the right solution.
+              Start with a cyber risk assessment or compare ProActive plans. We map gaps to real
+              SKUs — no obligation to buy from the storefront.
             </p>
             <div className="flex flex-col justify-center gap-4 sm:flex-row">
-              <Button asChild
-                  size="lg"
-                  variant="brand"
-                  className="h-12 px-6"
-                  data-testid="button-schedule-consult"
-                >
-                  <a href="/book">
-                    {CTA.primary}
+              <Button
+                asChild
+                size="lg"
+                variant="brand"
+                className="h-12 px-6"
+                data-testid="button-schedule-consult"
+              >
+                <a href="/book">
+                  {CTA.primary}
                   <ArrowRight className="ml-2 h-4 w-4" />
-                  </a>
-                </Button>
-              <Button asChild
-                  size="lg"
-                  variant="outline"
-                  className="h-12 border-white/30 bg-transparent px-6 text-white hover:bg-white/10"
-                  data-testid="button-see-plans"
-                >
-                  <Link href={CTA.secondaryHref}>
-                    {CTA.secondary}
-                  </Link>
-                </Button>
-              <Button asChild
-                  size="lg"
-                  className="h-12 border-2 border-white/30 bg-transparent px-6 text-white hover:bg-white/10"
-                  data-testid="button-call-us"
-                >
-                  <a href="tel:+13254809870">
-                    <Phone className="mr-2 h-4 w-4" />
+                </a>
+              </Button>
+              <Button
+                asChild
+                size="lg"
+                variant="outline"
+                className="h-12 border-white/30 bg-transparent px-6 text-white hover:bg-white/10"
+                data-testid="button-see-plans"
+              >
+                <Link href={CTA.secondaryHref}>{CTA.secondary}</Link>
+              </Button>
+              <Button
+                asChild
+                size="lg"
+                className="h-12 border-2 border-white/30 bg-transparent px-6 text-white hover:bg-white/10"
+                data-testid="button-call-us"
+              >
+                <a href="tel:+13254809870">
+                  <Phone className="mr-2 h-4 w-4" />
                   325-480-9870
-                  </a>
-                </Button>
+                </a>
+              </Button>
             </div>
           </motion.section>
         </div>

--- a/client/src/pages/store/StoreLanding.tsx
+++ b/client/src/pages/store/StoreLanding.tsx
@@ -21,8 +21,6 @@ import {
   Package,
   Settings,
   Server,
-  User,
-  LogOut,
   MessageCircle,
   Sparkles,
 } from "lucide-react";
@@ -39,11 +37,9 @@ import {
   isConfigurableProduct,
   type StoreOutcomeId,
 } from "@/data/storeMerchandising";
-import { CartButton } from "@/components/store/CartButton";
 import { useStoreAuth } from "@/hooks/useStoreAuth";
 import { useCart } from "@/contexts/CartContext";
 import { useToast } from "@/hooks/use-toast";
-import { PORTAL_LOGIN } from "@/lib/portalUrls";
 import { openMspAdvisor } from "@/lib/openMspAdvisor";
 import { StoreTrustStrip } from "@/components/store/StoreTrustStrip";
 import { ShopByOutcome } from "@/components/store/ShopByOutcome";
@@ -53,6 +49,9 @@ import { StoreBundlesSection } from "@/components/store/StoreBundlesSection";
 import { StoreProductCard } from "@/components/store/StoreProductCard";
 import { ConfigureProductDrawer } from "@/components/store/ConfigureProductDrawer";
 import { GuidedBuyingWizard } from "@/components/store/GuidedBuyingWizard";
+import { StorePageAtmosphere } from "@/components/store/StorePageAtmosphere";
+import { StoreClientBar } from "@/components/store/StoreClientBar";
+import { CTA } from "@/lib/ctaCopy";
 
 const categoryIcons: Record<ProductCategory, typeof Shield> = {
   contract_services: Building,
@@ -73,7 +72,7 @@ const categoryIcons: Record<ProductCategory, typeof Shield> = {
 
 const StoreLanding = () => {
   const prefersReducedMotion = useReducedMotion();
-  const { isLoggedIn, user, clientType, logout, getProductPrice, loginRedirect } = useStoreAuth();
+  const { isLoggedIn, getProductPrice, loginRedirect } = useStoreAuth();
   const { addToCart, openCart } = useCart();
   const { toast } = useToast();
   const [, setLocation] = useLocation();
@@ -136,72 +135,31 @@ const StoreLanding = () => {
   };
 
   return (
-    <div className="min-h-screen bg-[#0a0a0a]">
+    <div className="relative min-h-screen bg-[#0a0a0a]">
+      <StorePageAtmosphere />
       <MegaMenu />
 
-      <main className="pb-20 de-nav-clear">
+      <main className="relative z-10 pb-20 de-nav-clear">
         <div className="mx-auto max-w-[var(--de-canvas)] px-3 sm:px-4 lg:px-6">
-          <div className="mb-4 flex items-center justify-between">
-            {isLoggedIn && user ? (
-              <div className="flex items-center gap-3">
-                <div className="flex items-center gap-2 rounded-lg border border-de-accent/20 bg-de-accent/10 px-3 py-2">
-                  <User className="h-4 w-4 text-de-accent-ink" />
-                  <span className="text-sm text-white" data-testid="text-user-greeting">
-                    Welcome,{" "}
-                    <span className="font-semibold text-de-accent-ink">
-                      {user.fullName || user.username}
-                    </span>
-                  </span>
-                  {clientType !== "public" && (
-                    <span className="ml-2 rounded-full bg-de-accent/20 px-2 py-0.5 text-xs font-medium text-de-accent-ink">
-                      {clientType === "managed" ? "Managed Client" : "Co-Managed Client"}
-                    </span>
-                  )}
-                </div>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={logout}
-                  className="text-white/60 hover:bg-de-accent/10 hover:text-white"
-                  data-testid="button-store-logout"
-                >
-                  <LogOut className="mr-1 h-4 w-4" />
-                  Logout
-                </Button>
-              </div>
-            ) : (
-              <Link href={PORTAL_LOGIN}>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="h-11 border-none bg-de-accent px-5 text-base text-white hover:bg-[#6548ff]"
-                  data-testid="button-store-login"
-                >
-                  <User className="mr-2 h-4 w-4" />
-                  Login for Client Pricing
-                </Button>
-              </Link>
-            )}
-            <CartButton />
-          </div>
+          <StoreClientBar />
 
           <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_300px]">
             <div>
               <motion.div
                 className="mb-10"
-                initial={{ opacity: 0, y: 20 }}
+                initial={prefersReducedMotion ? false : { opacity: 0, y: 16 }}
                 animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.5 }}
+                transition={{ duration: prefersReducedMotion ? 0 : 0.45 }}
               >
-                <div className="mb-6 inline-flex items-center gap-2 rounded-full border border-de-accent/25 bg-de-accent/10 px-4 py-2">
+                <div className="mb-5 inline-flex items-center gap-2 rounded-full border border-de-accent/25 bg-de-accent/10 px-4 py-2">
                   <Package className="h-4 w-4 text-de-accent-ink" />
                   <span className="text-sm text-de-accent-ink">IT Services & Solutions</span>
                 </div>
-                <h1 className="mb-4 text-4xl font-bold text-white md:text-5xl lg:text-6xl xl:text-7xl">
+                <h1 className="mb-4 text-[clamp(2rem,6vw,3.5rem)] font-bold leading-[1.12] tracking-[-0.03em] text-white">
                   Tell us what you&apos;re trying to{" "}
                   <span className="text-de-accent-ink">accomplish</span>
                 </h1>
-                <p className="max-w-3xl text-xl leading-relaxed text-white/70 md:text-2xl">
+                <p className="max-w-2xl text-lg leading-relaxed text-white/70 md:text-xl">
                   Guided storefront for managed packages and à la carte services — shop by outcome,
                   ask Digerati to build a stack, then buy from the live catalog.
                 </p>
@@ -369,13 +327,13 @@ const StoreLanding = () => {
             viewport={{ once: true }}
             transition={{ duration: 0.5 }}
           >
-            <div className="mb-10 text-center">
-              <h2 className="mb-3 text-2xl font-bold text-white md:text-3xl">Browse by Category</h2>
+            <div className="mb-8">
+              <h2 className="mb-2 text-2xl font-bold text-white md:text-3xl">Browse by Category</h2>
               <p className="text-white/60">Explore our complete catalog of IT services and products.</p>
             </div>
 
             <motion.div
-              className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5"
+              className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3"
               variants={containerVariants}
               initial="hidden"
               whileInView="visible"
@@ -388,16 +346,19 @@ const StoreLanding = () => {
                   <motion.div key={category} variants={itemVariants}>
                     <Link href={`/store/co-managed?category=${category}`}>
                       <div
-                        className="group h-full cursor-pointer rounded-xl border border-white/10 bg-[#141414] p-4 text-center transition-all duration-300 hover:border-de-accent/30 hover:bg-[#171717]"
+                        className="group flex h-full cursor-pointer items-center gap-3 rounded-xl border border-white/10 bg-[#141414] px-3.5 py-3 text-left transition-colors duration-200 hover:border-de-accent/30 hover:bg-[#171717]"
                         data-testid={`category-${category}`}
                       >
-                        <div className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-lg border border-white/10 bg-white/[0.04] transition-colors group-hover:border-de-accent/30 group-hover:bg-de-accent/15">
+                        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-white/10 bg-white/[0.04] transition-colors group-hover:border-de-accent/30 group-hover:bg-de-accent/15">
                           <Icon className="h-5 w-5 text-de-accent-ink" />
                         </div>
-                        <h3 className="mb-1 text-sm font-medium text-white">
-                          {categoryLabels[category]}
-                        </h3>
-                        <p className="text-xs text-white/55">{productCount} items</p>
+                        <div className="min-w-0 flex-1">
+                          <h3 className="truncate text-sm font-medium text-white">
+                            {categoryLabels[category]}
+                          </h3>
+                          <p className="text-xs text-white/55">{productCount} items</p>
+                        </div>
+                        <ArrowRight className="h-4 w-4 shrink-0 text-white/30 group-hover:text-de-accent-ink" />
                       </div>
                     </Link>
                   </motion.div>
@@ -416,8 +377,8 @@ const StoreLanding = () => {
           >
             <div className="mb-8 flex items-center justify-between">
               <div>
-                <h2 className="mb-2 text-2xl font-bold text-white md:text-3xl">Featured Products</h2>
-                <p className="text-white/60">Popular items available for immediate purchase.</p>
+                <h2 className="mb-2 text-2xl font-bold text-white md:text-3xl">Available for checkout</h2>
+                <p className="text-white/60">Catalog items you can configure or add now — not a second popularity rail.</p>
               </div>
               <Link href="/store/co-managed">
                 <Button
@@ -473,13 +434,24 @@ const StoreLanding = () => {
             <div className="flex flex-col justify-center gap-4 sm:flex-row">
               <Button asChild
                   size="lg"
-                  className="h-12 bg-de-accent px-6 text-white hover:bg-[#6548ff]"
+                  variant="brand"
+                  className="h-12 px-6"
                   data-testid="button-schedule-consult"
                 >
                   <a href="/book">
-                    Schedule Free Consultation
+                    {CTA.primary}
                   <ArrowRight className="ml-2 h-4 w-4" />
                   </a>
+                </Button>
+              <Button asChild
+                  size="lg"
+                  variant="outline"
+                  className="h-12 border-white/30 bg-transparent px-6 text-white hover:bg-white/10"
+                  data-testid="button-see-plans"
+                >
+                  <Link href={CTA.secondaryHref}>
+                    {CTA.secondary}
+                  </Link>
                 </Button>
               <Button asChild
                   size="lg"

--- a/docs/STORE-SOLUTION-ENGINE.md
+++ b/docs/STORE-SOLUTION-ENGINE.md
@@ -1,0 +1,46 @@
+# Store Solution Engine
+
+**Decision:** The DE Solution is the canonical commerce object. Zoho Payments remains the money path. Portal auth remains the identity path. Stripe, Typesense, Redis, and a second customer identity system are **not** introduced in this slice.
+
+## Why this exists
+
+The storefront already had a client-side “Your Solution” cart (`localStorage`) plus Zoho checkout. That cart died across devices and was not recalculated server-side except at payment time.
+
+This layer adds a durable Solution so:
+
+`Store → product → another page → login → return later → request quote`
+
+can keep the same configuration.
+
+## What shipped (P0 / P1 slice)
+
+- Shared pricing math in `shared/storeCommerce.ts` — catalog list prices only
+- In-memory Solution store + `/api/store/solutions/current` and `/claim`
+- Cart drawer: Due today / Monthly / Annual, undo remove, save for later, continue shopping, checkout via `/store/checkout` (billing required)
+- Anonymous session persist + merge on portal login
+- Coverage and “recommended because” copy (heuristic stack coverage, not a security audit)
+- Mobile sticky solution bar on `/store*`
+
+## Explicitly not in this slice
+
+- Stripe Checkout / Billing / Tax
+- Typesense
+- Company RBAC, PO terms, admin catalog CMS
+- PDF quotes, share links, provisioning state machine
+- Changing Zoho as the payment authority
+
+## Source of truth
+
+| Object | Owner |
+|--------|--------|
+| Solution (items, qty, saved-for-later) | DE API + local cache |
+| Catalog / list price | `client/src/data/storeProducts.ts` |
+| Money movement | Zoho Payments via `secureStoreCheckout.ts` |
+| Identity | Existing portal JWT |
+
+## Next slices (when DE asks)
+
+1. Persist Solutions in Postgres `store_carts` (schema already exists)
+2. Honor `store_client_pricing` inside canonical checkout
+3. Quote PDF + Zoho CRM quote sync
+4. Shareable read-only solution links

--- a/docs/STORE-SOLUTION-ENGINE.md
+++ b/docs/STORE-SOLUTION-ENGINE.md
@@ -21,26 +21,32 @@ can keep the same configuration.
 - Coverage and “recommended because” copy (heuristic stack coverage, not a security audit)
 - Mobile sticky solution bar on `/store*`
 
+## What shipped (persistence / pricing / quote slice)
+
+- Solutions write through to Postgres `store_carts` when `DATABASE_URL` is healthy. The `items` jsonb holds `{ version, items, savedForLater, name, status }`. Guest TTL 30 days, signed-in 90 days. Memory remains the fallback when the database is unset or the write fails (including userId FK misses).
+- Canonical Zoho checkout honors `store_client_pricing` (DB rows when present, otherwise the existing demo overlay). Browser `unitPrice` is still ignored. Overrides apply only when `0 < customPrice < catalog list`.
+- Quote requests canonicalize against the catalog (including contract-only SKUs), generate a preliminary PDF at `GET /api/store/quote-requests/:id/pdf`, and best-effort sync Contact / Account / Deal / Lead / Quotes to Zoho CRM. CRM failure never fails the HTTP create. PDF is regenerated from stored lines — no Puppeteer, no filesystem source of truth.
+
 ## Explicitly not in this slice
 
 - Stripe Checkout / Billing / Tax
 - Typesense
 - Company RBAC, PO terms, admin catalog CMS
-- PDF quotes, share links, provisioning state machine
+- Shareable read-only solution links
 - Changing Zoho as the payment authority
 
 ## Source of truth
 
 | Object | Owner |
 |--------|--------|
-| Solution (items, qty, saved-for-later) | DE API + local cache |
+| Solution (items, qty, saved-for-later) | DE API + `store_carts` (memory fallback) |
 | Catalog / list price | `client/src/data/storeProducts.ts` |
+| Client list price | `store_client_pricing` then demo overlay |
 | Money movement | Zoho Payments via `secureStoreCheckout.ts` |
+| Quote PDF | Regenerated from stored canonical lines |
 | Identity | Existing portal JWT |
 
 ## Next slices (when DE asks)
 
-1. Persist Solutions in Postgres `store_carts` (schema already exists)
-2. Honor `store_client_pricing` inside canonical checkout
-3. Quote PDF + Zoho CRM quote sync
-4. Shareable read-only solution links
+1. Shareable read-only solution links
+2. Provisioning state machine after paid Zoho orders

--- a/server/index.ts
+++ b/server/index.ts
@@ -5,6 +5,7 @@ import express, { type Request, Response, NextFunction } from "express";
 import { createServer } from "http";
 import { registerRoutes, authMiddleware, requireRole } from "./routes";
 import { registerSecureZohoStoreCheckout } from "./secureStoreCheckout";
+import { registerStoreSolutionRoutes } from "./storeSolutionRoutes";
 import { registerPublicSupportChat } from "./publicSupportChat";
 import { createServer as createViteServer } from "vite";
 import path from "path";
@@ -269,6 +270,7 @@ app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 
 registerSecureZohoStoreCheckout(app, authMiddleware as any, requireRole as any);
+registerStoreSolutionRoutes(app, authMiddleware as any);
 
 app.use((req, res, next) => {
   if (req.path.toLowerCase() === "/solutions/proactive-ecosystem-packages") {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -5567,22 +5567,19 @@ export async function registerRoutes(app: Express) {
       if (!contactName || !contactEmail) {
         return res.status(400).json({ error: "Contact name and email are required" });
       }
-      
-      if (!requestedItems || !Array.isArray(requestedItems) || requestedItems.length === 0) {
-        return res.status(400).json({ error: "Requested items are required" });
+
+      const { canonicalizeQuoteItems } = await import("./storeQuoteCommerce");
+      const { insertQuoteRequest } = await import("./storeQuoteStore");
+      const { resolveClientPricingRows: resolveQuotePricing, toPriceOverrides: toQuoteOverrides } = await import("./storeClientPricing");
+      const pricingRows = await resolveQuotePricing(req.user?.clientId);
+      let canonicalItems;
+      try {
+        canonicalItems = canonicalizeQuoteItems(requestedItems, toQuoteOverrides(pricingRows));
+      } catch (error: any) {
+        return res.status(400).json({ error: error?.message || "Invalid quote items" });
       }
 
-      const { db } = await import("./db");
-      const { storeQuoteRequests } = await import("@shared/schema");
-      
-      // Generate quote number in QR-YYYYMMDD-XXXX format
-      const now = new Date();
-      const dateStr = now.toISOString().slice(0, 10).replace(/-/g, '');
-      const randomSuffix = Math.random().toString(36).substring(2, 6).toUpperCase();
-      const quoteNumber = `QR-${dateStr}-${randomSuffix}`;
-
-      const [quoteRequest] = await db.insert(storeQuoteRequests).values({
-        quoteNumber,
+      const quoteRequest = await insertQuoteRequest({
         userId: req.userId || null,
         clientId: req.user?.clientId || null,
         contactName,
@@ -5590,26 +5587,32 @@ export async function registerRoutes(app: Express) {
         contactPhone: contactPhone || null,
         companyName: companyName || null,
         message: message || null,
-        requestedItems,
-        status: "pending",
-      }).returning();
+        requestedItems: canonicalItems,
+      });
 
-      console.log(`[QUOTE REQUEST] Created: ${quoteNumber} for ${contactEmail}`);
+      console.log(`[QUOTE REQUEST] Created: ${quoteRequest.quoteNumber} for ${contactEmail}`);
+
+      void import("./storeQuoteCrm")
+        .then(({ syncStoreQuoteToCrm }) => syncStoreQuoteToCrm(quoteRequest))
+        .catch((error: any) => {
+          console.warn("[store-quote] CRM sync skipped:", error?.message || error);
+        });
       
       logSecurityEvent("QUOTE_REQUESTED", req, { 
         quoteId: quoteRequest.id, 
-        quoteNumber,
+        quoteNumber: quoteRequest.quoteNumber,
         clientId: req.user?.clientId,
         userId: req.userId,
         contactEmail,
         companyName,
-        itemCount: requestedItems.length,
-        items: requestedItems.map((item: any) => ({ id: item.id, name: item.name, quantity: item.quantity }))
+        itemCount: canonicalItems.length,
+        items: canonicalItems.map((item) => ({ id: item.productId, name: item.name, quantity: item.quantity })),
       });
 
       res.json({
         id: quoteRequest.id,
         quoteNumber: quoteRequest.quoteNumber,
+        pdfUrl: `/api/store/quote-requests/${quoteRequest.id}/pdf`,
         message: "Quote request submitted successfully",
       });
     } catch (error: any) {
@@ -5618,42 +5621,66 @@ export async function registerRoutes(app: Express) {
     }
   });
 
+  const canAccessQuote = (req: AuthenticatedRequest, quoteRequest: { userId: string | null; clientId: string | null; contactEmail: string | null }) => {
+    const isAdmin = req.user?.role === "admin";
+    const ownsQuote =
+      (req.userId && quoteRequest.userId === req.userId) ||
+      (req.user?.clientId && quoteRequest.clientId === req.user.clientId) ||
+      (req.user?.email &&
+        quoteRequest.contactEmail?.toLowerCase() === req.user.email.toLowerCase());
+    return { isAdmin, ownsQuote: !!(isAdmin || ownsQuote) };
+  };
+
+  app.get("/api/store/quote-requests/:id/pdf", [authMiddleware], async (req: AuthenticatedRequest, res: Response) => {
+    try {
+      const { getQuoteRequest } = await import("./storeQuoteStore");
+      const { buildQuotePdf } = await import("./storeQuotePdf");
+      const quoteRequest = await getQuoteRequest(req.params.id);
+      if (!quoteRequest) {
+        return res.status(404).json({ error: "Quote request not found" });
+      }
+      const { ownsQuote } = canAccessQuote(req, quoteRequest);
+      if (!ownsQuote) {
+        return res.status(403).json({ error: "Access denied" });
+      }
+
+      const pdf = buildQuotePdf(quoteRequest);
+      res.setHeader("Content-Type", "application/pdf");
+      res.setHeader("Content-Disposition", `attachment; filename="${quoteRequest.quoteNumber}.pdf"`);
+      return res.send(pdf);
+    } catch (error: any) {
+      console.error("[GET QUOTE PDF ERROR]", error);
+      return res.status(500).json({ error: "Failed to generate quote PDF" });
+    }
+  });
+
   // Get quote request by ID — authenticated owner or admin only
   app.get("/api/store/quote-requests/:id", [authMiddleware], async (req: AuthenticatedRequest, res: Response) => {
     try {
-      const { id } = req.params;
-      const { db } = await import("./db");
-      const { storeQuoteRequests } = await import("@shared/schema");
-      const { eq, or } = await import("drizzle-orm");
-      
-      const [quoteRequest] = await db.select().from(storeQuoteRequests).where(
-        or(
-          eq(storeQuoteRequests.id, id),
-          eq(storeQuoteRequests.quoteNumber, id)
-        )
-      ).limit(1);
+      const { getQuoteRequest } = await import("./storeQuoteStore");
+      const quoteRequest = await getQuoteRequest(req.params.id);
       
       if (!quoteRequest) {
         return res.status(404).json({ error: "Quote request not found" });
       }
 
-      const isAdmin = req.user?.role === "admin";
-      const ownsQuote =
-        (req.userId && quoteRequest.userId === req.userId) ||
-        (req.user?.clientId && quoteRequest.clientId === req.user.clientId) ||
-        (req.user?.email &&
-          quoteRequest.contactEmail?.toLowerCase() === req.user.email.toLowerCase());
-      if (!isAdmin && !ownsQuote) {
+      const { isAdmin, ownsQuote } = canAccessQuote(req, quoteRequest);
+      if (!ownsQuote) {
         return res.status(403).json({ error: "Access denied" });
       }
 
+      const payload = {
+        ...quoteRequest,
+        pdfUrl: `/api/store/quote-requests/${quoteRequest.id}/pdf`,
+      };
+
       // Never return internal assignment fields to non-admins
       if (!isAdmin) {
-        const { assignedTo, ...clientSafe } = quoteRequest as typeof quoteRequest & { assignedTo?: string | null };
+        const { assignedTo, ...clientSafe } = payload;
         return res.json(clientSafe);
       }
 
-      res.json(quoteRequest);
+      res.json(payload);
     } catch (error: any) {
       console.error("[GET QUOTE REQUEST ERROR]", error);
       res.status(500).json({ error: error.message || "Failed to get quote request" });
@@ -6017,33 +6044,13 @@ export async function registerRoutes(app: Express) {
 
   // ========== STORE CLIENT AUTH ROUTES ==========
 
-  // Demo client pricing - in production this would come from a database
-  const clientPricingData: Map<string, { productId: string; customPrice: number; discountPercent: number }[]> = new Map([
-    ["client-1", [
-      { productId: "prod-010", customPrice: 35, discountPercent: 10 },
-      { productId: "prod-011", customPrice: 22, discountPercent: 12 },
-      { productId: "prod-040", customPrice: 22.50, discountPercent: 10 },
-    ]],
-    ["client-2", [
-      { productId: "prod-010", customPrice: 32, discountPercent: 18 },
-      { productId: "prod-012", customPrice: 5, discountPercent: 17 },
-    ]],
-    ["client-3", [
-      { productId: "prod-010", customPrice: 37, discountPercent: 5 },
-      { productId: "prod-035", customPrice: 160, discountPercent: 9 },
-      { productId: "prod-036", customPrice: 200, discountPercent: 11 },
-    ]],
-    ["client-4", [
-      { productId: "prod-010", customPrice: 36, discountPercent: 8 },
-      { productId: "prod-030", customPrice: 179, discountPercent: 10 },
-    ]],
-    ["client-5", [
-      { productId: "prod-010", customPrice: 34, discountPercent: 13 },
-      { productId: "prod-011", customPrice: 20, discountPercent: 20 },
-      { productId: "prod-030", customPrice: 169, discountPercent: 15 },
-      { productId: "prod-040", customPrice: 20, discountPercent: 20 },
-    ]],
-  ]);
+  const {
+    listDemoClientPricing,
+    removeDemoClientPricing,
+    resolveClientPricingRows,
+    toPriceOverrides,
+    upsertDemoClientPricing,
+  } = await import("./storeClientPricing");
 
   // Get client info for store (returns client type)
   app.get("/api/store/client-info", [authMiddleware], async (req: AuthenticatedRequest, res: Response) => {
@@ -6091,7 +6098,7 @@ export async function registerRoutes(app: Express) {
         return res.json({ pricing: [] });
       }
 
-      const pricing = clientPricingData.get(user.clientId) || [];
+      const pricing = await resolveClientPricingRows(user.clientId);
       res.json({ pricing });
     } catch (error: any) {
       console.error("[ERROR] Failed to get client pricing:", error);
@@ -6144,26 +6151,13 @@ export async function registerRoutes(app: Express) {
         return res.status(400).json({ error: "Either custom price or discount percent is required" });
       }
       
-      // Get or create client pricing array
-      let clientPricing = clientPricingData.get(clientId) || [];
-      
-      // Check if pricing already exists for this product
-      const existingIndex = clientPricing.findIndex(p => p.productId === productId);
-      const oldPricing = existingIndex >= 0 ? clientPricing[existingIndex] : null;
-      
-      const newPricingEntry = {
+      const existingPricing = listDemoClientPricing(clientId);
+      const oldPricing = existingPricing.find((row) => row.productId === productId) || null;
+      const newPricingEntry = upsertDemoClientPricing(clientId, {
         productId,
         customPrice: customPrice || oldPricing?.customPrice || 0,
-        discountPercent: discountPercent !== undefined ? discountPercent : (oldPricing?.discountPercent || 0)
-      };
-      
-      if (existingIndex >= 0) {
-        clientPricing[existingIndex] = newPricingEntry;
-      } else {
-        clientPricing.push(newPricingEntry);
-      }
-      
-      clientPricingData.set(clientId, clientPricing);
+        discountPercent: discountPercent !== undefined ? discountPercent : (oldPricing?.discountPercent || 0),
+      });
       
       logSecurityEvent("CLIENT_PRICING_SET", req, { 
         clientId, 
@@ -6187,7 +6181,7 @@ export async function registerRoutes(app: Express) {
   app.get("/api/admin/client-pricing/:clientId", [authMiddleware, requireAdmin], async (req: AuthenticatedRequest, res: Response) => {
     try {
       const { clientId } = req.params;
-      const pricing = clientPricingData.get(clientId) || [];
+      const pricing = await resolveClientPricingRows(clientId);
       
       res.json({ clientId, pricing });
     } catch (error: any) {
@@ -6201,11 +6195,7 @@ export async function registerRoutes(app: Express) {
     try {
       const { clientId, productId } = req.params;
       
-      let clientPricing = clientPricingData.get(clientId) || [];
-      const oldPricing = clientPricing.find(p => p.productId === productId);
-      
-      clientPricing = clientPricing.filter(p => p.productId !== productId);
-      clientPricingData.set(clientId, clientPricing);
+      const oldPricing = removeDemoClientPricing(clientId, productId);
       
       logSecurityEvent("CLIENT_PRICING_REMOVED", req, { 
         clientId, 

--- a/server/secureStoreCheckout.test.ts
+++ b/server/secureStoreCheckout.test.ts
@@ -51,6 +51,39 @@ describe("secure store checkout canonicalization", () => {
     ], "comanaged")).toThrow(/unknown or mismatched store product/i);
   });
 
+  it("honors a server-side client list price below catalog", () => {
+    const items = canonicalizeCheckoutLineItems(
+      [
+        {
+          productId: "prod-010",
+          sku: "DE-SVC-CM-ENDPOINT-CORE-MO",
+          quantity: 2,
+          unitPrice: 0.01,
+        },
+      ],
+      "comanaged",
+      { "prod-010": 30 },
+    );
+
+    expect(items[0].unitPrice).toBe(30);
+    expect(items[0].total).toBe(60);
+    expect(canonicalCheckoutTotal(items)).toBe(60);
+  });
+
+  it("keeps catalog price when no client override is present", () => {
+    const items = canonicalizeCheckoutLineItems(
+      [
+        {
+          productId: "prod-010",
+          sku: "DE-SVC-CM-ENDPOINT-CORE-MO",
+          quantity: 1,
+        },
+      ],
+      "comanaged",
+    );
+    expect(items[0].unitPrice).toBe(39);
+  });
+
   it("rejects invalid quantities", () => {
     expect(() => canonicalizeCheckoutLineItems([
       {

--- a/server/secureStoreCheckout.ts
+++ b/server/secureStoreCheckout.ts
@@ -1,5 +1,6 @@
 import type { Express, NextFunction, Request, Response } from "express";
 import { storeProducts, type StoreProduct } from "../client/src/data/storeProducts";
+import { resolveClientPricingRows, resolveUnitPrice, toPriceOverrides } from "./storeClientPricing";
 
 type StoreRole = "public" | "prospect" | "managed" | "comanaged" | "admin";
 
@@ -46,6 +47,7 @@ function isPurchasableForRole(product: StoreProduct, role: StoreRole): boolean {
 export function canonicalizeCheckoutLineItems(
   suppliedItems: unknown,
   role: StoreRole,
+  priceOverrides: Record<string, number> = {},
 ): CanonicalCheckoutLineItem[] {
   if (!Array.isArray(suppliedItems) || suppliedItems.length === 0) {
     throw new Error("Line items are required");
@@ -80,7 +82,7 @@ export function canonicalizeCheckoutLineItems(
       throw new Error(`Invalid quantity for ${product.sku}`);
     }
 
-    const unitPrice = money(Number(product.basePrice));
+    const unitPrice = resolveUnitPrice(Number(product.basePrice), priceOverrides[product.id]);
     if (!Number.isFinite(unitPrice) || unitPrice <= 0) {
       throw new Error(`Product does not have a valid checkout price: ${product.sku}`);
     }
@@ -122,9 +124,11 @@ export function registerSecureZohoStoreCheckout(
         }
 
         const role = (req.user?.storeRole || "public") as StoreRole;
+        const pricingRows = await resolveClientPricingRows(req.user?.clientId);
+        const priceOverrides = toPriceOverrides(pricingRows);
         let lineItems: CanonicalCheckoutLineItem[];
         try {
-          lineItems = canonicalizeCheckoutLineItems(req.body?.lineItems, role);
+          lineItems = canonicalizeCheckoutLineItems(req.body?.lineItems, role, priceOverrides);
         } catch (error: any) {
           console.warn("[SECURITY] CHECKOUT_CART_REJECTED", {
             userId: req.userId,

--- a/server/storeClientPricing.test.ts
+++ b/server/storeClientPricing.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import {
+  listDemoClientPricing,
+  resolveUnitPrice,
+  toPriceOverrides,
+} from "./storeClientPricing";
+
+describe("store client pricing", () => {
+  it("applies only a verified discount below catalog list price", () => {
+    expect(resolveUnitPrice(39, 30)).toBe(30);
+    expect(resolveUnitPrice(39, 39)).toBe(39);
+    expect(resolveUnitPrice(39, 40)).toBe(39);
+    expect(resolveUnitPrice(39, 0)).toBe(39);
+    expect(resolveUnitPrice(39, undefined)).toBe(39);
+  });
+
+  it("maps demo rows to product overrides without trusting missing prices", () => {
+    const overrides = toPriceOverrides(listDemoClientPricing("client-1"));
+    expect(overrides["prod-010"]).toBe(35);
+    expect(overrides["missing"]).toBeUndefined();
+  });
+});

--- a/server/storeClientPricing.ts
+++ b/server/storeClientPricing.ts
@@ -1,0 +1,129 @@
+import { and, eq } from "drizzle-orm";
+import { money } from "@shared/storeCommerce";
+import { storeClientPricing } from "@shared/schema";
+import { db, dbReady, initPromise } from "./db";
+
+export type ClientPriceEntry = {
+  productId: string;
+  customPrice: number;
+  discountPercent: number;
+};
+
+/**
+ * Demo / admin overlay. Used when Postgres has no active rows for the client.
+ * Not a public pricing API — checkout still ignores browser unit prices.
+ */
+const demoClientPricing = new Map<string, ClientPriceEntry[]>([
+  [
+    "client-1",
+    [
+      { productId: "prod-010", customPrice: 35, discountPercent: 10 },
+      { productId: "prod-011", customPrice: 22, discountPercent: 12 },
+      { productId: "prod-040", customPrice: 22.5, discountPercent: 10 },
+    ],
+  ],
+  [
+    "client-2",
+    [
+      { productId: "prod-010", customPrice: 32, discountPercent: 18 },
+      { productId: "prod-012", customPrice: 5, discountPercent: 17 },
+    ],
+  ],
+  [
+    "client-3",
+    [
+      { productId: "prod-010", customPrice: 37, discountPercent: 5 },
+      { productId: "prod-035", customPrice: 160, discountPercent: 9 },
+      { productId: "prod-036", customPrice: 200, discountPercent: 11 },
+    ],
+  ],
+  [
+    "client-4",
+    [
+      { productId: "prod-010", customPrice: 36, discountPercent: 8 },
+      { productId: "prod-030", customPrice: 179, discountPercent: 10 },
+    ],
+  ],
+  [
+    "client-5",
+    [
+      { productId: "prod-010", customPrice: 34, discountPercent: 13 },
+      { productId: "prod-011", customPrice: 20, discountPercent: 20 },
+      { productId: "prod-030", customPrice: 169, discountPercent: 15 },
+      { productId: "prod-040", customPrice: 20, discountPercent: 20 },
+    ],
+  ],
+]);
+
+export function listDemoClientPricing(clientId: string): ClientPriceEntry[] {
+  return [...(demoClientPricing.get(clientId) || [])];
+}
+
+export function upsertDemoClientPricing(clientId: string, entry: ClientPriceEntry): ClientPriceEntry {
+  const current = listDemoClientPricing(clientId);
+  const index = current.findIndex((row) => row.productId === entry.productId);
+  if (index >= 0) current[index] = entry;
+  else current.push(entry);
+  demoClientPricing.set(clientId, current);
+  return entry;
+}
+
+export function removeDemoClientPricing(clientId: string, productId: string): ClientPriceEntry | undefined {
+  const current = listDemoClientPricing(clientId);
+  const removed = current.find((row) => row.productId === productId);
+  demoClientPricing.set(
+    clientId,
+    current.filter((row) => row.productId !== productId),
+  );
+  return removed;
+}
+
+async function loadDbClientPricing(clientId: string): Promise<ClientPriceEntry[]> {
+  await initPromise;
+  if (!dbReady || !db) return [];
+  try {
+    const rows = await db
+      .select()
+      .from(storeClientPricing)
+      .where(and(eq(storeClientPricing.clientId, clientId), eq(storeClientPricing.isActive, true)));
+    return rows
+      .map((row: { productId: string; customPrice: string | number; discountPercent?: string | number | null }) => ({
+        productId: row.productId,
+        customPrice: Number(row.customPrice),
+        discountPercent: Number(row.discountPercent || 0),
+      }))
+      .filter((row: ClientPriceEntry) => Number.isFinite(row.customPrice) && row.customPrice > 0);
+  } catch (error: any) {
+    console.warn("[store-pricing] database lookup skipped:", error?.message || error);
+    return [];
+  }
+}
+
+/** DB rows win when present; otherwise the in-memory overlay. */
+export async function resolveClientPricingRows(clientId: string | null | undefined): Promise<ClientPriceEntry[]> {
+  if (!clientId) return [];
+  const fromDb = await loadDbClientPricing(clientId);
+  if (fromDb.length) return fromDb;
+  return listDemoClientPricing(clientId);
+}
+
+export function toPriceOverrides(rows: ClientPriceEntry[]): Record<string, number> {
+  const overrides: Record<string, number> = {};
+  for (const row of rows) {
+    const price = money(Number(row.customPrice));
+    if (Number.isFinite(price) && price > 0) overrides[row.productId] = price;
+  }
+  return overrides;
+}
+
+/**
+ * Honor a server-side client list price only when it is a real discount.
+ * Higher or invalid overrides fall back to catalog list price.
+ */
+export function resolveUnitPrice(listPrice: number, override?: number): number {
+  const list = money(listPrice);
+  if (override == null) return list;
+  const custom = money(Number(override));
+  if (!Number.isFinite(custom) || custom <= 0 || custom >= list) return list;
+  return custom;
+}

--- a/server/storeQuoteCommerce.test.ts
+++ b/server/storeQuoteCommerce.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { canonicalizeQuoteItems, quoteTotals } from "./storeQuoteCommerce";
+
+describe("store quote canonicalization", () => {
+  it("keeps contract-only SKUs and ignores browser unit prices", () => {
+    const items = canonicalizeQuoteItems([
+      {
+        productId: "prod-001",
+        sku: "DE-SVC-MGD-OFFICE-MO",
+        quantity: 1,
+        unitPrice: 0.01,
+      },
+    ]);
+    expect(items).toHaveLength(1);
+    expect(items[0].contractOnly).toBe(true);
+    expect(items[0].unitPrice).toBeGreaterThan(1);
+    expect(items[0].unitPrice).not.toBe(0.01);
+  });
+
+  it("applies a client discount on quote lines", () => {
+    const items = canonicalizeQuoteItems(
+      [
+        {
+          productId: "prod-010",
+          sku: "DE-SVC-CM-ENDPOINT-CORE-MO",
+          quantity: 4,
+          unitPrice: 1,
+        },
+      ],
+      { "prod-010": 30 },
+    );
+    expect(items[0].listPrice).toBe(39);
+    expect(items[0].unitPrice).toBe(30);
+    expect(quoteTotals(items).monthly).toBe(120);
+  });
+
+  it("rejects unknown or mismatched catalog products", () => {
+    expect(() =>
+      canonicalizeQuoteItems([{ productId: "not-real", quantity: 1 }]),
+    ).toThrow(/unknown store product/i);
+    expect(() =>
+      canonicalizeQuoteItems([
+        {
+          productId: "prod-010",
+          sku: "DE-SVC-CM-ENDPOINT-EDR-MO",
+          quantity: 1,
+        },
+      ]),
+    ).toThrow(/mismatched/i);
+  });
+});

--- a/server/storeQuoteCommerce.ts
+++ b/server/storeQuoteCommerce.ts
@@ -1,0 +1,96 @@
+import { money, pricingBucket, type CommercePricingType } from "@shared/storeCommerce";
+import { storeProducts } from "../client/src/data/storeProducts";
+import { resolveUnitPrice } from "./storeClientPricing";
+
+export type CanonicalQuoteLine = {
+  productId: string;
+  sku: string;
+  name: string;
+  quantity: number;
+  unitPrice: number;
+  listPrice: number;
+  pricingType: CommercePricingType;
+  total: number;
+  contractOnly: boolean;
+};
+
+export type QuoteTotals = {
+  dueToday: number;
+  monthly: number;
+  annual: number;
+};
+
+function stringValue(value: unknown, maxLength: number): string {
+  return typeof value === "string" ? value.trim().slice(0, maxLength) : "";
+}
+
+/**
+ * Quotes may include contract-only SKUs. Browser unit prices are ignored.
+ * Client list prices apply only when they are a verified discount.
+ */
+export function canonicalizeQuoteItems(
+  suppliedItems: unknown,
+  priceOverrides: Record<string, number> = {},
+): CanonicalQuoteLine[] {
+  if (!Array.isArray(suppliedItems) || suppliedItems.length === 0) {
+    throw new Error("Requested items are required");
+  }
+  if (suppliedItems.length > 50) {
+    throw new Error("Too many line items");
+  }
+
+  const canonical: CanonicalQuoteLine[] = [];
+  for (const raw of suppliedItems) {
+    if (!raw || typeof raw !== "object") {
+      throw new Error("Invalid line item");
+    }
+    const item = raw as Record<string, unknown>;
+    const productId = stringValue(item.productId ?? item.id, 100);
+    const sku = stringValue(item.sku, 100);
+    if (!productId) {
+      throw new Error("Every line item must include productId");
+    }
+
+    const product = storeProducts.find((candidate) => candidate.id === productId);
+    if (!product) {
+      throw new Error(`Unknown store product: ${productId}`);
+    }
+    if (sku && product.sku !== sku) {
+      throw new Error(`Unknown or mismatched store product: ${sku || productId}`);
+    }
+
+    const rawQuantity = Number(item.quantity);
+    if (!Number.isSafeInteger(rawQuantity) || rawQuantity < product.minimumQuantity || rawQuantity > 10000) {
+      throw new Error(`Invalid quantity for ${product.sku}`);
+    }
+
+    const listPrice = money(Number(product.basePrice));
+    if (!Number.isFinite(listPrice) || listPrice <= 0) {
+      throw new Error(`Product does not have a valid quote price: ${product.sku}`);
+    }
+
+    const unitPrice = resolveUnitPrice(listPrice, priceOverrides[product.id]);
+    canonical.push({
+      productId: product.id,
+      sku: product.sku,
+      name: product.name,
+      quantity: rawQuantity,
+      unitPrice,
+      listPrice,
+      pricingType: product.pricingType,
+      total: money(unitPrice * rawQuantity),
+      contractOnly: product.isContractOnly,
+    });
+  }
+
+  return canonical;
+}
+
+export function quoteTotals(lines: CanonicalQuoteLine[]): QuoteTotals {
+  const totals: QuoteTotals = { dueToday: 0, monthly: 0, annual: 0 };
+  for (const line of lines) {
+    const bucket = pricingBucket(line.pricingType);
+    totals[bucket] = money(totals[bucket] + line.total);
+  }
+  return totals;
+}

--- a/server/storeQuoteCrm.test.ts
+++ b/server/storeQuoteCrm.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { buildCrmQuoteDescription } from "./storeQuoteCrm";
+import { canonicalizeQuoteItems } from "./storeQuoteCommerce";
+
+describe("store quote CRM payload", () => {
+  it("includes the quote number and line SKUs without inventing contract value", () => {
+    const requestedItems = canonicalizeQuoteItems([
+      {
+        productId: "prod-010",
+        sku: "DE-SVC-CM-ENDPOINT-CORE-MO",
+        quantity: 2,
+      },
+    ]);
+    const description = buildCrmQuoteDescription({
+      quoteNumber: "QR-20260818-TEST",
+      contactName: "Jordan Buyer",
+      contactEmail: "jordan@example.com",
+      companyName: "Example Medical",
+      requestedItems,
+      message: "Need coverage for two clinics.",
+    });
+    expect(description).toContain("QR-20260818-TEST");
+    expect(description).toContain("DE-SVC-CM-ENDPOINT-CORE-MO");
+    expect(description).toContain("Example Medical");
+    expect(description).not.toMatch(/password|token|secret/i);
+  });
+});

--- a/server/storeQuoteCrm.ts
+++ b/server/storeQuoteCrm.ts
@@ -1,0 +1,168 @@
+import { zohoClient } from "./zoho/zohoClient";
+import { zohoCRMService } from "./zoho/zohoCRM";
+import { money } from "@shared/storeCommerce";
+import type { CanonicalQuoteLine } from "./storeQuoteCommerce";
+import { quoteTotals } from "./storeQuoteCommerce";
+
+export type StoreQuoteCrmInput = {
+  quoteNumber: string;
+  contactName: string;
+  contactEmail: string;
+  contactPhone?: string | null;
+  companyName?: string | null;
+  message?: string | null;
+  requestedItems: CanonicalQuoteLine[];
+};
+
+export type StoreQuoteCrmResult = {
+  accountId?: string;
+  contactId?: string;
+  dealId?: string;
+  leadId?: string;
+  quoteId?: string;
+};
+
+function splitName(fullName: string): { first: string; last: string } {
+  const parts = fullName.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return { first: "", last: "Unknown" };
+  if (parts.length === 1) return { first: "", last: parts[0] };
+  return { first: parts[0], last: parts.slice(1).join(" ") };
+}
+
+export function buildCrmQuoteDescription(quote: StoreQuoteCrmInput): string {
+  const totals = quoteTotals(quote.requestedItems);
+  const lines = quote.requestedItems
+    .slice(0, 25)
+    .map((item) => `${item.quantity} x ${item.sku} ${item.name} @ $${item.unitPrice.toFixed(2)}`);
+  return [
+    `Store quote ${quote.quoteNumber}`,
+    quote.companyName ? `Company: ${quote.companyName}` : "",
+    `Due today $${totals.dueToday.toFixed(2)} / Monthly $${totals.monthly.toFixed(2)} / Annual $${totals.annual.toFixed(2)}`,
+    "",
+    "Requested items:",
+    ...lines,
+    quote.message ? `\nRequester notes: ${quote.message.slice(0, 500)}` : "",
+  ]
+    .filter((line) => line !== "")
+    .join("\n")
+    .slice(0, 3000);
+}
+
+function closingDate(): string {
+  const date = new Date();
+  date.setUTCDate(date.getUTCDate() + 30);
+  return date.toISOString().slice(0, 10);
+}
+
+/**
+ * Best-effort CRM sync. Never throws to the quote HTTP path.
+ * Zoho Quotes module is optional — Deal + Contact + Lead always attempted first.
+ */
+export async function syncStoreQuoteToCrm(quote: StoreQuoteCrmInput): Promise<StoreQuoteCrmResult | null> {
+  if (!zohoClient.isConfigured()) {
+    console.info("[store-quote] CRM sync skipped — Zoho is not configured");
+    return null;
+  }
+
+  const result: StoreQuoteCrmResult = {};
+  const email = quote.contactEmail.trim().toLowerCase();
+  const company = (quote.companyName || "Store quote prospect").trim().slice(0, 200);
+  const { first, last } = splitName(quote.contactName);
+  const description = buildCrmQuoteDescription(quote);
+  const totals = quoteTotals(quote.requestedItems);
+  const amount = money(totals.dueToday + totals.monthly + totals.annual);
+
+  try {
+    const accounts = await zohoCRMService.searchAccounts(`(Account_Name:equals:${company.replace(/[()]/g, "")})`);
+    if (accounts[0]?.id) {
+      result.accountId = accounts[0].id;
+    } else {
+      const created = await zohoCRMService.createAccount({
+        Account_Name: company,
+        Phone: quote.contactPhone || "",
+        Description: `Created from store quote ${quote.quoteNumber}`,
+      });
+      result.accountId = (created as { details?: { id?: string }; id?: string }).details?.id || created.id;
+    }
+  } catch (error: any) {
+    console.warn("[store-quote] CRM account sync failed:", error?.message || error);
+  }
+
+  try {
+    const existing = await zohoCRMService.getContactByEmail(email);
+    if (existing?.id) {
+      result.contactId = existing.id;
+    } else {
+      const created = await zohoCRMService.createContact({
+        First_Name: first || undefined,
+        Last_Name: last,
+        Email: email,
+        Phone: quote.contactPhone || "",
+        Account_Name: result.accountId ? { id: result.accountId, name: company } : undefined,
+      });
+      result.contactId = (created as { details?: { id?: string }; id?: string }).details?.id || created.id;
+    }
+  } catch (error: any) {
+    console.warn("[store-quote] CRM contact sync failed:", error?.message || error);
+  }
+
+  try {
+    const created = await zohoCRMService.createDeal({
+      Deal_Name: `Store quote ${quote.quoteNumber}${quote.companyName ? ` — ${quote.companyName}` : ""}`.slice(0, 120),
+      Amount: amount,
+      Stage: "Qualification",
+      Closing_Date: closingDate(),
+      Account_Name: result.accountId ? { id: result.accountId, name: company } : undefined,
+      Contact_Name: result.contactId ? { id: result.contactId, name: quote.contactName } : undefined,
+      Description: description,
+    } as any);
+    result.dealId = (created as { details?: { id?: string }; id?: string }).details?.id || created.id;
+  } catch (error: any) {
+    console.warn("[store-quote] CRM deal sync failed:", error?.message || error);
+  }
+
+  try {
+    const existingLead = await zohoCRMService.getLeadByEmail(email);
+    if (existingLead?.id) {
+      result.leadId = existingLead.id;
+    } else {
+      const created = await zohoCRMService.createLead({
+        First_Name: first || undefined,
+        Last_Name: last,
+        Email: email,
+        Phone: quote.contactPhone || undefined,
+        Company: company,
+        Lead_Source: "Store Quote",
+        Description: description,
+        Lead_Status: "Not Contacted",
+      });
+      result.leadId = (created as { details?: { id?: string }; id?: string }).details?.id || created.id;
+    }
+  } catch (error: any) {
+    console.warn("[store-quote] CRM lead sync failed:", error?.message || error);
+  }
+
+  try {
+    const created = await zohoCRMService.createQuote({
+      Subject: quote.quoteNumber,
+      Quote_Stage: "Draft",
+      Account_Name: result.accountId ? { id: result.accountId } : undefined,
+      Contact_Name: result.contactId ? { id: result.contactId } : undefined,
+      Description: description,
+    });
+    result.quoteId = created?.details?.id || created?.id;
+  } catch (error: any) {
+    console.warn("[store-quote] CRM Quotes module unavailable:", error?.message || error);
+  }
+
+  console.info("[store-quote] CRM sync finished", {
+    quoteNumber: quote.quoteNumber,
+    accountId: result.accountId || null,
+    contactId: result.contactId || null,
+    dealId: result.dealId || null,
+    leadId: result.leadId || null,
+    quoteId: result.quoteId || null,
+  });
+
+  return result;
+}

--- a/server/storeQuotePdf.test.ts
+++ b/server/storeQuotePdf.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { canonicalizeQuoteItems } from "./storeQuoteCommerce";
+import { buildQuotePdf } from "./storeQuotePdf";
+
+describe("store quote PDF", () => {
+  it("writes a PDF that restates the quote number and catalog totals", () => {
+    const items = canonicalizeQuoteItems([
+      {
+        productId: "prod-010",
+        sku: "DE-SVC-CM-ENDPOINT-CORE-MO",
+        quantity: 2,
+      },
+    ]);
+    const pdf = buildQuotePdf({
+      quoteNumber: "QR-20260818-TEST",
+      contactName: "Jordan Buyer",
+      contactEmail: "jordan@example.com",
+      companyName: "Example Medical",
+      createdAt: new Date("2026-08-18T12:00:00.000Z"),
+      requestedItems: items,
+      message: "Need endpoint coverage for two clinics.",
+    });
+
+    const text = pdf.toString("latin1");
+    expect(text.startsWith("%PDF-1.4")).toBe(true);
+    expect(text).toContain("QR-20260818-TEST");
+    expect(text).toContain("Jordan Buyer");
+    expect(text).toContain("78.00");
+    expect(text).toContain("%%EOF");
+  });
+});

--- a/server/storeQuotePdf.ts
+++ b/server/storeQuotePdf.ts
@@ -1,0 +1,152 @@
+import { billingLabel, money } from "@shared/storeCommerce";
+import type { CanonicalQuoteLine, QuoteTotals } from "./storeQuoteCommerce";
+import { quoteTotals } from "./storeQuoteCommerce";
+
+export type QuotePdfInput = {
+  quoteNumber: string;
+  contactName: string;
+  contactEmail: string;
+  companyName?: string | null;
+  createdAt: Date | string;
+  requestedItems: CanonicalQuoteLine[];
+  message?: string | null;
+};
+
+function pdfEscape(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/\(/g, "\\(")
+    .replace(/\)/g, "\\)")
+    .replace(/[^\x09\x20-\x7E]/g, "?");
+}
+
+function moneyLabel(value: number): string {
+  return `$${money(value).toFixed(2)}`;
+}
+
+function wrapLine(text: string, width: number): string[] {
+  const words = text.split(/\s+/).filter(Boolean);
+  const lines: string[] = [];
+  let current = "";
+  for (const word of words) {
+    const next = current ? `${current} ${word}` : word;
+    if (next.length > width) {
+      if (current) lines.push(current);
+      current = word.length > width ? word.slice(0, width) : word;
+    } else {
+      current = next;
+    }
+  }
+  if (current) lines.push(current);
+  return lines.length ? lines : [""];
+}
+
+function buildPageContent(lines: string[]): string {
+  const commands = [
+    "BT",
+    "/F1 11 Tf",
+    "14 TL",
+    "48 744 Td",
+    ...lines.map((line, index) => (index === 0 ? `(${pdfEscape(line)}) Tj` : `T* (${pdfEscape(line)}) Tj`)),
+    "ET",
+  ];
+  return commands.join("\n");
+}
+
+/**
+ * Minimal PDF 1.4 writer — no Puppeteer, no filesystem source of truth.
+ * Regenerated on each download from the stored canonical quote.
+ */
+export function buildQuotePdf(quote: QuotePdfInput): Buffer {
+  const totals: QuoteTotals = quoteTotals(quote.requestedItems);
+  const submitted =
+    quote.createdAt instanceof Date ? quote.createdAt.toISOString().slice(0, 10) : String(quote.createdAt).slice(0, 10);
+
+  const body: string[] = [
+    "DIGERATI EXPERTS",
+    "Preliminary Solution Quote",
+    "",
+    `Quote ${quote.quoteNumber}`,
+    `Date ${submitted}`,
+    `Prepared for ${quote.contactName}`,
+    quote.companyName ? `Company ${quote.companyName}` : "",
+    `Email ${quote.contactEmail}`,
+    "",
+    "This PDF restates catalog pricing for the requested solution.",
+    "It is not a signed commercial offer. A consultant will confirm terms.",
+    "",
+    "Line items",
+    "----------------------------------------",
+  ];
+
+  for (const item of quote.requestedItems) {
+    const cadence = billingLabel(item.pricingType);
+    const discount =
+      item.unitPrice < item.listPrice ? ` (list ${moneyLabel(item.listPrice)})` : "";
+    body.push(
+      `${item.quantity} x ${item.name}`,
+      `  ${item.sku}  ${cadence}  ${moneyLabel(item.unitPrice)} each${discount}  = ${moneyLabel(item.total)}`,
+    );
+    if (item.contractOnly) body.push("  Contract review required before provisioning.");
+  }
+
+  body.push(
+    "----------------------------------------",
+    `Due today   ${moneyLabel(totals.dueToday)}`,
+    `Monthly     ${moneyLabel(totals.monthly)}`,
+    `Annual      ${moneyLabel(totals.annual)}`,
+    "",
+  );
+
+  if (quote.message) {
+    body.push("Notes from request");
+    body.push(...wrapLine(quote.message.slice(0, 800), 88));
+    body.push("");
+  }
+
+  body.push(
+    "Digerati Experts  |  digeratiexperts.com",
+    "Questions: sales@digerati-experts.com  |  325-480-9870",
+  );
+
+  const filtered = body.filter((line) => line !== undefined);
+  const pages: string[][] = [];
+  const perPage = 46;
+  for (let i = 0; i < filtered.length; i += perPage) {
+    pages.push(filtered.slice(i, i + perPage));
+  }
+
+  const objects: string[] = [];
+  objects.push("<< /Type /Catalog /Pages 2 0 R >>");
+  const pageIds = pages.map((_, index) => 3 + index * 2);
+  objects.push(`<< /Type /Pages /Kids [${pageIds.map((id) => `${id} 0 R`).join(" ")}] /Count ${pages.length} >>`);
+
+  const contentIds: number[] = [];
+  pages.forEach((pageLines, index) => {
+    const pageId = 3 + index * 2;
+    const contentId = pageId + 1;
+    contentIds.push(contentId);
+    objects[pageId - 1] =
+      `<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents ${contentId} 0 R /Resources << /Font << /F1 ${3 + pages.length * 2} 0 R >> >> >>`;
+    const stream = buildPageContent(pageLines);
+    objects[contentId - 1] = `<< /Length ${Buffer.byteLength(stream, "utf8")} >>\nstream\n${stream}\nendstream`;
+  });
+
+  const fontId = 3 + pages.length * 2;
+  objects[fontId - 1] = "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>";
+
+  let pdf = "%PDF-1.4\n";
+  const offsets = [0];
+  objects.forEach((object, index) => {
+    offsets.push(Buffer.byteLength(pdf, "utf8"));
+    pdf += `${index + 1} 0 obj\n${object}\nendobj\n`;
+  });
+  const xref = Buffer.byteLength(pdf, "utf8");
+  pdf += `xref\n0 ${objects.length + 1}\n`;
+  pdf += "0000000000 65535 f \n";
+  for (let i = 1; i < offsets.length; i += 1) {
+    pdf += `${String(offsets[i]).padStart(10, "0")} 00000 n \n`;
+  }
+  pdf += `trailer << /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xref}\n%%EOF`;
+  return Buffer.from(pdf, "utf8");
+}

--- a/server/storeQuoteStore.test.ts
+++ b/server/storeQuoteStore.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { canonicalizeQuoteItems } from "./storeQuoteCommerce";
+import { getQuoteRequest, insertQuoteRequest } from "./storeQuoteStore";
+
+describe("store quote store", () => {
+  it("keeps a quote available without Postgres", async () => {
+    const requestedItems = canonicalizeQuoteItems([
+      {
+        productId: "prod-010",
+        sku: "DE-SVC-CM-ENDPOINT-CORE-MO",
+        quantity: 1,
+      },
+    ]);
+    const created = await insertQuoteRequest({
+      contactName: "Jordan Buyer",
+      contactEmail: "jordan@example.com",
+      requestedItems,
+    });
+    const byId = await getQuoteRequest(created.id);
+    const byNumber = await getQuoteRequest(created.quoteNumber);
+    expect(byId?.quoteNumber).toBe(created.quoteNumber);
+    expect(byNumber?.id).toBe(created.id);
+    expect(byId?.requestedItems[0].unitPrice).toBe(39);
+  });
+});

--- a/server/storeQuoteStore.ts
+++ b/server/storeQuoteStore.ts
@@ -1,0 +1,143 @@
+import { randomUUID } from "crypto";
+import { eq, or } from "drizzle-orm";
+import { storeQuoteRequests } from "@shared/schema";
+import { db, dbReady, initPromise } from "./db";
+import type { CanonicalQuoteLine } from "./storeQuoteCommerce";
+
+export type StoredQuoteRequest = {
+  id: string;
+  quoteNumber: string;
+  userId: string | null;
+  clientId: string | null;
+  contactName: string;
+  contactEmail: string;
+  contactPhone: string | null;
+  companyName: string | null;
+  requestedItems: CanonicalQuoteLine[];
+  message: string | null;
+  status: string;
+  assignedTo: string | null;
+  meetingScheduled: Date | null;
+  quoteSentAt: Date | null;
+  convertedOrderId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+const quotes = new Map<string, StoredQuoteRequest>();
+
+export function makeQuoteNumber(now = new Date()): string {
+  const dateStr = now.toISOString().slice(0, 10).replace(/-/g, "");
+  const randomSuffix = Math.random().toString(36).substring(2, 6).toUpperCase();
+  return `QR-${dateStr}-${randomSuffix}`;
+}
+
+function remember(record: StoredQuoteRequest) {
+  quotes.set(record.id, record);
+  quotes.set(record.quoteNumber, record);
+  return record;
+}
+
+function rowToQuote(row: any): StoredQuoteRequest {
+  return {
+    id: row.id,
+    quoteNumber: row.quoteNumber,
+    userId: row.userId ?? null,
+    clientId: row.clientId ?? null,
+    contactName: row.contactName,
+    contactEmail: row.contactEmail,
+    contactPhone: row.contactPhone ?? null,
+    companyName: row.companyName ?? null,
+    requestedItems: Array.isArray(row.requestedItems) ? row.requestedItems : [],
+    message: row.message ?? null,
+    status: row.status || "pending",
+    assignedTo: row.assignedTo ?? null,
+    meetingScheduled: row.meetingScheduled ?? null,
+    quoteSentAt: row.quoteSentAt ?? null,
+    convertedOrderId: row.convertedOrderId ?? null,
+    createdAt: row.createdAt instanceof Date ? row.createdAt : new Date(row.createdAt || Date.now()),
+    updatedAt: row.updatedAt instanceof Date ? row.updatedAt : new Date(row.updatedAt || Date.now()),
+  };
+}
+
+export async function insertQuoteRequest(input: {
+  quoteNumber?: string;
+  userId?: string | null;
+  clientId?: string | null;
+  contactName: string;
+  contactEmail: string;
+  contactPhone?: string | null;
+  companyName?: string | null;
+  requestedItems: CanonicalQuoteLine[];
+  message?: string | null;
+}): Promise<StoredQuoteRequest> {
+  const now = new Date();
+  const record: StoredQuoteRequest = {
+    id: randomUUID(),
+    quoteNumber: input.quoteNumber || makeQuoteNumber(now),
+    userId: input.userId ?? null,
+    clientId: input.clientId ?? null,
+    contactName: input.contactName,
+    contactEmail: input.contactEmail,
+    contactPhone: input.contactPhone ?? null,
+    companyName: input.companyName ?? null,
+    requestedItems: input.requestedItems,
+    message: input.message ?? null,
+    status: "pending",
+    assignedTo: null,
+    meetingScheduled: null,
+    quoteSentAt: now,
+    convertedOrderId: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+  remember(record);
+
+  await initPromise;
+  if (dbReady && db) {
+    try {
+      const [row] = await db
+        .insert(storeQuoteRequests)
+        .values({
+          id: record.id,
+          quoteNumber: record.quoteNumber,
+          userId: record.userId,
+          clientId: record.clientId,
+          contactName: record.contactName,
+          contactEmail: record.contactEmail,
+          contactPhone: record.contactPhone,
+          companyName: record.companyName,
+          requestedItems: record.requestedItems,
+          message: record.message,
+          status: record.status,
+          quoteSentAt: record.quoteSentAt,
+        })
+        .returning();
+      if (row) return remember(rowToQuote(row));
+    } catch (error: any) {
+      console.warn("[store-quote] database insert skipped:", error?.message || error);
+    }
+  }
+
+  return record;
+}
+
+export async function getQuoteRequest(idOrNumber: string): Promise<StoredQuoteRequest | undefined> {
+  const cached = quotes.get(idOrNumber);
+  if (cached) return cached;
+
+  await initPromise;
+  if (!dbReady || !db) return undefined;
+  try {
+    const [row] = await db
+      .select()
+      .from(storeQuoteRequests)
+      .where(or(eq(storeQuoteRequests.id, idOrNumber), eq(storeQuoteRequests.quoteNumber, idOrNumber)))
+      .limit(1);
+    if (!row) return undefined;
+    return remember(rowToQuote(row));
+  } catch (error: any) {
+    console.warn("[store-quote] database lookup skipped:", error?.message || error);
+    return undefined;
+  }
+}

--- a/server/storeSolutionRoutes.ts
+++ b/server/storeSolutionRoutes.ts
@@ -1,0 +1,94 @@
+import type { Express, NextFunction, Request, Response } from "express";
+import jwt from "jsonwebtoken";
+import {
+  claimSolution,
+  createSolution,
+  findSolution,
+  publicSolution,
+  upsertSolution,
+} from "./storeSolutionStore";
+import type { SolutionLineInput } from "@shared/storeCommerce";
+
+type SolutionRequest = Request & {
+  userId?: string;
+  user?: { id?: string };
+};
+
+function readSessionId(req: Request): string {
+  const fromBody = typeof req.body?.sessionId === "string" ? req.body.sessionId.trim() : "";
+  const fromQuery = typeof req.query.sessionId === "string" ? req.query.sessionId.trim() : "";
+  return (fromBody || fromQuery).slice(0, 80);
+}
+
+function optionalUserId(req: SolutionRequest): string | null {
+  const authHeader = req.headers.authorization;
+  const token =
+    authHeader && authHeader.startsWith("Bearer ") ? authHeader.slice("Bearer ".length).trim() : "";
+  if (!token || !process.env.JWT_SECRET) return req.userId ?? null;
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET) as { userId?: string };
+    return decoded.userId || req.userId || null;
+  } catch {
+    return req.userId ?? null;
+  }
+}
+
+function parseLines(value: unknown): SolutionLineInput[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((raw) => {
+      if (!raw || typeof raw !== "object") return null;
+      const item = raw as Record<string, unknown>;
+      const productId = typeof item.productId === "string" ? item.productId.trim() : "";
+      const sku = typeof item.sku === "string" ? item.sku.trim() : undefined;
+      const quantity = Number(item.quantity);
+      if (!productId || !Number.isFinite(quantity)) return null;
+      return { productId, sku, quantity };
+    })
+    .filter((line): line is SolutionLineInput => !!line)
+    .slice(0, 50);
+}
+
+export function registerStoreSolutionRoutes(
+  app: Express,
+  authMiddleware: (req: SolutionRequest, res: Response, next: NextFunction) => unknown,
+) {
+  app.get("/api/store/solutions/current", (req: SolutionRequest, res: Response) => {
+    const sessionId = readSessionId(req);
+    if (!sessionId) return res.status(400).json({ error: "sessionId is required" });
+    const userId = optionalUserId(req);
+    const existing = findSolution({ sessionId, userId });
+    if (!existing) {
+      return res.json({ solution: publicSolution(createSolution(sessionId, userId)) });
+    }
+    return res.json({ solution: publicSolution(existing) });
+  });
+
+  app.put("/api/store/solutions/current", (req: SolutionRequest, res: Response) => {
+    const sessionId = readSessionId(req);
+    if (!sessionId) return res.status(400).json({ error: "sessionId is required" });
+    const userId = optionalUserId(req);
+    const items = parseLines(req.body?.items);
+    const savedForLater = parseLines(req.body?.savedForLater);
+    const name = typeof req.body?.name === "string" ? req.body.name.slice(0, 80) : undefined;
+    const solution = upsertSolution({
+      id: typeof req.body?.id === "string" ? req.body.id : undefined,
+      sessionId,
+      userId,
+      name,
+      items,
+      savedForLater,
+    });
+    return res.json({ solution: publicSolution(solution) });
+  });
+
+  app.post("/api/store/solutions/claim", authMiddleware, (req: SolutionRequest, res: Response) => {
+    const sessionId = readSessionId(req);
+    const userId = req.userId || req.user?.id;
+    if (!sessionId || !userId) {
+      return res.status(400).json({ error: "sessionId and authenticated user are required" });
+    }
+    const solution = claimSolution(sessionId, userId);
+    return res.json({ solution: publicSolution(solution) });
+  });
+}

--- a/server/storeSolutionRoutes.ts
+++ b/server/storeSolutionRoutes.ts
@@ -1,11 +1,11 @@
 import type { Express, NextFunction, Request, Response } from "express";
 import jwt from "jsonwebtoken";
 import {
-  claimSolution,
+  claimSolutionDurable,
   createSolution,
-  findSolution,
+  findSolutionDurable,
   publicSolution,
-  upsertSolution,
+  upsertSolutionDurable,
 } from "./storeSolutionStore";
 import type { SolutionLineInput } from "@shared/storeCommerce";
 
@@ -53,25 +53,25 @@ export function registerStoreSolutionRoutes(
   app: Express,
   authMiddleware: (req: SolutionRequest, res: Response, next: NextFunction) => unknown,
 ) {
-  app.get("/api/store/solutions/current", (req: SolutionRequest, res: Response) => {
+  app.get("/api/store/solutions/current", async (req: SolutionRequest, res: Response) => {
     const sessionId = readSessionId(req);
     if (!sessionId) return res.status(400).json({ error: "sessionId is required" });
     const userId = optionalUserId(req);
-    const existing = findSolution({ sessionId, userId });
+    const existing = await findSolutionDurable({ sessionId, userId });
     if (!existing) {
       return res.json({ solution: publicSolution(createSolution(sessionId, userId)) });
     }
     return res.json({ solution: publicSolution(existing) });
   });
 
-  app.put("/api/store/solutions/current", (req: SolutionRequest, res: Response) => {
+  app.put("/api/store/solutions/current", async (req: SolutionRequest, res: Response) => {
     const sessionId = readSessionId(req);
     if (!sessionId) return res.status(400).json({ error: "sessionId is required" });
     const userId = optionalUserId(req);
     const items = parseLines(req.body?.items);
     const savedForLater = parseLines(req.body?.savedForLater);
     const name = typeof req.body?.name === "string" ? req.body.name.slice(0, 80) : undefined;
-    const solution = upsertSolution({
+    const solution = await upsertSolutionDurable({
       id: typeof req.body?.id === "string" ? req.body.id : undefined,
       sessionId,
       userId,
@@ -82,13 +82,13 @@ export function registerStoreSolutionRoutes(
     return res.json({ solution: publicSolution(solution) });
   });
 
-  app.post("/api/store/solutions/claim", authMiddleware, (req: SolutionRequest, res: Response) => {
+  app.post("/api/store/solutions/claim", authMiddleware, async (req: SolutionRequest, res: Response) => {
     const sessionId = readSessionId(req);
     const userId = req.userId || req.user?.id;
     if (!sessionId || !userId) {
       return res.status(400).json({ error: "sessionId and authenticated user are required" });
     }
-    const solution = claimSolution(sessionId, userId);
+    const solution = await claimSolutionDurable(sessionId, userId);
     return res.json({ solution: publicSolution(solution) });
   });
 }

--- a/server/storeSolutionStore.test.ts
+++ b/server/storeSolutionStore.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { claimSolution, createSolution, upsertSolution } from "./storeSolutionStore";
+
+describe("store solution store", () => {
+  it("persists a guest solution and recalculates catalog totals", () => {
+    const created = createSolution("session-a");
+    const saved = upsertSolution({
+      id: created.id,
+      sessionId: "session-a",
+      items: [{ productId: "prod-010", sku: "DE-SVC-CM-ENDPOINT-CORE-MO", quantity: 5 }],
+    });
+    expect(saved.id).toBe(created.id);
+    expect(saved.snapshot.totals.monthly).toBe(195);
+    expect(saved.snapshot.lines[0].name).toContain("Endpoint");
+  });
+
+  it("merges guest and authenticated solutions without dropping either side", () => {
+    const guest = upsertSolution({
+      sessionId: "guest-merge",
+      items: [{ productId: "prod-010", sku: "DE-SVC-CM-ENDPOINT-CORE-MO", quantity: 4 }],
+    });
+    upsertSolution({
+      sessionId: "user-session",
+      userId: "user-1",
+      items: [{ productId: "prod-011", sku: "DE-SVC-CM-ENDPOINT-EDR-MO", quantity: 2 }],
+    });
+    const claimed = claimSolution(guest.sessionId, "user-1");
+    const ids = claimed.items.map((item) => item.productId).sort();
+    expect(ids).toEqual(["prod-010", "prod-011"]);
+    expect(claimed.items.find((item) => item.productId === "prod-010")?.quantity).toBe(4);
+  });
+});

--- a/server/storeSolutionStore.test.ts
+++ b/server/storeSolutionStore.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { claimSolution, createSolution, upsertSolution } from "./storeSolutionStore";
+import {
+  claimSolution,
+  createSolution,
+  parseCartPayload,
+  serializeCartPayload,
+  upsertSolution,
+} from "./storeSolutionStore";
 
 describe("store solution store", () => {
   it("persists a guest solution and recalculates catalog totals", () => {
@@ -29,4 +35,26 @@ describe("store solution store", () => {
     expect(ids).toEqual(["prod-010", "prod-011"]);
     expect(claimed.items.find((item) => item.productId === "prod-010")?.quantity).toBe(4);
   });
+
+  it("round-trips solution payload inside store_carts items jsonb", () => {
+    const saved = upsertSolution({
+      sessionId: "payload-session",
+      items: [{ productId: "prod-010", quantity: 3 }],
+      savedForLater: [{ productId: "prod-080", quantity: 1 }],
+      name: "Office stack",
+    });
+    const encoded = serializeCartPayload(saved);
+    expect(encoded.version).toBe(1);
+    const decoded = parseCartPayload(encoded);
+    expect(decoded.items).toEqual(saved.items);
+    expect(decoded.savedForLater).toEqual(saved.savedForLater);
+    expect(decoded.name).toBe("Office stack");
+  });
+
+  it("reads legacy cart arrays that only stored product lines", () => {
+    const decoded = parseCartPayload([{ productId: "prod-010", quantity: 2 }]);
+    expect(decoded.items).toEqual([{ productId: "prod-010", quantity: 2 }]);
+    expect(decoded.savedForLater).toEqual([]);
+  });
 });
+

--- a/server/storeSolutionStore.ts
+++ b/server/storeSolutionStore.ts
@@ -1,0 +1,162 @@
+import { randomUUID } from "crypto";
+import { computeSolutionSnapshot, type SolutionLineInput, type SolutionSnapshot } from "@shared/storeCommerce";
+import { storeProducts } from "../client/src/data/storeProducts";
+
+export type StoredSolution = {
+  id: string;
+  sessionId: string;
+  userId: string | null;
+  name: string;
+  status: "draft" | "saved" | "archived";
+  items: SolutionLineInput[];
+  savedForLater: SolutionLineInput[];
+  snapshot: SolutionSnapshot;
+  updatedAt: string;
+  createdAt: string;
+};
+
+const solutions = new Map<string, StoredSolution>();
+const GUEST_TTL_MS = 1000 * 60 * 60 * 24 * 30;
+
+function catalog() {
+  return storeProducts.map((product) => ({
+    id: product.id,
+    sku: product.sku,
+    name: product.name,
+    basePrice: product.basePrice,
+    pricingType: product.pricingType,
+    pricingUnit: product.pricingUnit,
+    minimumQuantity: product.minimumQuantity,
+    isCheckoutEnabled: product.isCheckoutEnabled,
+    isContractOnly: product.isContractOnly,
+  }));
+}
+
+function hydrate(record: StoredSolution): StoredSolution {
+  return {
+    ...record,
+    snapshot: computeSolutionSnapshot(record.items, catalog()),
+  };
+}
+
+function expireGuests() {
+  const cutoff = Date.now() - GUEST_TTL_MS;
+  for (const [id, record] of solutions) {
+    if (record.userId) continue;
+    if (new Date(record.updatedAt).getTime() < cutoff) solutions.delete(id);
+  }
+}
+
+export function createSolution(sessionId: string, userId: string | null = null): StoredSolution {
+  expireGuests();
+  const now = new Date().toISOString();
+  const record: StoredSolution = {
+    id: randomUUID(),
+    sessionId,
+    userId,
+    name: "Your Solution",
+    status: "draft",
+    items: [],
+    savedForLater: [],
+    snapshot: computeSolutionSnapshot([], catalog()),
+    createdAt: now,
+    updatedAt: now,
+  };
+  solutions.set(record.id, record);
+  return record;
+}
+
+export function getSolution(id: string): StoredSolution | undefined {
+  const record = solutions.get(id);
+  return record ? hydrate(record) : undefined;
+}
+
+export function findSolution(opts: { id?: string; sessionId?: string; userId?: string | null }): StoredSolution | undefined {
+  expireGuests();
+  if (opts.id) {
+    const exact = solutions.get(opts.id);
+    if (exact) return hydrate(exact);
+  }
+  if (opts.userId) {
+    const owned = [...solutions.values()].find((record) => record.userId === opts.userId && record.status !== "archived");
+    if (owned) return hydrate(owned);
+  }
+  if (opts.sessionId) {
+    const guest = [...solutions.values()].find(
+      (record) => record.sessionId === opts.sessionId && record.status !== "archived",
+    );
+    if (guest) return hydrate(guest);
+  }
+  return undefined;
+}
+
+export function upsertSolution(input: {
+  id?: string;
+  sessionId: string;
+  userId?: string | null;
+  name?: string;
+  items: SolutionLineInput[];
+  savedForLater?: SolutionLineInput[];
+}): StoredSolution {
+  const existing = findSolution({ id: input.id, sessionId: input.sessionId, userId: input.userId });
+  const now = new Date().toISOString();
+  const base = existing ?? createSolution(input.sessionId, input.userId ?? null);
+  const next: StoredSolution = {
+    ...base,
+    sessionId: input.sessionId || base.sessionId,
+    userId: input.userId ?? base.userId,
+    name: input.name?.trim() || base.name,
+    items: input.items,
+    savedForLater: input.savedForLater ?? base.savedForLater,
+    updatedAt: now,
+    snapshot: computeSolutionSnapshot(input.items, catalog()),
+  };
+  solutions.set(next.id, next);
+  return next;
+}
+
+function mergeLines(primary: SolutionLineInput[], secondary: SolutionLineInput[]): SolutionLineInput[] {
+  const map = new Map<string, number>();
+  for (const line of [...primary, ...secondary]) {
+    map.set(line.productId, Math.max(map.get(line.productId) ?? 0, line.quantity));
+  }
+  return [...map.entries()].map(([productId, quantity]) => ({ productId, quantity }));
+}
+
+/** Attach a guest solution to a portal user. Union quantities; never drop either side. */
+export function claimSolution(sessionId: string, userId: string): StoredSolution {
+  const guest = findSolution({ sessionId });
+  const owned = findSolution({ userId });
+  if (guest && owned && guest.id !== owned.id) {
+    const merged = upsertSolution({
+      id: owned.id,
+      sessionId,
+      userId,
+      items: mergeLines(owned.items, guest.items),
+      savedForLater: mergeLines(owned.savedForLater, guest.savedForLater),
+    });
+    solutions.delete(guest.id);
+    return merged;
+  }
+  if (guest) {
+    guest.userId = userId;
+    guest.updatedAt = new Date().toISOString();
+    solutions.set(guest.id, guest);
+    return hydrate(guest);
+  }
+  if (owned) return owned;
+  return createSolution(sessionId, userId);
+}
+
+export function publicSolution(record: StoredSolution) {
+  return {
+    id: record.id,
+    name: record.name,
+    status: record.status,
+    items: record.items,
+    savedForLater: record.savedForLater,
+    snapshot: record.snapshot,
+    updatedAt: record.updatedAt,
+    createdAt: record.createdAt,
+  };
+}

--- a/server/storeSolutionStore.ts
+++ b/server/storeSolutionStore.ts
@@ -1,6 +1,9 @@
 import { randomUUID } from "crypto";
-import { computeSolutionSnapshot, type SolutionLineInput, type SolutionSnapshot } from "@shared/storeCommerce";
+import { eq } from "drizzle-orm";
+import { computeSolutionSnapshot, money, type SolutionLineInput, type SolutionSnapshot } from "@shared/storeCommerce";
+import { storeCarts } from "@shared/schema";
 import { storeProducts } from "../client/src/data/storeProducts";
+import { db, dbReady, initPromise } from "./db";
 
 export type StoredSolution = {
   id: string;
@@ -159,4 +162,220 @@ export function publicSolution(record: StoredSolution) {
     updatedAt: record.updatedAt,
     createdAt: record.createdAt,
   };
+}
+
+export type CartPayloadV1 = {
+  version: 1;
+  items: SolutionLineInput[];
+  savedForLater: SolutionLineInput[];
+  name: string;
+  status: StoredSolution["status"];
+};
+
+function asLine(raw: unknown): SolutionLineInput | null {
+  if (!raw || typeof raw !== "object") return null;
+  const item = raw as Record<string, unknown>;
+  const productId = typeof item.productId === "string" ? item.productId.trim() : "";
+  const sku = typeof item.sku === "string" ? item.sku.trim() : undefined;
+  const quantity = Number(item.quantity);
+  if (!productId || !Number.isFinite(quantity)) return null;
+  return { productId, sku, quantity };
+}
+
+export function serializeCartPayload(record: StoredSolution): CartPayloadV1 {
+  return {
+    version: 1,
+    items: record.items,
+    savedForLater: record.savedForLater,
+    name: record.name,
+    status: record.status,
+  };
+}
+
+export function parseCartPayload(raw: unknown): Pick<StoredSolution, "items" | "savedForLater" | "name" | "status"> {
+  if (Array.isArray(raw)) {
+    return {
+      items: raw.map(asLine).filter((line): line is SolutionLineInput => !!line),
+      savedForLater: [],
+      name: "Your Solution",
+      status: "draft",
+    };
+  }
+  if (raw && typeof raw === "object") {
+    const payload = raw as Record<string, unknown>;
+    const status = payload.status === "saved" || payload.status === "archived" ? payload.status : "draft";
+    return {
+      items: Array.isArray(payload.items)
+        ? payload.items.map(asLine).filter((line): line is SolutionLineInput => !!line)
+        : [],
+      savedForLater: Array.isArray(payload.savedForLater)
+        ? payload.savedForLater.map(asLine).filter((line): line is SolutionLineInput => !!line)
+        : [],
+      name: typeof payload.name === "string" && payload.name.trim() ? payload.name.trim().slice(0, 80) : "Your Solution",
+      status,
+    };
+  }
+  return { items: [], savedForLater: [], name: "Your Solution", status: "draft" };
+}
+
+function rowToSolution(row: {
+  id: string;
+  sessionId: string | null;
+  userId: string | null;
+  items: unknown;
+  createdAt?: Date | string | null;
+  updatedAt?: Date | string | null;
+}): StoredSolution {
+  const payload = parseCartPayload(row.items);
+  const createdAt =
+    row.createdAt instanceof Date ? row.createdAt.toISOString() : String(row.createdAt || new Date().toISOString());
+  const updatedAt =
+    row.updatedAt instanceof Date ? row.updatedAt.toISOString() : String(row.updatedAt || new Date().toISOString());
+  return hydrate({
+    id: row.id,
+    sessionId: row.sessionId || "",
+    userId: row.userId,
+    name: payload.name,
+    status: payload.status,
+    items: payload.items,
+    savedForLater: payload.savedForLater,
+    snapshot: computeSolutionSnapshot([], catalog()),
+    createdAt,
+    updatedAt,
+  });
+}
+
+async function loadFromDb(opts: { id?: string; sessionId?: string; userId?: string | null }): Promise<StoredSolution | undefined> {
+  await initPromise;
+  if (!dbReady || !db) return undefined;
+  try {
+    let rows: any[] = [];
+    if (opts.id) {
+      rows = await db.select().from(storeCarts).where(eq(storeCarts.id, opts.id)).limit(1);
+    } else if (opts.userId) {
+      rows = await db.select().from(storeCarts).where(eq(storeCarts.userId, opts.userId)).limit(8);
+    } else if (opts.sessionId) {
+      rows = await db.select().from(storeCarts).where(eq(storeCarts.sessionId, opts.sessionId)).limit(8);
+    }
+    const now = Date.now();
+    const fresh = rows
+      .filter((row) => !row.expiresAt || new Date(row.expiresAt).getTime() > now)
+      .sort(
+        (left, right) =>
+          new Date(right.updatedAt || 0).getTime() - new Date(left.updatedAt || 0).getTime(),
+      );
+    const row = fresh[0];
+    if (!row) return undefined;
+    const record = rowToSolution(row);
+    solutions.set(record.id, record);
+    return record;
+  } catch (error: any) {
+    console.warn("[store-solution] database load skipped:", error?.message || error);
+    return undefined;
+  }
+}
+
+async function deleteCartRow(id: string): Promise<void> {
+  await initPromise;
+  if (!dbReady || !db) return;
+  try {
+    await db.delete(storeCarts).where(eq(storeCarts.id, id));
+  } catch (error: any) {
+    console.warn("[store-solution] database delete skipped:", error?.message || error);
+  }
+}
+
+export async function persistSolutionRecord(record: StoredSolution): Promise<void> {
+  solutions.set(record.id, record);
+  await initPromise;
+  if (!dbReady || !db) return;
+
+  const expiresAt = new Date(Date.now() + (record.userId ? 90 : 30) * 24 * 60 * 60 * 1000);
+  const values = {
+    sessionId: record.sessionId || null,
+    userId: record.userId,
+    items: serializeCartPayload(record),
+    subtotal: money(record.snapshot.totals.monthly + record.snapshot.totals.dueToday).toFixed(2),
+    expiresAt,
+    updatedAt: new Date(),
+  };
+
+  try {
+    const existing = await db.select({ id: storeCarts.id }).from(storeCarts).where(eq(storeCarts.id, record.id)).limit(1);
+    if (existing[0]) {
+      await db.update(storeCarts).set(values).where(eq(storeCarts.id, record.id));
+      return;
+    }
+    await db.insert(storeCarts).values({ id: record.id, ...values });
+  } catch (error: any) {
+    const message = String(error?.message || error);
+    if (record.userId && /foreign key|violates/i.test(message)) {
+      try {
+        await db
+          .insert(storeCarts)
+          .values({ id: record.id, ...values, userId: null })
+          .onConflictDoUpdate({
+            target: storeCarts.id,
+            set: { ...values, userId: null },
+          });
+        return;
+      } catch (retryError: any) {
+        console.warn("[store-solution] database persist skipped:", retryError?.message || retryError);
+        return;
+      }
+    }
+    console.warn("[store-solution] database persist skipped:", message);
+  }
+}
+
+export async function findSolutionDurable(opts: {
+  id?: string;
+  sessionId?: string;
+  userId?: string | null;
+}): Promise<StoredSolution | undefined> {
+  const memory = findSolution(opts);
+  if (memory) return memory;
+  if (opts.id) {
+    const byId = await loadFromDb({ id: opts.id });
+    if (byId) return byId;
+  }
+  if (opts.userId) {
+    const byUser = await loadFromDb({ userId: opts.userId });
+    if (byUser) return byUser;
+  }
+  if (opts.sessionId) {
+    const bySession = await loadFromDb({ sessionId: opts.sessionId });
+    if (bySession) return bySession;
+  }
+  return undefined;
+}
+
+export async function upsertSolutionDurable(input: {
+  id?: string;
+  sessionId: string;
+  userId?: string | null;
+  name?: string;
+  items: SolutionLineInput[];
+  savedForLater?: SolutionLineInput[];
+}): Promise<StoredSolution> {
+  await findSolutionDurable({ id: input.id, sessionId: input.sessionId, userId: input.userId });
+  const record = upsertSolution(input);
+  await persistSolutionRecord(record);
+  return record;
+}
+
+export async function claimSolutionDurable(sessionId: string, userId: string): Promise<StoredSolution> {
+  const guest = (await findSolutionDurable({ sessionId })) ?? findSolution({ sessionId });
+  const owned = (await findSolutionDurable({ userId })) ?? findSolution({ userId });
+  const result = claimSolution(sessionId, userId);
+  await persistSolutionRecord(result);
+  if (guest && owned && guest.id !== owned.id) {
+    await deleteCartRow(guest.id);
+  }
+  return result;
+}
+
+export async function createSolutionDurable(sessionId: string, userId: string | null = null): Promise<StoredSolution> {
+  const record = createSolution(sessionId, userId);
+  return record;
 }

--- a/server/zoho/zohoCRM.ts
+++ b/server/zoho/zohoCRM.ts
@@ -258,6 +258,35 @@ class ZohoCRMService {
     const leads = await this.searchLeads(`(Email:equals:${email})`);
     return leads[0] || null;
   }
+
+  async searchAccounts(criteria: string): Promise<ZohoCRMAccount[]> {
+    try {
+      const client = await zohoClient.getClient();
+      const response = await client.get("/crm/v6/Accounts/search", {
+        params: { criteria },
+      });
+      return response.data?.data || [];
+    } catch (error: any) {
+      console.error("Error searching accounts:", error.response?.data || error.message);
+      return [];
+    }
+  }
+
+  async createDeal(data: Partial<ZohoCRMDeal> & { Description?: string }): Promise<any> {
+    const client = await zohoClient.getClient();
+    const response = await client.post("/crm/v6/Deals", {
+      data: [data],
+    });
+    return response.data?.data?.[0];
+  }
+
+  async createQuote(data: Record<string, unknown>): Promise<any> {
+    const client = await zohoClient.getClient();
+    const response = await client.post("/crm/v6/Quotes", {
+      data: [data],
+    });
+    return response.data?.data?.[0];
+  }
 }
 
 export const zohoCRMService = new ZohoCRMService();

--- a/shared/storeCommerce.test.ts
+++ b/shared/storeCommerce.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { computeSolutionSnapshot, money, pricingBucket } from "./storeCommerce";
+import { storeProducts } from "../client/src/data/storeProducts";
+
+const catalog = storeProducts.map((product) => ({
+  id: product.id,
+  sku: product.sku,
+  name: product.name,
+  basePrice: product.basePrice,
+  pricingType: product.pricingType,
+  pricingUnit: product.pricingUnit,
+  minimumQuantity: product.minimumQuantity,
+  isCheckoutEnabled: product.isCheckoutEnabled,
+  isContractOnly: product.isContractOnly,
+}));
+
+describe("computeSolutionSnapshot", () => {
+  it("recalculates from catalog list prices and ignores client-supplied amounts", () => {
+    const endpoint = storeProducts.find((product) => product.id === "prod-010");
+    expect(endpoint).toBeTruthy();
+    const snapshot = computeSolutionSnapshot(
+      [{ productId: "prod-010", sku: "DE-SVC-CM-ENDPOINT-CORE-MO", quantity: 10 }],
+      catalog,
+    );
+    expect(snapshot.lines).toHaveLength(1);
+    expect(snapshot.lines[0].unitPrice).toBe(endpoint!.basePrice);
+    expect(snapshot.totals.monthly).toBe(money(endpoint!.basePrice * 10));
+    expect(snapshot.totals.dueToday).toBe(0);
+  });
+
+  it("splits one-time work into Due Today and yearly into Annual", () => {
+    const oneTime = storeProducts.find(
+      (product) => product.pricingType === "one_time" && product.isCheckoutEnabled && !product.isContractOnly,
+    );
+    const yearly = storeProducts.find(
+      (product) => product.pricingType === "yearly" && product.isCheckoutEnabled && !product.isContractOnly,
+    );
+    expect(oneTime && yearly).toBeTruthy();
+    const snapshot = computeSolutionSnapshot(
+      [
+        { productId: oneTime!.id, sku: oneTime!.sku, quantity: 1 },
+        { productId: yearly!.id, sku: yearly!.sku, quantity: 2 },
+      ],
+      catalog,
+    );
+    expect(snapshot.totals.dueToday).toBe(money(oneTime!.basePrice));
+    expect(snapshot.totals.annual).toBe(money(yearly!.basePrice * 2));
+    expect(pricingBucket("yearly")).toBe("annual");
+  });
+
+  it("drops contract-only and unknown SKUs instead of inventing prices", () => {
+    const snapshot = computeSolutionSnapshot(
+      [
+        { productId: "prod-001", quantity: 1 },
+        { productId: "not-a-real-product", quantity: 4 },
+      ],
+      catalog,
+    );
+    expect(snapshot.lines).toHaveLength(0);
+    expect(snapshot.totals.itemCount).toBe(0);
+  });
+
+  it("enforces minimum quantity and merges duplicate lines", () => {
+    const product = storeProducts.find((entry) => entry.id === "prod-010")!;
+    const snapshot = computeSolutionSnapshot(
+      [
+        { productId: product.id, sku: product.sku, quantity: 0 },
+        { productId: product.id, sku: product.sku, quantity: 3 },
+      ],
+      catalog,
+    );
+    expect(snapshot.lines[0].quantity).toBe(3);
+  });
+});

--- a/shared/storeCommerce.ts
+++ b/shared/storeCommerce.ts
@@ -1,0 +1,171 @@
+/**
+ * DE Solution commerce math.
+ *
+ * The Solution is the canonical object. Browser totals are display-only;
+ * the server recalculates from the catalog before persist / quote / checkout.
+ * Zoho Payments remains the money path — this module never talks to Stripe.
+ */
+
+export type CommercePricingType =
+  | "one_time"
+  | "monthly"
+  | "yearly"
+  | "per_hour"
+  | "per_user"
+  | "per_endpoint"
+  | "per_device"
+  | "per_location"
+  | "per_seat";
+
+export type CommerceProduct = {
+  id: string;
+  sku: string;
+  name: string;
+  basePrice: number;
+  pricingType: CommercePricingType;
+  pricingUnit?: string;
+  minimumQuantity: number;
+  isCheckoutEnabled: boolean;
+  isContractOnly: boolean;
+};
+
+export type SolutionLineInput = {
+  productId: string;
+  sku?: string;
+  quantity: number;
+};
+
+export type CanonicalSolutionLine = {
+  productId: string;
+  sku: string;
+  name: string;
+  quantity: number;
+  unitPrice: number;
+  lineTotal: number;
+  pricingType: CommercePricingType;
+  pricingUnit: string;
+  bucket: "dueToday" | "monthly" | "annual";
+};
+
+export type SolutionTotals = {
+  dueToday: number;
+  monthly: number;
+  annual: number;
+  oneTime: number;
+  recurringMonthlyEquivalent: number;
+  itemCount: number;
+  lineCount: number;
+};
+
+export type SolutionSnapshot = {
+  lines: CanonicalSolutionLine[];
+  totals: SolutionTotals;
+};
+
+export function money(value: number): number {
+  return Math.round((value + Number.EPSILON) * 100) / 100;
+}
+
+export function isRecurringPricingType(pricingType: CommercePricingType): boolean {
+  return (
+    pricingType === "monthly" ||
+    pricingType === "yearly" ||
+    pricingType === "per_user" ||
+    pricingType === "per_endpoint" ||
+    pricingType === "per_device" ||
+    pricingType === "per_location" ||
+    pricingType === "per_seat"
+  );
+}
+
+export function pricingBucket(pricingType: CommercePricingType): CanonicalSolutionLine["bucket"] {
+  if (pricingType === "yearly") return "annual";
+  if (isRecurringPricingType(pricingType)) return "monthly";
+  return "dueToday";
+}
+
+export function billingLabel(pricingType: CommercePricingType, unit?: string): string {
+  switch (pricingType) {
+    case "one_time":
+      return "One-time";
+    case "yearly":
+      return unit ? `Per ${unit} / year` : "Annual";
+    case "monthly":
+      return unit ? `Per ${unit} / month` : "Monthly";
+    case "per_hour":
+      return "Hourly / as used";
+    case "per_user":
+    case "per_seat":
+      return "Per user / month";
+    case "per_endpoint":
+    case "per_device":
+      return "Per endpoint / month";
+    case "per_location":
+      return "Per site / month";
+    default:
+      return "Quoted";
+  }
+}
+
+function findProduct(
+  catalog: CommerceProduct[],
+  productId: string,
+  sku?: string,
+): CommerceProduct | undefined {
+  const byId = catalog.find((product) => product.id === productId);
+  if (!byId) return undefined;
+  if (sku && byId.sku !== sku) return undefined;
+  return byId;
+}
+
+/**
+ * Recalculate a solution from catalog list prices.
+ * Client-supplied unit prices are ignored — they are not authoritative.
+ */
+export function computeSolutionSnapshot(
+  lines: SolutionLineInput[],
+  catalog: CommerceProduct[],
+): SolutionSnapshot {
+  const merged = new Map<string, number>();
+  for (const line of lines) {
+    if (!line || typeof line.productId !== "string") continue;
+    const quantity = Number(line.quantity);
+    if (!Number.isFinite(quantity)) continue;
+    merged.set(line.productId, (merged.get(line.productId) ?? 0) + quantity);
+  }
+
+  const canonical: CanonicalSolutionLine[] = [];
+  for (const [productId, rawQuantity] of merged) {
+    const input = lines.find((line) => line.productId === productId);
+    const product = findProduct(catalog, productId, input?.sku);
+    if (!product || product.isContractOnly || !product.isCheckoutEnabled) continue;
+    const quantity = Math.min(10000, Math.max(product.minimumQuantity, Math.floor(rawQuantity)));
+    const unitPrice = money(product.basePrice);
+    const bucket = pricingBucket(product.pricingType);
+    canonical.push({
+      productId: product.id,
+      sku: product.sku,
+      name: product.name,
+      quantity,
+      unitPrice,
+      lineTotal: money(unitPrice * quantity),
+      pricingType: product.pricingType,
+      pricingUnit: product.pricingUnit || "unit",
+      bucket,
+    });
+  }
+
+  const totals: SolutionTotals = {
+    dueToday: money(canonical.filter((line) => line.bucket === "dueToday").reduce((sum, line) => sum + line.lineTotal, 0)),
+    monthly: money(canonical.filter((line) => line.bucket === "monthly").reduce((sum, line) => sum + line.lineTotal, 0)),
+    annual: money(canonical.filter((line) => line.bucket === "annual").reduce((sum, line) => sum + line.lineTotal, 0)),
+    oneTime: 0,
+    recurringMonthlyEquivalent: 0,
+    itemCount: canonical.reduce((sum, line) => sum + line.quantity, 0),
+    lineCount: canonical.length,
+  };
+  totals.oneTime = totals.dueToday;
+  totals.recurringMonthlyEquivalent = money(totals.monthly + totals.annual / 12);
+
+  return { lines: canonical, totals };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The store is now a **Solution**, not a disposable browser cart. This PR is the commerce engine plus the next three slices — not the entire 7-phase B2B platform.

## Architectural decisions
- **Solution is canonical.** Browser state is a cache. Server recalculates from the catalog.
- **Zoho Payments stays the money path.** Stripe / Stripe Billing / Stripe Tax are not added.
- **Portal auth stays the identity path.**
- Typesense, Redis, company RBAC, and admin CMS remain deferred.

## What shipped
- Shared pricing engine: Due Today / Monthly / Annual from catalog list prices
- `PUT/GET /api/store/solutions/current` + `POST /claim` on login merge
- Solutions write through to Postgres `store_carts` when the database is up (`items` jsonb holds items, saved-for-later, name, status). Memory fallback when `DATABASE_URL` is unset
- Canonical Zoho checkout honors `store_client_pricing` (DB first, demo overlay otherwise). Browser `unitPrice` is still ignored. Overrides apply only when `0 < customPrice < list`
- Quote requests canonicalize catalog lines (including contract-only SKUs), emit a preliminary PDF at `GET /api/store/quote-requests/:id/pdf`, and best-effort sync Contact / Account / Deal / Lead / Quotes to Zoho CRM. CRM failure never fails quote create
- Cart drawer: split totals, undo, save for later, checkout via `/store/checkout`
- Confirmation page: download preliminary quote PDF

## Verification
- Vitest: 22 tests covering solution math, cart payload, checkout tamper + client override, quote canonicalize/PDF/CRM description
- API on `:3302`: 8 × $39 = $312/mo persisted; unauthenticated quote `401`; client-1 pricing `prod-010` = $35; tampered `$0.01` quote stored as $35 + contract-only Office $165; PDF is valid `%PDF-1.4`; checkout tamper `409`; trusted total reaches Zoho gate `503` (payments not configured in this environment)
- Browser: confirmation shows `QR-20260818-12J6` and downloads the preliminary PDF at 1440 / 768 / 390

[Quote confirmation at 1440](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fquote_confirmation_1440.png)
[quote_confirmation_pdf_download.mp4](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fquote_confirmation_pdf_download.mp4)

## Preserved
- Catalog, pills, electric store accent, Zoho checkout
- Portal login: `https://portal.digeratiexperts.com/portal/login`

## Still needs DE / production
- `DATABASE_URL` for durable `store_carts` across process restarts
- Zoho CRM credentials for live Contact/Deal/Quote sync
- Zoho Payments for live checkout (intentionally not stubbed)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55eac13a-e87f-4a00-9c34-f63bb77c3080&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

