### PR TITLE
Hide sticky risk-assessment bar while scrolling or overlapping

### DIFF
--- a/client/src/components/StickyCTABar.tsx
+++ b/client/src/components/StickyCTABar.tsx
@@ -51,6 +51,7 @@ export function StickyCTABar() {
 
   useEffect(() => {
     if (dismissed || !routeAllowed) {
+      document.documentElement.dataset.stickyCtaScrolling = "false";
       setPastThreshold(false);
       setScrolling(false);
       setOverlapping(false);
@@ -92,16 +93,21 @@ export function StickyCTABar() {
       setOverlapping(overlayHits || footerHits);
     };
 
+    const markScrolling = (on: boolean) => {
+      document.documentElement.dataset.stickyCtaScrolling = on ? "true" : "false";
+      setScrolling(on);
+    };
+
     const onScroll = () => {
       const scrollY = window.scrollY;
       setPastThreshold(isPastStickyCtaThreshold(scrollY, window.innerHeight));
-      setScrolling(true);
+      markScrolling(true);
       if (Math.abs(scrollY - lastShowScroll.current) >= STICKY_CTA_RESHOW_DELTA_PX) {
         setAutoHidden(false);
       }
       window.clearTimeout(idleTimer);
       idleTimer = window.setTimeout(() => {
-        setScrolling(false);
+        markScrolling(false);
         measureOverlap();
       }, STICKY_CTA_SCROLL_IDLE_MS);
     };
@@ -124,6 +130,7 @@ export function StickyCTABar() {
       window.clearInterval(overlapPoll);
       window.removeEventListener("scroll", onScrollRaf);
       window.removeEventListener("resize", measureOverlap);
+      document.documentElement.dataset.stickyCtaScrolling = "false";
     };
   }, [dismissed, routeAllowed]);
 
@@ -167,10 +174,10 @@ export function StickyCTABar() {
       {visible && (
         <motion.div
           ref={barRef}
-          initial={{ y: 100, opacity: 0 }}
+          initial={{ y: 24, opacity: 0 }}
           animate={{ y: 0, opacity: 1 }}
-          exit={{ y: 100, opacity: 0 }}
-          transition={{ type: "spring", stiffness: 300, damping: 30 }}
+          exit={{ y: 16, opacity: 0 }}
+          transition={{ duration: 0.16, ease: "easeOut" }}
           className="de-bottom-bar"
           data-testid="sticky-cta-bar"
           data-sticky-cta-chrome="true"

--- a/client/src/components/StickyCTABar.tsx
+++ b/client/src/components/StickyCTABar.tsx
@@ -10,6 +10,7 @@ import {
   STICKY_CTA_FALLBACK_HEIGHT,
   STICKY_CTA_RESHOW_DELTA_PX,
   STICKY_CTA_SCROLL_IDLE_MS,
+  isNearDocumentEnd,
   isPastStickyCtaThreshold,
   isStickyCtaRouteAllowed,
   rectOverlapsPageContent,
@@ -80,10 +81,15 @@ export function StickyCTABar() {
         height,
         right: left + width,
       };
-      const hits = rectOverlapsPageContent(rect, (x) =>
+      const overlayHits = rectOverlapsPageContent(rect, (x) =>
         document.elementsFromPoint(x, top + Math.min(20, height / 2)),
       );
-      setOverlapping(hits);
+      const footerHits = isNearDocumentEnd(
+        window.scrollY,
+        window.innerHeight,
+        document.documentElement.scrollHeight,
+      );
+      setOverlapping(overlayHits || footerHits);
     };
 
     const onScroll = () => {
@@ -112,16 +118,23 @@ export function StickyCTABar() {
     onScroll();
     window.addEventListener("scroll", onScrollRaf, { passive: true });
     window.addEventListener("resize", measureOverlap);
+    const overlapPoll = window.setInterval(measureOverlap, 500);
     return () => {
       window.clearTimeout(idleTimer);
+      window.clearInterval(overlapPoll);
       window.removeEventListener("scroll", onScrollRaf);
       window.removeEventListener("resize", measureOverlap);
     };
   }, [dismissed, routeAllowed]);
 
   useEffect(() => {
-    if (!visible) {
+    if (dismissed || !routeAllowed) {
       publishStickyCtaHeight(0);
+      return;
+    }
+    if (!visible) {
+      // Keep the reserved slot while the bar is only parked so the page does not jump.
+      publishStickyCtaHeight(lastHeight.current);
       return;
     }
     lastShowScroll.current = window.scrollY;
@@ -138,9 +151,8 @@ export function StickyCTABar() {
     return () => {
       ro.disconnect();
       window.clearTimeout(hideTimer);
-      publishStickyCtaHeight(0);
     };
-  }, [visible]);
+  }, [visible, dismissed, routeAllowed]);
 
   const handleDismiss = () => {
     setDismissed(true);

--- a/client/src/components/StickyCTABar.tsx
+++ b/client/src/components/StickyCTABar.tsx
@@ -1,75 +1,158 @@
-import { useState, useEffect, useRef } from "react";
-import { motion, AnimatePresence } from "framer-motion";
-import { Shield, ArrowRight, X, Phone } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { ArrowRight, Phone, Shield, X } from "lucide-react";
+import { useLocation } from "wouter";
 import { Button } from "@/components/ui/button";
 import { useBooking } from "@/contexts/BookingContext";
 import { CTA } from "@/lib/ctaCopy";
+import {
+  STICKY_CTA_AUTO_HIDE_MS,
+  STICKY_CTA_FALLBACK_HEIGHT,
+  STICKY_CTA_RESHOW_DELTA_PX,
+  STICKY_CTA_SCROLL_IDLE_MS,
+  isPastStickyCtaThreshold,
+  isStickyCtaRouteAllowed,
+  rectOverlapsPageContent,
+  shouldShowStickyCta,
+} from "@/lib/stickyCtaVisibility";
+
+function publishStickyCtaHeight(px: number) {
+  document.documentElement.style.setProperty("--de-sticky-cta-h", `${Math.round(px)}px`);
+}
 
 export function StickyCTABar() {
-  const [isVisible, setIsVisible] = useState(false);
-  const [isDismissed, setIsDismissed] = useState(false);
+  const [location] = useLocation();
+  const [dismissed, setDismissed] = useState(false);
+  const [pastThreshold, setPastThreshold] = useState(false);
+  const [scrolling, setScrolling] = useState(false);
+  const [overlapping, setOverlapping] = useState(false);
+  const [autoHidden, setAutoHidden] = useState(false);
   const { openBooking } = useBooking();
   const barRef = useRef<HTMLDivElement>(null);
+  const lastShowScroll = useRef(0);
+  const lastHeight = useRef(STICKY_CTA_FALLBACK_HEIGHT);
+
+  const routeAllowed = isStickyCtaRouteAllowed(location);
+  const visible = shouldShowStickyCta({
+    dismissed,
+    routeAllowed,
+    pastThreshold,
+    scrolling,
+    overlapping,
+    autoHidden,
+  });
 
   useEffect(() => {
-    const dismissed = sessionStorage.getItem("stickyCtaDismissed");
-    if (dismissed) {
-      setIsDismissed(true);
-      return;
+    if (sessionStorage.getItem("stickyCtaDismissed")) {
+      setDismissed(true);
     }
-
-    const handleScroll = () => {
-      const scrollY = window.scrollY;
-      const threshold = window.innerHeight * 0.5;
-      const path = window.location.pathname;
-      const isPortalPage = path.startsWith("/portal");
-      const isHomePage = path === "/";
-
-      if (isPortalPage || isHomePage) {
-        setIsVisible(false);
-        return;
-      }
-
-      setIsVisible(scrollY > threshold);
-    };
-
-    window.addEventListener("scroll", handleScroll, { passive: true });
-    handleScroll();
-
-    return () => window.removeEventListener("scroll", handleScroll);
   }, []);
 
   useEffect(() => {
-    const root = document.documentElement;
-    const el = barRef.current;
-    if (!isVisible || isDismissed || !el) {
-      root.style.setProperty("--de-sticky-cta-h", "0px");
+    if (dismissed || !routeAllowed) {
+      setPastThreshold(false);
+      setScrolling(false);
+      setOverlapping(false);
+      setAutoHidden(false);
       return;
     }
 
+    let idleTimer: number | undefined;
+    let ticking = false;
+
+    const measureOverlap = () => {
+      const bar = barRef.current;
+      const height = bar?.offsetHeight || lastHeight.current;
+      const width = bar?.offsetWidth || window.innerWidth - 32;
+      const bottomGap = 16;
+      const unified = Number.parseFloat(
+        getComputedStyle(document.documentElement).getPropertyValue("--de-unified-bar-h"),
+      ) || 0;
+      const cookie = Number.parseFloat(
+        getComputedStyle(document.documentElement).getPropertyValue("--de-cookie-h"),
+      ) || 0;
+      const top = window.innerHeight - bottomGap - cookie - unified - height;
+      const left = bar?.getBoundingClientRect().left ?? 16;
+      const rect = {
+        top,
+        left,
+        width,
+        height,
+        right: left + width,
+      };
+      const hits = rectOverlapsPageContent(rect, (x) =>
+        document.elementsFromPoint(x, top + Math.min(20, height / 2)),
+      );
+      setOverlapping(hits);
+    };
+
+    const onScroll = () => {
+      const scrollY = window.scrollY;
+      setPastThreshold(isPastStickyCtaThreshold(scrollY, window.innerHeight));
+      setScrolling(true);
+      if (Math.abs(scrollY - lastShowScroll.current) >= STICKY_CTA_RESHOW_DELTA_PX) {
+        setAutoHidden(false);
+      }
+      window.clearTimeout(idleTimer);
+      idleTimer = window.setTimeout(() => {
+        setScrolling(false);
+        measureOverlap();
+      }, STICKY_CTA_SCROLL_IDLE_MS);
+    };
+
+    const onScrollRaf = () => {
+      if (ticking) return;
+      ticking = true;
+      window.requestAnimationFrame(() => {
+        onScroll();
+        ticking = false;
+      });
+    };
+
+    onScroll();
+    window.addEventListener("scroll", onScrollRaf, { passive: true });
+    window.addEventListener("resize", measureOverlap);
+    return () => {
+      window.clearTimeout(idleTimer);
+      window.removeEventListener("scroll", onScrollRaf);
+      window.removeEventListener("resize", measureOverlap);
+    };
+  }, [dismissed, routeAllowed]);
+
+  useEffect(() => {
+    if (!visible) {
+      publishStickyCtaHeight(0);
+      return;
+    }
+    lastShowScroll.current = window.scrollY;
+    const el = barRef.current;
+    if (!el) return;
     const publish = () => {
-      root.style.setProperty("--de-sticky-cta-h", `${Math.round(el.offsetHeight)}px`);
+      lastHeight.current = el.offsetHeight;
+      publishStickyCtaHeight(el.offsetHeight);
     };
     publish();
     const ro = new ResizeObserver(publish);
     ro.observe(el);
+    const hideTimer = window.setTimeout(() => setAutoHidden(true), STICKY_CTA_AUTO_HIDE_MS);
     return () => {
       ro.disconnect();
-      root.style.setProperty("--de-sticky-cta-h", "0px");
+      window.clearTimeout(hideTimer);
+      publishStickyCtaHeight(0);
     };
-  }, [isVisible, isDismissed]);
+  }, [visible]);
 
   const handleDismiss = () => {
-    setIsDismissed(true);
+    setDismissed(true);
     sessionStorage.setItem("stickyCtaDismissed", "true");
-    document.documentElement.style.setProperty("--de-sticky-cta-h", "0px");
+    publishStickyCtaHeight(0);
   };
 
-  if (isDismissed) return null;
+  if (dismissed) return null;
 
   return (
     <AnimatePresence>
-      {isVisible && (
+      {visible && (
         <motion.div
           ref={barRef}
           initial={{ y: 100, opacity: 0 }}
@@ -78,6 +161,7 @@ export function StickyCTABar() {
           transition={{ type: "spring", stiffness: 300, damping: 30 }}
           className="de-bottom-bar"
           data-testid="sticky-cta-bar"
+          data-sticky-cta-chrome="true"
         >
           <div className="relative overflow-hidden rounded-2xl border border-pink-400/35 bg-de-raised backdrop-blur-lg shadow-lg shadow-pink-500/20">
             <button

--- a/client/src/components/StickyCTABar.tsx
+++ b/client/src/components/StickyCTABar.tsx
@@ -11,6 +11,7 @@ import {
   STICKY_CTA_RESHOW_DELTA_PX,
   STICKY_CTA_SCROLL_IDLE_MS,
   isNearDocumentEnd,
+  isPageFooterOnScreen,
   isPastStickyCtaThreshold,
   isStickyCtaRouteAllowed,
   rectOverlapsPageContent,
@@ -85,12 +86,16 @@ export function StickyCTABar() {
       const overlayHits = rectOverlapsPageContent(rect, (x) =>
         document.elementsFromPoint(x, top + Math.min(20, height / 2)),
       );
-      const footerHits = isNearDocumentEnd(
+      const footerHits = Array.from(document.querySelectorAll("footer")).some((el) => {
+        if (el.closest("[role='dialog']") || el.closest(".de-desk-shell")) return false;
+        return isPageFooterOnScreen(el.getBoundingClientRect().top, window.innerHeight);
+      });
+      const endHits = isNearDocumentEnd(
         window.scrollY,
         window.innerHeight,
         document.documentElement.scrollHeight,
       );
-      setOverlapping(overlayHits || footerHits);
+      setOverlapping(overlayHits || footerHits || endHits);
     };
 
     const markScrolling = (on: boolean) => {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -330,6 +330,13 @@ html.de-marketing-canvas body {
   );
 }
 
+/* Instantly clear the dock while the visitor is moving so the bar never sits on copy. */
+html[data-sticky-cta-scrolling="true"] .de-bottom-bar {
+  opacity: 0 !important;
+  visibility: hidden;
+  pointer-events: none;
+}
+
 .de-fab-rail {
   position: fixed;
   z-index: 55;

--- a/client/src/lib/stickyCtaVisibility.test.ts
+++ b/client/src/lib/stickyCtaVisibility.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  isNearDocumentEnd,
   isPastStickyCtaThreshold,
   isStickyCtaRouteAllowed,
   rectOverlapsPageContent,
@@ -35,7 +36,7 @@ describe("sticky CTA visibility", () => {
     expect(shouldShowStickyCta({ ...base, dismissed: true })).toBe(false);
   });
 
-  it("treats page content under the bar as overlap", () => {
+  it("does not treat ordinary page copy as overlap", () => {
     const article = {
       closest: () => null,
     } as unknown as Element;
@@ -43,7 +44,24 @@ describe("sticky CTA visibility", () => {
       { top: 700, left: 40, width: 1200, height: 100, right: 1240 },
       () => [article],
     );
-    expect(overlaps).toBe(true);
+    expect(overlaps).toBe(false);
+  });
+
+  it("parks when a dialog or cookie banner sits in the same slot", () => {
+    const dialog = {
+      closest: (selector: string) => (selector === "[role='dialog']" ? dialog : null),
+    } as unknown as Element;
+    expect(
+      rectOverlapsPageContent(
+        { top: 700, left: 40, width: 1200, height: 100, right: 1240 },
+        () => [dialog],
+      ),
+    ).toBe(true);
+  });
+
+  it("parks near the document footer", () => {
+    expect(isNearDocumentEnd(2200, 800, 2400)).toBe(true);
+    expect(isNearDocumentEnd(400, 800, 2400)).toBe(false);
   });
 
   it("ignores the dock and the bar itself", () => {

--- a/client/src/lib/stickyCtaVisibility.test.ts
+++ b/client/src/lib/stickyCtaVisibility.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  isPastStickyCtaThreshold,
+  isStickyCtaRouteAllowed,
+  rectOverlapsPageContent,
+  shouldShowStickyCta,
+} from "./stickyCtaVisibility";
+
+describe("sticky CTA visibility", () => {
+  it("stays off the homepage and portal", () => {
+    expect(isStickyCtaRouteAllowed("/")).toBe(false);
+    expect(isStickyCtaRouteAllowed("/portal/dashboard")).toBe(false);
+    expect(isStickyCtaRouteAllowed("/solutions")).toBe(true);
+    expect(isStickyCtaRouteAllowed("/store")).toBe(true);
+  });
+
+  it("waits until the visitor is halfway down the first screen", () => {
+    expect(isPastStickyCtaThreshold(100, 800)).toBe(false);
+    expect(isPastStickyCtaThreshold(401, 800)).toBe(true);
+  });
+
+  it("hides while scrolling, overlapping, timed out, or dismissed", () => {
+    const base = {
+      dismissed: false,
+      routeAllowed: true,
+      pastThreshold: true,
+      scrolling: false,
+      overlapping: false,
+      autoHidden: false,
+    };
+    expect(shouldShowStickyCta(base)).toBe(true);
+    expect(shouldShowStickyCta({ ...base, scrolling: true })).toBe(false);
+    expect(shouldShowStickyCta({ ...base, overlapping: true })).toBe(false);
+    expect(shouldShowStickyCta({ ...base, autoHidden: true })).toBe(false);
+    expect(shouldShowStickyCta({ ...base, dismissed: true })).toBe(false);
+  });
+
+  it("treats page content under the bar as overlap", () => {
+    const article = {
+      closest: () => null,
+    } as unknown as Element;
+    const overlaps = rectOverlapsPageContent(
+      { top: 700, left: 40, width: 1200, height: 100, right: 1240 },
+      () => [article],
+    );
+    expect(overlaps).toBe(true);
+  });
+
+  it("ignores the dock and the bar itself", () => {
+    const dock = {
+      closest: (selector: string) => (selector === ".de-unified-bar" ? dock : null),
+    } as unknown as Element;
+    const overlaps = rectOverlapsPageContent(
+      { top: 700, left: 40, width: 1200, height: 100, right: 1240 },
+      () => [dock],
+    );
+    expect(overlaps).toBe(false);
+  });
+});

--- a/client/src/lib/stickyCtaVisibility.test.ts
+++ b/client/src/lib/stickyCtaVisibility.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   isNearDocumentEnd,
+  isPageFooterOnScreen,
   isPastStickyCtaThreshold,
   isStickyCtaRouteAllowed,
   rectOverlapsPageContent,
@@ -62,6 +63,11 @@ describe("sticky CTA visibility", () => {
   it("parks near the document footer", () => {
     expect(isNearDocumentEnd(2200, 800, 2400)).toBe(true);
     expect(isNearDocumentEnd(400, 800, 2400)).toBe(false);
+  });
+
+  it("parks as soon as the marketing footer enters the viewport", () => {
+    expect(isPageFooterOnScreen(880, 900)).toBe(true);
+    expect(isPageFooterOnScreen(1200, 900)).toBe(false);
   });
 
   it("ignores the dock and the bar itself", () => {

--- a/client/src/lib/stickyCtaVisibility.ts
+++ b/client/src/lib/stickyCtaVisibility.ts
@@ -2,6 +2,24 @@ export const STICKY_CTA_SCROLL_IDLE_MS = 900;
 export const STICKY_CTA_AUTO_HIDE_MS = 12_000;
 export const STICKY_CTA_RESHOW_DELTA_PX = 160;
 export const STICKY_CTA_FALLBACK_HEIGHT = 112;
+export const STICKY_CTA_END_RESERVE_PX = 160;
+
+const COMPETING_CHROME_SELECTORS = [
+  "[data-testid='sticky-cta-bar']",
+  ".de-bottom-bar",
+  ".de-unified-bar",
+  ".de-fab-rail",
+  "[data-sticky-cta-chrome]",
+];
+
+const BLOCKING_OVERLAY_SELECTORS = [
+  "[role='dialog']",
+  "[aria-modal='true']",
+  "[data-radix-dialog-content]",
+  "[data-radix-dialog-overlay]",
+  "[data-testid='cookie-consent-banner']",
+  ".de-desk-shell",
+];
 
 export function isStickyCtaRouteAllowed(path: string): boolean {
   return path !== "/" && !path.startsWith("/portal");
@@ -9,6 +27,16 @@ export function isStickyCtaRouteAllowed(path: string): boolean {
 
 export function isPastStickyCtaThreshold(scrollY: number, viewportH: number): boolean {
   return scrollY > viewportH * 0.5;
+}
+
+/** Park the bar when the visitor is on the page footer so links stay clickable. */
+export function isNearDocumentEnd(
+  scrollY: number,
+  viewportH: number,
+  scrollHeight: number,
+  reservePx = STICKY_CTA_END_RESERVE_PX,
+): boolean {
+  return scrollY + viewportH >= scrollHeight - reservePx;
 }
 
 export function shouldShowStickyCta(input: {
@@ -31,23 +59,17 @@ export function shouldShowStickyCta(input: {
 
 export function isStickyCtaChrome(el: Element | null): boolean {
   if (!el) return true;
-  return Boolean(
-    el.closest("[data-testid='sticky-cta-bar']") ||
-      el.closest(".de-bottom-bar") ||
-      el.closest(".de-unified-bar") ||
-      el.closest(".de-fab-rail") ||
-      el.closest("[data-sticky-cta-chrome]"),
-  );
+  return COMPETING_CHROME_SELECTORS.some((selector) => el.closest(selector));
 }
 
-/** Page content or a modal under the bar should park it. */
+/** Dialogs, drawers, cookie, and Desk occupy the same dock — page copy does not. */
 export function isBlockingStickyCtaTarget(el: Element | null): boolean {
   if (!el) return false;
   if (typeof document !== "undefined" && (el === document.documentElement || el === document.body)) {
     return false;
   }
   if (isStickyCtaChrome(el)) return false;
-  return true;
+  return BLOCKING_OVERLAY_SELECTORS.some((selector) => el.closest(selector));
 }
 
 export function samplePointsInRect(rect: DOMRect): Array<{ x: number; y: number }> {
@@ -70,7 +92,9 @@ export function rectOverlapsPageContent(
   const body = typeof document === "undefined" ? null : document.body;
   return points.some(({ x }) => {
     const stack = elementsFromPoint(x);
-    const top = stack.find((el) => el !== root && el !== body);
-    return isBlockingStickyCtaTarget(top ?? null);
+    return stack.some((el) => {
+      if (el === root || el === body) return false;
+      return isBlockingStickyCtaTarget(el);
+    });
   });
 }

--- a/client/src/lib/stickyCtaVisibility.ts
+++ b/client/src/lib/stickyCtaVisibility.ts
@@ -1,0 +1,76 @@
+export const STICKY_CTA_SCROLL_IDLE_MS = 900;
+export const STICKY_CTA_AUTO_HIDE_MS = 12_000;
+export const STICKY_CTA_RESHOW_DELTA_PX = 160;
+export const STICKY_CTA_FALLBACK_HEIGHT = 112;
+
+export function isStickyCtaRouteAllowed(path: string): boolean {
+  return path !== "/" && !path.startsWith("/portal");
+}
+
+export function isPastStickyCtaThreshold(scrollY: number, viewportH: number): boolean {
+  return scrollY > viewportH * 0.5;
+}
+
+export function shouldShowStickyCta(input: {
+  dismissed: boolean;
+  routeAllowed: boolean;
+  pastThreshold: boolean;
+  scrolling: boolean;
+  overlapping: boolean;
+  autoHidden: boolean;
+}): boolean {
+  return (
+    !input.dismissed &&
+    input.routeAllowed &&
+    input.pastThreshold &&
+    !input.scrolling &&
+    !input.overlapping &&
+    !input.autoHidden
+  );
+}
+
+export function isStickyCtaChrome(el: Element | null): boolean {
+  if (!el) return true;
+  return Boolean(
+    el.closest("[data-testid='sticky-cta-bar']") ||
+      el.closest(".de-bottom-bar") ||
+      el.closest(".de-unified-bar") ||
+      el.closest(".de-fab-rail") ||
+      el.closest("[data-sticky-cta-chrome]"),
+  );
+}
+
+/** Page content or a modal under the bar should park it. */
+export function isBlockingStickyCtaTarget(el: Element | null): boolean {
+  if (!el) return false;
+  if (typeof document !== "undefined" && (el === document.documentElement || el === document.body)) {
+    return false;
+  }
+  if (isStickyCtaChrome(el)) return false;
+  return true;
+}
+
+export function samplePointsInRect(rect: DOMRect): Array<{ x: number; y: number }> {
+  const y = rect.top + Math.min(24, Math.max(8, rect.height / 2));
+  const inset = Math.min(48, rect.width * 0.12);
+  return [
+    { x: rect.left + inset, y },
+    { x: rect.left + rect.width / 2, y },
+    { x: rect.right - inset, y },
+  ];
+}
+
+export function rectOverlapsPageContent(
+  rect: Pick<DOMRect, "top" | "left" | "width" | "height" | "right">,
+  elementsFromPoint: (x: number) => Element[],
+): boolean {
+  if (rect.width <= 0 || rect.height <= 0) return false;
+  const points = samplePointsInRect(rect as DOMRect);
+  const root = typeof document === "undefined" ? null : document.documentElement;
+  const body = typeof document === "undefined" ? null : document.body;
+  return points.some(({ x }) => {
+    const stack = elementsFromPoint(x);
+    const top = stack.find((el) => el !== root && el !== body);
+    return isBlockingStickyCtaTarget(top ?? null);
+  });
+}

--- a/client/src/lib/stickyCtaVisibility.ts
+++ b/client/src/lib/stickyCtaVisibility.ts
@@ -39,6 +39,11 @@ export function isNearDocumentEnd(
   return scrollY + viewportH >= scrollHeight - reservePx;
 }
 
+/** True once a marketing footer has entered the viewport — not only at the last 160px. */
+export function isPageFooterOnScreen(footerTop: number, viewportH: number): boolean {
+  return Number.isFinite(footerTop) && footerTop < viewportH;
+}
+
 export function shouldShowStickyCta(input: {
   dismissed: boolean;
   routeAllowed: boolean;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The Independent Risk Assessment sticky bar keeps its current size and chrome. It hides the moment the visitor scrolls, when a dialog/Desk/cookie banner occupies the same slot, and whenever a marketing footer is on screen. After the page idles (~900ms) it returns so the CTA is not missed, then auto-hides after 12s and can come back after ~160px more scroll. Session dismiss (X) is unchanged. Hidden on `/` and `/portal/*` as before.

Ordinary page copy is not treated as a permanent overlap. Reserved height stays while the bar is only temporarily hidden so the page does not jump. A document scroll flag hides the bar instantly so tablet/phone do not keep covering copy during the exit animation.

## Testing
- Unit tests for visibility, overlay vs page copy, and footer park
- Browser verify on `/solutions` at 390 / 768 / 1440: idle show, scroll hide, footer hide

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55eac13a-e87f-4a00-9c34-f63bb77c3080&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

