### PR TITLE
ProActive Coverage visualizer on pricing

### DIFF
--- a/client/src/components/pricing/ProActiveCoverageMap.tsx
+++ b/client/src/components/pricing/ProActiveCoverageMap.tsx
@@ -1,0 +1,106 @@
+import { TIER_ORDER, isTierLit, type CoverageTier } from "@/lib/proactiveCoverage";
+
+const LAYERS: { id: CoverageTier; label: string; inset: number }[] = [
+  { id: "enterprise", label: "Enterprise", inset: 8 },
+  { id: "business", label: "Business", inset: 36 },
+  { id: "office", label: "Office", inset: 64 },
+  { id: "it", label: "IT", inset: 92 },
+];
+
+type ProActiveCoverageMapProps = {
+  selected: CoverageTier;
+  onSelect: (tier: CoverageTier) => void;
+};
+
+/**
+ * Graphite coverage rings. Magenta marks the selected depth and every
+ * layer it includes. Teal is reserved for the next unlit ring only.
+ */
+export function ProActiveCoverageMap({ selected, onSelect }: ProActiveCoverageMapProps) {
+  return (
+    <div className="de-style-box p-6 md:p-8" data-testid="proactive-coverage-map">
+      <div className="mb-6 flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+        <div>
+          <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[#F04C97]">
+            ProActive Coverage
+          </p>
+          <h2 className="mt-2 text-2xl font-bold text-white md:text-3xl">
+            Select a package depth<span className="text-[#D3126A]">:</span>
+          </h2>
+          <p className="mt-2 max-w-xl text-sm text-white/55">
+            Rings light from the core outward. IT is the operating baseline; Enterprise adds governance on top of
+            Business.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2" role="tablist" aria-label="ProActive package depth">
+          {TIER_ORDER.map((tier) => {
+            const active = selected === tier;
+            return (
+              <button
+                key={tier}
+                type="button"
+                role="tab"
+                aria-selected={active}
+                onClick={() => onSelect(tier)}
+                className={`h-11 rounded-full border px-4 text-sm font-medium capitalize ${
+                  active
+                    ? "border-[#D3126A] bg-[#D3126A] text-white"
+                    : "border-de-hairline bg-de-raised text-white/75 hover:border-white/25 hover:text-white"
+                }`}
+                data-testid={`coverage-select-${tier}`}
+              >
+                {tier}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <svg
+        viewBox="0 0 640 280"
+        className="mx-auto h-auto w-full max-w-3xl"
+        role="img"
+        aria-label={`Coverage depth selected: ${selected}`}
+      >
+        {LAYERS.map((layer) => {
+          const lit = isTierLit(selected, layer.id);
+          const active = selected === layer.id;
+          const nextUnlit = !lit && tierIndexSafe(layer.id) === tierIndexSafe(selected) + 1;
+          const stroke = active ? "#D3126A" : lit ? "#8A8A8A" : nextUnlit ? "#2DD4BF" : "#2A2A2A";
+          const fill = active ? "rgba(211,18,106,0.08)" : lit ? "#151217" : "#050312";
+          return (
+            <g key={layer.id}>
+              <rect
+                x={layer.inset}
+                y={layer.inset * 0.55}
+                width={640 - layer.inset * 2}
+                height={280 - layer.inset * 1.1}
+                rx={18}
+                fill={fill}
+                stroke={stroke}
+                strokeWidth={active ? 2.5 : 1.25}
+                className="cursor-pointer"
+                onClick={() => onSelect(layer.id)}
+              />
+              <text
+                x={640 - layer.inset - 12}
+                y={layer.inset * 0.55 + 22}
+                textAnchor="end"
+                fill={active ? "#F7A8C8" : lit ? "#EDEDED" : "#6B6B6B"}
+                fontSize="13"
+                fontFamily="Space Grotesk, Inter, sans-serif"
+                className="pointer-events-none"
+              >
+                {layer.label}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+    </div>
+  );
+}
+
+function tierIndexSafe(tier: CoverageTier): number {
+  return TIER_ORDER.indexOf(tier);
+}

--- a/client/src/lib/proactiveCoverage.test.ts
+++ b/client/src/lib/proactiveCoverage.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { coverageRowIsUniform, isTierLit } from "./proactiveCoverage";
+
+describe("proactiveCoverage", () => {
+  it("lights progressive layers up to the selected tier", () => {
+    expect(isTierLit("business", "it")).toBe(true);
+    expect(isTierLit("business", "office")).toBe(true);
+    expect(isTierLit("business", "business")).toBe(true);
+    expect(isTierLit("business", "enterprise")).toBe(false);
+  });
+
+  it("treats identical matrix cells as non-differences", () => {
+    expect(coverageRowIsUniform([true, true, true, true])).toBe(true);
+    expect(coverageRowIsUniform(["addon", "addon", "addon", "addon"])).toBe(true);
+    expect(coverageRowIsUniform([false, true, true, true])).toBe(false);
+  });
+});

--- a/client/src/lib/proactiveCoverage.ts
+++ b/client/src/lib/proactiveCoverage.ts
@@ -1,0 +1,31 @@
+export const TIER_ORDER = ["it", "office", "business", "enterprise"] as const;
+export type CoverageTier = (typeof TIER_ORDER)[number];
+
+export function tierIndex(tier: CoverageTier): number {
+  return TIER_ORDER.indexOf(tier);
+}
+
+export function isTierLit(selected: CoverageTier, candidate: CoverageTier): boolean {
+  return tierIndex(candidate) <= tierIndex(selected);
+}
+
+export function coverageRowIsUniform(cells: readonly unknown[]): boolean {
+  if (cells.length === 0) return true;
+  return cells.every((cell) => String(cell) === String(cells[0]));
+}
+
+export function categoryLayer(categoryId: string): CoverageTier | "always" {
+  switch (categoryId) {
+    case "core-it":
+      return "it";
+    case "workplace-network":
+    case "backup":
+      return "office";
+    case "security-ops":
+      return "business";
+    case "compliance-strategy":
+      return "enterprise";
+    default:
+      return "always";
+  }
+}

--- a/client/src/pages/ProActiveEcosystemPricing.tsx
+++ b/client/src/pages/ProActiveEcosystemPricing.tsx
@@ -351,7 +351,6 @@ export default function ProActiveEcosystemPricing() {
           <section className="mb-6 grid gap-6 md:grid-cols-2 xl:grid-cols-4" aria-label="ProActive Ecosystem packages">
             {estimates.map((plan) => {
               const expanded = !!expandedCards[plan.id];
-              const visibleBullets = expanded ? plan.bullets : plan.bullets.slice(0, PREVIEW_BULLETS);
               const selected = selectedTier === plan.id;
               return (
               <motion.article
@@ -391,8 +390,14 @@ export default function ProActiveEcosystemPricing() {
                   {plan.priceNote && <p className="mt-2 text-xs text-white/50">{plan.priceNote}</p>}
                 </div>
                 <ul className="mb-4 flex-1 space-y-2">
-                  {visibleBullets.map((bullet) => (
-                    <li key={bullet} className="flex items-start gap-2 text-sm text-white/70">
+                  {plan.bullets.map((bullet, index) => (
+                    <li
+                      key={bullet}
+                      className={cn(
+                        "flex items-start gap-2 text-sm text-white/70",
+                        !expanded && index >= PREVIEW_BULLETS && "hidden",
+                      )}
+                    >
                       <Check className="mt-0.5 h-4 w-4 flex-shrink-0 text-emerald-400" />
                       <span>{bullet}</span>
                     </li>

--- a/client/src/pages/ProActiveEcosystemPricing.tsx
+++ b/client/src/pages/ProActiveEcosystemPricing.tsx
@@ -6,13 +6,21 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
   Users, Building2, Shield, Server, Layers, Bookmark, Briefcase,
-  FileCheck, ArrowRight, Check, Calculator, Database, Info,
+  FileCheck, ArrowRight, Check, Calculator, Database, Info, ChevronDown,
 } from "lucide-react";
 import { useSEO } from "@/hooks/useSEO";
 import { Link } from "wouter";
 import { pricing, estimateMonthly, PRICING_SCOPE_NOTE, NO_BLACK_BOX_TAGLINE, type PricingTierKey } from "@/data/pricing";
 import { PricingToolsSection } from "./sections/PricingToolsSection";
 import { CTA } from "@/lib/ctaCopy";
+import { ProActiveCoverageMap } from "@/components/pricing/ProActiveCoverageMap";
+import {
+  categoryLayer,
+  coverageRowIsUniform,
+  isTierLit,
+  type CoverageTier,
+} from "@/lib/proactiveCoverage";
+import { cn } from "@/lib/utils";
 
 type CellValue = boolean | string;
 
@@ -122,8 +130,6 @@ interface PlanCard {
   minUsers?: number;
   siteMin?: number;
   bullets: string[];
-  gradient: string;
-  borderColor: string;
   learnMoreUrl: string;
 }
 
@@ -147,8 +153,6 @@ const plans: PlanCard[] = [
       "Managed Workplace: limited / add-on",
       "No backup included by default",
     ],
-    gradient: "from-slate-500 ",
-    borderColor: "border-slate-500/30",
     learnMoreUrl: pricing.it.learnMoreUrl,
   },
   {
@@ -170,8 +174,6 @@ const plans: PlanCard[] = [
       "Threat Detection / SOC (add-on)",
       "BCDR, cloud backup, compliance reports (add-ons)",
     ],
-    gradient: " ",
-    borderColor: "border-de-hairline",
     learnMoreUrl: pricing.office.learnMoreUrl,
   },
   {
@@ -193,8 +195,6 @@ const plans: PlanCard[] = [
       "Budgeting / planning + 2× tech & security business reviews per year",
       "Spend-card controls included or available",
     ],
-    gradient: " to-fuchsia-500",
-    borderColor: "border-de-hairline",
     learnMoreUrl: pricing.business.learnMoreUrl,
   },
   {
@@ -216,11 +216,11 @@ const plans: PlanCard[] = [
       "Advanced / custom backup, BCDR, data protection strategy",
       "Multi-site / complex network support, executive reporting",
     ],
-    gradient: "from-fuchsia-500 to-pink-500",
-    borderColor: "border-fuchsia-500/40",
     learnMoreUrl: pricing.enterprise.learnMoreUrl,
   },
 ];
+
+const PREVIEW_BULLETS = 5;
 
 const MatrixCell = ({ value }: { value: CellValue }) => {
   if (value === true) {
@@ -243,6 +243,9 @@ export default function ProActiveEcosystemPricing() {
   const prefersReducedMotion = useReducedMotion();
   const [userCount, setUserCount] = useState<number | "">(10);
   const [siteCount, setSiteCount] = useState<number | "">(1);
+  const [selectedTier, setSelectedTier] = useState<CoverageTier>("business");
+  const [expandedCards, setExpandedCards] = useState<Record<string, boolean>>({});
+  const [showDifferencesOnly, setShowDifferencesOnly] = useState(false);
 
   useSEO({
     title: "ProActive Ecosystem Pricing — Managed IT & Cybersecurity Packages",
@@ -275,8 +278,8 @@ export default function ProActiveEcosystemPricing() {
     : { hidden: { opacity: 0, y: 20 }, visible: { opacity: 1, y: 0, transition: { duration: 0.4 } } };
 
   return (
-    <div className="min-h-screen relative overflow-hidden">
-      <div className="fixed inset-0 bg-gradient-to-b from-[#0a0118] via-[#0d0720] to-[#050312]" aria-hidden="true" />
+    <div className="relative min-h-screen overflow-hidden bg-de-bg">
+      <div className="fixed inset-0 bg-de-surface" aria-hidden="true" />
       <div className="relative z-10">
         <MegaMenu />
 
@@ -301,9 +304,13 @@ export default function ProActiveEcosystemPricing() {
             </p>
           </motion.header>
 
+          <section className="mb-14">
+            <ProActiveCoverageMap selected={selectedTier} onSelect={setSelectedTier} />
+          </section>
+
           {/* Estimator */}
           <section className="mb-14" aria-labelledby="estimator-heading">
-            <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-6 md:p-8">
+            <div className="de-style-box p-6 md:p-8">
               <h2 id="estimator-heading" className="flex items-center gap-3 text-xl font-semibold text-white mb-2">
                 <Calculator className="w-5 h-5 text-de-magenta-ink" />
                 Estimate Your Starting Point
@@ -341,56 +348,81 @@ export default function ProActiveEcosystemPricing() {
           </section>
 
           {/* Plan cards */}
-          <section className="grid md:grid-cols-2 xl:grid-cols-4 gap-6 mb-6" aria-label="ProActive Ecosystem packages">
-            {estimates.map((plan) => (
+          <section className="mb-6 grid gap-6 md:grid-cols-2 xl:grid-cols-4" aria-label="ProActive Ecosystem packages">
+            {estimates.map((plan) => {
+              const expanded = !!expandedCards[plan.id];
+              const visibleBullets = expanded ? plan.bullets : plan.bullets.slice(0, PREVIEW_BULLETS);
+              const selected = selectedTier === plan.id;
+              return (
               <motion.article
                 key={plan.id}
-                className={`relative rounded-2xl border ${plan.borderColor} bg-white/[0.03] p-6 flex flex-col`}
+                className={cn(
+                  "relative flex flex-col rounded-2xl border bg-de-raised p-6",
+                  selected ? "border-[#D3126A]" : "border-de-hairline",
+                )}
                 initial={prefersReducedMotion ? undefined : "hidden"}
                 whileInView={prefersReducedMotion ? undefined : "visible"}
                 viewport={{ once: true }}
                 variants={fadeIn}
                 data-testid={`plan-card-${plan.id}`}
               >
-                <div className={`inline-flex self-start px-3 py-1 rounded-full bg-de-magenta text-white text-xs font-semibold mb-4`}>
+                <button
+                  type="button"
+                  className="mb-4 inline-flex self-start rounded-full border border-de-hairline bg-de-bg px-3 py-1 text-xs font-semibold text-white"
+                  onClick={() => setSelectedTier(plan.id as CoverageTier)}
+                >
                   {plan.shortName}
-                </div>
-                <h3 className="text-lg font-bold text-white mb-1">{plan.name}</h3>
-                <p className="text-sm text-white/50 mb-4">{plan.tagline}</p>
+                </button>
+                <h3 className="mb-1 text-lg font-bold text-white">{plan.name}</h3>
+                <p className="mb-4 text-sm text-white/50">{plan.tagline}</p>
                 <div className="mb-4">
-                  <p className="text-de-magenta-ink font-semibold">{plan.priceLabel}</p>
+                  <p className="font-semibold text-de-magenta-ink">{plan.priceLabel}</p>
                   {plan.siteMin ? (
-                    <p className="text-xs text-white/50 mt-1">${plan.siteMin.toLocaleString()}/site/mo minimum</p>
+                    <p className="mt-1 text-xs text-white/50">${plan.siteMin.toLocaleString()}/site/mo minimum</p>
                   ) : null}
                   {plan.minUsers ? (
-                    <p className="text-xs text-white/50 mt-1">Minimum {plan.minUsers} users</p>
+                    <p className="mt-1 text-xs text-white/50">Minimum {plan.minUsers} users</p>
                   ) : null}
                   {plan.monthlyEstimate != null && (
-                    <p className="text-2xl font-bold text-white mt-2" data-testid={`estimate-${plan.id}`}>
+                    <p className="mt-2 text-2xl font-bold text-white" data-testid={`estimate-${plan.id}`}>
                       ~${plan.monthlyEstimate.toLocaleString()}<span className="text-sm font-normal text-white/50">/mo</span>
                     </p>
                   )}
-                  {plan.priceNote && <p className="text-xs text-white/50 mt-2">{plan.priceNote}</p>}
+                  {plan.priceNote && <p className="mt-2 text-xs text-white/50">{plan.priceNote}</p>}
                 </div>
-                <ul className="space-y-2 mb-6 flex-1">
-                  {plan.bullets.map((bullet) => (
+                <ul className="mb-4 flex-1 space-y-2">
+                  {visibleBullets.map((bullet) => (
                     <li key={bullet} className="flex items-start gap-2 text-sm text-white/70">
-                      <Check className="w-4 h-4 text-emerald-400 mt-0.5 flex-shrink-0" />
+                      <Check className="mt-0.5 h-4 w-4 flex-shrink-0 text-emerald-400" />
                       <span>{bullet}</span>
                     </li>
                   ))}
                 </ul>
+                {plan.bullets.length > PREVIEW_BULLETS && (
+                  <button
+                    type="button"
+                    className="mb-4 inline-flex items-center gap-1 text-sm text-[#F04C97] hover:text-white"
+                    onClick={() =>
+                      setExpandedCards((current) => ({ ...current, [plan.id]: !current[plan.id] }))
+                    }
+                    data-testid={`plan-expand-${plan.id}`}
+                  >
+                    {expanded ? "Show less" : `Show all ${plan.bullets.length} outcomes`}
+                    <ChevronDown className={cn("h-4 w-4", expanded && "rotate-180")} />
+                  </button>
+                )}
                 <Link href={plan.learnMoreUrl}>
                   <Button
                     variant="outline"
-                    className="w-full border-de-hairline bg-white/5 text-white hover:border-de-hairline hover:bg-de-raised hover:text-white"
+                    className="w-full border-de-hairline bg-de-bg text-white hover:border-[#D3126A] hover:bg-de-raised hover:text-white"
                   >
-                    Learn More
-                    <ArrowRight className="w-4 h-4 ml-2" />
+                    Explore {plan.shortName}
+                    <ArrowRight className="ml-2 h-4 w-4" />
                   </Button>
                 </Link>
               </motion.article>
-            ))}
+              );
+            })}
           </section>
 
           <p className="text-center text-sm text-white/55 mb-16 max-w-2xl mx-auto">
@@ -398,64 +430,112 @@ export default function ProActiveEcosystemPricing() {
             assessment of your environment, security needs, and selected add-ons.
           </p>
 
-          {/* Comparison matrix */}
+          {/* Coverage Explorer — same matrix facts, progressive reveal */}
           <section className="mb-16" aria-labelledby="matrix-heading">
-            <div className="text-center mb-8">
-              <h2 id="matrix-heading" className="text-3xl font-bold text-white mb-2">
-                Service Comparison Matrix
-              </h2>
-              <p className="text-white/60">
-                What's included, enhanced, or available as an add-on across each ProActive Ecosystem package.
-              </p>
+            <div className="mb-8 flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+              <div>
+                <h2 id="matrix-heading" className="mb-2 text-3xl font-bold text-white">
+                  Coverage Explorer
+                </h2>
+                <p className="text-white/60">
+                  What's included, enhanced, or available as an add-on across each ProActive Ecosystem package.
+                </p>
+              </div>
+              <label className="inline-flex h-11 items-center gap-2 text-sm text-white/70">
+                <input
+                  type="checkbox"
+                  checked={showDifferencesOnly}
+                  onChange={(event) => setShowDifferencesOnly(event.target.checked)}
+                  className="h-4 w-4 accent-[#D3126A]"
+                  data-testid="coverage-show-differences"
+                />
+                Show differences only
+              </label>
             </div>
 
             <div className="space-y-8">
-              {matrixCategories.map((category) => (
-                <div key={category.id} className="rounded-2xl border border-white/10 bg-white/[0.02] overflow-hidden">
-                  <div className="flex items-center gap-3 px-5 py-4 border-b border-white/10">
+              {matrixCategories.map((category) => {
+                const layer = categoryLayer(category.id);
+                const dimmed = layer !== "always" && !isTierLit(selectedTier, layer);
+                const services = showDifferencesOnly
+                  ? category.services.filter(
+                      (service) =>
+                        !coverageRowIsUniform([
+                          service.it,
+                          service.office,
+                          service.business,
+                          service.enterprise,
+                        ]),
+                    )
+                  : category.services;
+                if (services.length === 0) return null;
+                return (
+                <div
+                  key={category.id}
+                  className={cn(
+                    "overflow-hidden rounded-2xl border border-de-hairline bg-de-raised",
+                    dimmed && "opacity-55",
+                  )}
+                >
+                  <div className="flex items-center gap-3 border-b border-white/10 px-5 py-4">
                     <span className="text-de-magenta-ink">{category.icon}</span>
                     <h3 className="font-semibold text-white">{category.title}</h3>
                     {category.ribbon && (
-                      <span className="ml-auto text-xs text-amber-400/90 border border-amber-400/30 rounded-full px-3 py-1">
+                      <span className="ml-auto rounded-full border border-amber-400/30 px-3 py-1 text-xs text-amber-400/90">
                         {category.ribbon}
                       </span>
                     )}
                   </div>
-                  <div className="overflow-x-auto">
+                  <div className="max-h-[70vh] overflow-auto">
                     <table className="w-full text-left">
-                      <thead>
+                      <thead className="sticky top-0 z-10 bg-de-raised">
                         <tr className="text-xs uppercase tracking-wide text-white/55">
-                          <th className="px-5 py-3 font-medium min-w-[220px]">Service</th>
-                          <th className="px-3 py-3 font-medium text-center">IT</th>
-                          <th className="px-3 py-3 font-medium text-center">Office</th>
-                          <th className="px-3 py-3 font-medium text-center">Business</th>
-                          <th className="px-3 py-3 font-medium text-center">Enterprise</th>
+                          <th className="min-w-[220px] px-5 py-3 font-medium">Service</th>
+                          {(["it", "office", "business", "enterprise"] as CoverageTier[]).map((tier) => (
+                            <th
+                              key={tier}
+                              className={cn(
+                                "px-3 py-3 text-center font-medium capitalize",
+                                selectedTier === tier && "text-[#F04C97]",
+                              )}
+                            >
+                              {tier}
+                            </th>
+                          ))}
                         </tr>
                       </thead>
                       <tbody>
-                        {category.services.map((service) => (
+                        {services.map((service) => (
                           <tr key={service.name} className="border-t border-white/5">
                             <td className="px-5 py-3 text-sm text-white/80">
                               <span className="inline-flex items-center gap-1.5">
                                 {service.name}
                                 {service.tooltip && (
                                   <span title={service.tooltip}>
-                                    <Info className="w-3.5 h-3.5 text-white/55" aria-label={service.tooltip} />
+                                    <Info className="h-3.5 w-3.5 text-white/55" aria-label={service.tooltip} />
                                   </span>
                                 )}
                               </span>
                             </td>
-                            <td className="px-3 py-3 text-center"><MatrixCell value={service.it} /></td>
-                            <td className="px-3 py-3 text-center"><MatrixCell value={service.office} /></td>
-                            <td className="px-3 py-3 text-center"><MatrixCell value={service.business} /></td>
-                            <td className="px-3 py-3 text-center"><MatrixCell value={service.enterprise} /></td>
+                            {(["it", "office", "business", "enterprise"] as CoverageTier[]).map((tier) => (
+                              <td
+                                key={tier}
+                                className={cn(
+                                  "px-3 py-3 text-center",
+                                  selectedTier === tier && "bg-[#D3126A]/10",
+                                )}
+                              >
+                                <MatrixCell value={service[tier]} />
+                              </td>
+                            ))}
                           </tr>
                         ))}
                       </tbody>
                     </table>
                   </div>
                 </div>
-              ))}
+                );
+              })}
             </div>
 
             <p className="text-center text-xs text-white/55 mt-6 max-w-3xl mx-auto">

--- a/client/src/pages/sections/DigeratiCalculatorsSection.tsx
+++ b/client/src/pages/sections/DigeratiCalculatorsSection.tsx
@@ -42,14 +42,8 @@ export const DigeratiCalculatorsSection = (props: CalculatorProps): JSX.Element 
   const [pricingExpanded, setPricingExpanded] = useState(false);
 
   return (
-    <section id="calculators" className="py-14 md:py-18 lg:py-20 relative overflow-hidden bg-[#0a0a0a]">
-      {/* Subtle background accent */}
-      <div 
-        className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[800px] h-[400px] pointer-events-none opacity-30"
-        style={{ background: "radial-gradient(ellipse, rgba(139, 92, 246, 0.1) 0%, transparent 60%)" }}
-      />
-
-      <div className="max-w-4xl mx-auto px-3 sm:px-4 lg:px-6 relative z-10">
+    <section id="calculators" className="relative overflow-hidden py-6 md:py-8">
+      <div className="relative z-10 mx-auto max-w-4xl px-0">
         {/* Section header */}
         <motion.div 
           className="text-center mb-8 md:mb-10"
@@ -79,7 +73,7 @@ export const DigeratiCalculatorsSection = (props: CalculatorProps): JSX.Element 
             viewport={{ once: true, margin: "-30px" }}
             transition={{ duration: 0.3 }}
           >
-            <Card className="bg-[#111111] border border-white/[0.08] rounded-xl overflow-hidden">
+            <Card className="overflow-hidden rounded-xl border border-de-hairline bg-de-raised">
               {/* Accordion trigger */}
               <button
                 onClick={() => setDowntimeExpanded(!downtimeExpanded)}
@@ -209,12 +203,7 @@ export const DigeratiCalculatorsSection = (props: CalculatorProps): JSX.Element 
                       </div>
 
                       {/* Results area */}
-                      <div 
-                        className="p-6 md:p-8 border-t border-white/[0.06]"
-                        style={{
-                          background: "linear-gradient(135deg, rgba(139, 92, 246, 0.08) 0%, rgba(168, 85, 247, 0.05) 50%, rgba(192, 38, 211, 0.03) 100%)",
-                        }}
-                      >
+                      <div className="border-t border-white/10 bg-de-bg p-6 md:p-8">
                         <div className="grid sm:grid-cols-2 gap-6">
                           <div className="text-center sm:text-left">
                             <p className="text-xs font-bold text-white/50 uppercase tracking-widest mb-2">Per-Incident Cost</p>
@@ -257,7 +246,7 @@ export const DigeratiCalculatorsSection = (props: CalculatorProps): JSX.Element 
             viewport={{ once: true, margin: "-30px" }}
             transition={{ duration: 0.3, delay: 0.05 }}
           >
-            <Card className="bg-[#111111] border border-white/[0.08] rounded-xl overflow-hidden">
+            <Card className="overflow-hidden rounded-xl border border-de-hairline bg-de-raised">
               {/* Accordion trigger */}
               <button
                 onClick={() => setPricingExpanded(!pricingExpanded)}
@@ -346,12 +335,7 @@ export const DigeratiCalculatorsSection = (props: CalculatorProps): JSX.Element 
                       </div>
 
                       {/* Results area */}
-                      <div 
-                        className="p-6 md:p-8 border-t border-white/[0.06]"
-                        style={{
-                          background: "linear-gradient(135deg, rgba(139, 92, 246, 0.08) 0%, rgba(168, 85, 247, 0.05) 50%, rgba(192, 38, 211, 0.03) 100%)",
-                        }}
-                      >
+                      <div className="border-t border-white/10 bg-de-bg p-6 md:p-8">
                         <div className="text-center">
                           <p className="text-xs font-bold text-white/50 uppercase tracking-widest mb-2">Estimated Monthly Cost</p>
                           <p className="text-4xl md:text-5xl font-bold text-de-magenta-ink">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Phase 2 — Pricing visual system

Separate from the store trust / Solution PR. Restyles `/proactive-ecosystem-pricing` without deleting facts, calculator inputs, matrix rows, or CTAs.

### What changed
- **ProActive Coverage** SVG: graphite rings, magenta for the selected depth, teal only on the next unlit ring.
- Selecting IT / Office / Business / Enterprise lights progressive layers and highlights that column in the matrix.
- Package cards preview 5 outcomes, then expand to the full existing list. All 8 IT outcomes stay in the DOM when collapsed. **Explore {tier}** replaces Learn More (same URLs).
- Matrix is a **Coverage Explorer** with sticky tier headers and **Show differences only** (21 rows → 16 when filtering identical cells).
- Estimator and downtime/investment calculators stay. Removed the isolated black field and leftover purple washes.

### Not added
- Photography, shields, neon, or invented customer counts / trust-strip stats.

### Verification
- Helper tests for progressive lighting and difference rows.
- Browser: 1440 coverage map + IT selection, 390 stacked tabs, expand-to-8 outcomes, no horizontal overflow at 390 / 768 / 1440.

[ProActive Coverage map at 1440](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpricing_coverage_1440.png)
[IT depth selected at 1440](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpricing_coverage_it_1440.png)
[Coverage map on 390](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpricing_coverage_390.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55eac13a-e87f-4a00-9c34-f63bb77c3080&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

