### PR TITLE
Homepage chapter fields, grain, and photography parallax

### DIFF
--- a/client/src/components/visual/ParallaxStill.tsx
+++ b/client/src/components/visual/ParallaxStill.tsx
@@ -50,24 +50,26 @@ export function ParallaxStill({
   const extra = reduceMotion ? 0 : travel;
 
   return (
-    <div ref={ref} className={cn("relative overflow-hidden", className)}>
-      <motion.img
-        src={src}
-        alt={alt}
-        sizes={sizes}
-        loading={loading}
-        decoding="async"
-        width={width}
-        height={height}
-        aria-hidden={alt === "" ? true : undefined}
-        data-testid={testId}
-        className={cn("absolute left-0 w-full object-cover object-center", imgClassName)}
-        style={{
-          y,
-          top: extra ? `-${extra}%` : 0,
-          height: extra ? `${100 + extra * 2}%` : "100%",
-        }}
-      />
+    <div className={cn("relative overflow-hidden", className)}>
+      <div ref={ref} className="absolute inset-0">
+        <motion.img
+          src={src}
+          alt={alt}
+          sizes={sizes}
+          loading={loading}
+          decoding="async"
+          width={width}
+          height={height}
+          aria-hidden={alt === "" ? true : undefined}
+          data-testid={testId}
+          className={cn("absolute left-0 w-full object-cover object-center", imgClassName)}
+          style={{
+            y,
+            top: extra ? `-${extra}%` : 0,
+            height: extra ? `${100 + extra * 2}%` : "100%",
+          }}
+        />
+      </div>
     </div>
   );
 }

--- a/client/src/components/visual/ParallaxStill.tsx
+++ b/client/src/components/visual/ParallaxStill.tsx
@@ -1,0 +1,73 @@
+import { useRef } from "react";
+import { motion, useReducedMotion, useScroll, useTransform } from "framer-motion";
+import { cn } from "@/lib/utils";
+
+/** Extra travel as a percent of the frame. 8–14 is cinematic; keep ≤14. */
+export function parallaxTravelRange(
+  reduceMotion: boolean | null,
+  travelPercent: number,
+): [string, string] {
+  if (reduceMotion) return ["0%", "0%"];
+  return [`-${travelPercent}%`, `${travelPercent}%`];
+}
+
+type ParallaxStillProps = {
+  src: string;
+  alt: string;
+  className?: string;
+  imgClassName?: string;
+  travel?: number;
+  sizes?: string;
+  loading?: "eager" | "lazy";
+  width?: number;
+  height?: number;
+  testId?: string;
+};
+
+/**
+ * In-frame photography parallax. Parent should clip (`overflow-hidden`).
+ * Reduced motion holds the still. Do not use on card grids, forms, or FAQ.
+ */
+export function ParallaxStill({
+  src,
+  alt,
+  className,
+  imgClassName,
+  travel = 12,
+  sizes,
+  loading = "lazy",
+  width,
+  height,
+  testId,
+}: ParallaxStillProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const reduceMotion = useReducedMotion();
+  const { scrollYProgress } = useScroll({
+    target: ref,
+    offset: ["start end", "end start"],
+  });
+  const y = useTransform(scrollYProgress, [0, 1], parallaxTravelRange(reduceMotion, travel));
+  const extra = reduceMotion ? 0 : travel;
+
+  return (
+    <div ref={ref} className={cn("relative overflow-hidden", className)}>
+      <motion.img
+        src={src}
+        alt={alt}
+        sizes={sizes}
+        loading={loading}
+        decoding="async"
+        width={width}
+        height={height}
+        aria-hidden={alt === "" ? true : undefined}
+        data-testid={testId}
+        className={cn("absolute left-0 w-full object-cover object-center", imgClassName)}
+        style={{
+          y,
+          top: extra ? `-${extra}%` : 0,
+          height: extra ? `${100 + extra * 2}%` : "100%",
+        }}
+      />
+    </div>
+  );
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -157,6 +157,9 @@ html.de-store-gesture-lock body {
   --de-paper: #f7f5f2;
   --de-paper-raised: #ffffff;
   --de-paper-hairline: rgba(26, 18, 16, 0.1);
+  /* Film grain as premultiplied SVG so chapters can also keep fade pseudos. */
+  --de-field-grain: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='deGrain' x='0' y='0'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.75' numOctaves='4' stitchTiles='stitch' result='n'/%3E%3CfeColorMatrix type='matrix' values='0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.05 0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23deGrain)'/%3E%3C/svg%3E");
+  --de-field-grain-paper: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='deGrainPaper' x='0' y='0'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch' result='n'/%3E%3CfeColorMatrix type='matrix' values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.045 0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23deGrainPaper)'/%3E%3C/svg%3E");
   --de-fg: #ffffff;
   /* Floor ≥ ~4.5:1 body text on --de-bg / --de-surface / --de-raised.
    * Prefer these over ad-hoc text-white/50–/60 and pink-300 on dark fields. */
@@ -428,9 +431,21 @@ html.de-marketing-canvas body {
 /* Contained chapter field — one step lighter than the well so page black
  * shows in the gutters. Magenta pops on this quiet charcoal, not yellow. */
 .de-style-box {
+  position: relative;
+  isolation: isolate;
   background-color: var(--de-raised);
   border: 1px solid var(--de-hairline);
   border-radius: 1.5rem;
+}
+.de-style-box::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  border-radius: inherit;
+  background-image: var(--de-field-grain);
+  background-size: 180px 180px;
 }
 .de-style-box-inset {
   background-color: var(--de-bg);
@@ -472,7 +487,51 @@ html.de-marketing-canvas body {
   box-shadow: 0 8px 32px rgba(26, 18, 16, 0.1);
 }
 
-/* Hairline fade between dark graphite and paper chapters. No parallax. */
+/*
+ * Film grain + corner lighting — opt-in per chapter.
+ * Grain is a background-image so fade ::before/::after stay available.
+ * .de-field-grain-film overlays photography (hero / CTA) above the still
+ * and under copy (z-index: 1 vs content z-10).
+ * Violet/magenta appear only as lighting. Never as a wash fill.
+ */
+.de-field-grain {
+  background-image: var(--de-field-grain);
+  background-size: 180px 180px;
+}
+
+.de-field-grain-paper {
+  background-image: var(--de-field-grain-paper);
+  background-size: 180px 180px;
+}
+
+.de-field-grain-film,
+.de-field-lit {
+  position: relative;
+  isolation: isolate;
+}
+
+.de-field-grain-film::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  background-image: var(--de-field-grain);
+  background-size: 180px 180px;
+}
+
+.de-field-lit::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(ellipse 48% 70% at 92% -8%, rgba(211, 18, 106, 0.14) 0%, transparent 58%),
+    radial-gradient(ellipse 42% 64% at 6% 108%, rgba(91, 69, 224, 0.10) 0%, transparent 56%);
+}
+
+/* Hairline fade between dark graphite and paper chapters. Do not parallax the fade. */
 .de-chapter-fade-from-dark {
   position: relative;
 }
@@ -504,6 +563,23 @@ html.de-marketing-canvas body {
 }
 @media (prefers-reduced-motion: reduce) {
   .de-chapter-fade-to-dark::after {
+    height: 32px;
+  }
+}
+
+.de-chapter-fade-to-surface {
+  position: relative;
+}
+.de-chapter-fade-to-surface::after {
+  content: "";
+  pointer-events: none;
+  position: absolute;
+  inset: auto 0 0 0;
+  height: 72px;
+  background: linear-gradient(to bottom, transparent, var(--de-surface));
+}
+@media (prefers-reduced-motion: reduce) {
+  .de-chapter-fade-to-surface::after {
     height: 32px;
   }
 }
@@ -550,12 +626,23 @@ html.de-marketing-canvas body {
 }
 
 .de-process-band {
+  position: relative;
+  isolation: isolate;
   background-color: var(--de-surface);
   background-image:
     radial-gradient(ellipse 42% 120% at 16% -30%, rgba(91, 69, 224, 0.22) 0%, transparent 62%),
     radial-gradient(ellipse 34% 110% at 88% -24%, rgba(211, 18, 106, 0.14) 0%, transparent 60%);
   border-top: 1px solid var(--de-hairline);
   border-bottom: 1px solid var(--de-hairline);
+}
+.de-process-band::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background-image: var(--de-field-grain);
+  background-size: 180px 180px;
 }
 
 /* Primary nav labels must never crop glyphs when type/logo scale up */

--- a/client/src/lib/homepageFields.test.ts
+++ b/client/src/lib/homepageFields.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("homepage chapter fields", () => {
+  const css = readFileSync(path.resolve(__dirname, "../index.css"), "utf8");
+  const homepage = readFileSync(
+    path.resolve(__dirname, "../pages/DigeratiHomepage.tsx"),
+    "utf8",
+  );
+  const insights = readFileSync(
+    path.resolve(__dirname, "../pages/sections/DigeratiThreatsInsightsSection.tsx"),
+    "utf8",
+  );
+
+  it("defines grain, paper grain, film overlay, lighting, and surface fade as opt-in utilities", () => {
+    expect(css).toContain("--de-field-grain:");
+    expect(css).toContain("--de-field-grain-paper:");
+    expect(css).toContain(".de-field-grain {");
+    expect(css).toContain(".de-field-grain-paper {");
+    expect(css).toContain(".de-field-grain-film::after");
+    expect(css).toContain(".de-field-lit::before");
+    expect(css).toContain(".de-chapter-fade-to-surface");
+    expect(css).toContain("isolation: isolate");
+  });
+
+  it("keeps lighting as radial washes, not a violet fill", () => {
+    const litBlock = css.slice(css.indexOf(".de-field-lit::before"), css.indexOf(".de-field-lit::before") + 520);
+    expect(litBlock).toContain("rgba(211, 18, 106");
+    expect(litBlock).toContain("rgba(91, 69, 224");
+    expect(litBlock).not.toMatch(/background-color:\s*#(5B45E0|8B5CF6|7c3aed)/i);
+  });
+
+  it("recedes insights after the pricing surface so the pair is not two slabs", () => {
+    expect(insights).toMatch(/className="de-dark-well/);
+    expect(homepage).toContain("DigeratiThreatsInsightsSection");
+    expect(homepage).toContain("DigeratiPricingSection");
+  });
+});

--- a/client/src/lib/parallaxStill.test.ts
+++ b/client/src/lib/parallaxStill.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { parallaxTravelRange } from "@/components/visual/ParallaxStill";
+
+describe("parallaxTravelRange", () => {
+  it("holds still when the visitor prefers reduced motion", () => {
+    expect(parallaxTravelRange(true, 12)).toEqual(["0%", "0%"]);
+  });
+
+  it("travels equally above and below the frame", () => {
+    expect(parallaxTravelRange(false, 12)).toEqual(["-12%", "12%"]);
+    expect(parallaxTravelRange(null, 8)).toEqual(["-8%", "8%"]);
+  });
+});

--- a/client/src/pages/DigeratiHomepage.tsx
+++ b/client/src/pages/DigeratiHomepage.tsx
@@ -55,7 +55,11 @@ export const DigeratiHomepage = (): JSX.Element => {
 
   return (
     <FullPageScrollProvider sections={homepageSections} enableOnMobile={false}>
-      {/* Live shade well + A+C canvas base. Ask DE sits bottom-right. */}
+      {/* Live shade well + A+C canvas base. Ask DE sits bottom-right.
+          Chapter fields are neighbor-aware: well → style-box → well → surface →
+          paper → process band → well → paper → well → style-box → surface →
+          well (insights) → surface (office photo) → paper (lead+FAQ) →
+          surface (newsletter) → cinematic well (CTA) → quiet well (contact). */}
       <div className="de-dark-well min-h-screen bg-[#050312] pb-8">
         <OrganizationJsonLd />
         <WebSiteJsonLd />

--- a/client/src/pages/sections/DigeratiAIAssistanceSection.tsx
+++ b/client/src/pages/sections/DigeratiAIAssistanceSection.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button";
 import { motion, useReducedMotion } from "framer-motion";
 import { useBooking } from "@/contexts/BookingContext";
 import { CTA } from "@/lib/ctaCopy";
+import { ParallaxStill } from "@/components/visual/ParallaxStill";
 import officeEveningImg from "@assets/de-arizona-office-evening.png";
 
 const capabilities = [
@@ -17,28 +18,27 @@ export const DigeratiAIAssistanceSection = (): JSX.Element => {
   const { openBooking } = useBooking();
 
   return (
-    <section className="de-dark-chapter de-chapter-hairline relative overflow-hidden py-20">
+    <section className="de-dark-chapter de-chapter-hairline de-field-grain de-field-lit relative overflow-hidden py-20">
       <div className="container mx-auto px-3 sm:px-4 lg:px-6 relative z-10">
-        <div className="grid lg:grid-cols-2 gap-12 items-center">
+        <div className="grid items-stretch gap-12 lg:grid-cols-2">
           <motion.div
-            className="flex justify-center lg:justify-start order-2 lg:order-1"
+            className="order-2 flex justify-center lg:order-1 lg:justify-start"
             initial={prefersReducedMotion ? {} : { opacity: 0, x: -24 }}
             whileInView={{ opacity: 1, x: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.5 }}
           >
-            <div className="relative max-w-md w-full">
-              <div className="relative rounded-2xl overflow-hidden border border-white/10 shadow-2xl">
-                <img
+            <div className="relative w-full max-w-md lg:max-w-none lg:h-full">
+              <div className="relative flex aspect-[4/3] min-h-[16rem] overflow-hidden rounded-2xl border border-white/10 shadow-2xl lg:aspect-auto lg:h-full lg:min-h-[22rem]">
+                <ParallaxStill
                   src={officeEveningImg}
                   alt="Arizona professional office where Digerati Experts supports local businesses"
-                  loading="lazy"
-                  decoding="async"
+                  travel={10}
                   width={448}
                   height={300}
-                  className="w-full object-cover aspect-[4/3]"
+                  className="absolute inset-0"
                 />
-                <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/90 to-transparent p-6">
+                <div className="relative mt-auto w-full bg-gradient-to-t from-black/90 to-transparent p-6 pt-16">
                   <p className="text-base font-medium text-white">Local operations. Human judgment.</p>
                   <p className="text-base text-white/75 mt-1">
                     Arizona-based · Principal-led · Always-on monitoring

--- a/client/src/pages/sections/DigeratiAlertBanner.tsx
+++ b/client/src/pages/sections/DigeratiAlertBanner.tsx
@@ -50,7 +50,7 @@ export const DigeratiAlertBanner = (): JSX.Element => {
   };
 
   return (
-    <section className="de-dark-well de-chapter-hairline relative overflow-hidden py-8 lg:py-16">
+    <section className="de-dark-well de-chapter-hairline de-field-grain relative overflow-hidden py-8 lg:py-16">
       <div className="container relative z-10 mx-auto px-3 sm:px-4 lg:px-6">
         <motion.div
           className="mb-8 text-center md:mb-16"
@@ -68,7 +68,7 @@ export const DigeratiAlertBanner = (): JSX.Element => {
         </motion.div>
 
         <motion.div
-          className="mb-8 grid gap-4 md:mb-12 md:grid-cols-3 md:gap-8"
+          className="mb-8 grid grid-cols-1 items-stretch gap-4 md:mb-12 md:grid-cols-3 md:gap-8"
           variants={containerVariants}
           initial="hidden"
           whileInView="visible"
@@ -79,9 +79,9 @@ export const DigeratiAlertBanner = (): JSX.Element => {
               key={feature.title}
               variants={cardVariants}
               data-testid={feature.testId}
-              className="group relative"
+              className="group relative flex h-full"
             >
-              <div className="relative h-full rounded-2xl border border-de-hairline bg-de-raised p-6 transition-colors duration-300 group-hover:border-white/20">
+              <div className="relative flex h-full flex-col rounded-2xl border border-de-hairline bg-de-raised p-6 transition-colors duration-300 group-hover:border-white/20">
                 <div className="mb-5 flex h-14 w-14 items-center justify-center rounded-xl border border-white/10 bg-white/5">
                   <feature.icon className="h-7 w-7 text-[#D3126A]" />
                 </div>

--- a/client/src/pages/sections/DigeratiCTASection.tsx
+++ b/client/src/pages/sections/DigeratiCTASection.tsx
@@ -1,5 +1,6 @@
 import { Shield, Award, CheckCircle } from "lucide-react";
 import { motion, useReducedMotion } from "framer-motion";
+import { ParallaxStill } from "@/components/visual/ParallaxStill";
 import ctaBgImage from "@assets/de-section-atmosphere.png";
 import { CTA } from "@/lib/ctaCopy";
 import { useBooking } from "@/contexts/BookingContext";
@@ -16,12 +17,16 @@ export const DigeratiCTASection = (): JSX.Element => {
   const { openBooking } = useBooking();
 
   return (
-    <section className="de-dark-well de-chapter-hairline relative overflow-hidden py-12 lg:py-16">
-      <div className="absolute inset-0 pointer-events-none overflow-hidden">
-        <img src={ctaBgImage} alt="" loading="lazy" className="absolute top-0 left-0 w-full h-auto opacity-[0.15]" />
-      </div>
+    <section className="de-dark-well de-chapter-hairline de-field-grain-film de-field-lit relative overflow-hidden py-16 lg:py-24">
+      <ParallaxStill
+        src={ctaBgImage}
+        alt=""
+        travel={10}
+        className="pointer-events-none absolute inset-0 z-0"
+        imgClassName="opacity-[0.22]"
+      />
 
-      <div className="max-w-4xl mx-auto px-3 sm:px-4 lg:px-6 text-center relative z-10">
+      <div className="relative z-10 mx-auto flex max-w-4xl flex-col items-center px-3 text-center sm:px-4 lg:px-6">
         <motion.div
           initial={prefersReducedMotion ? false : { opacity: 0, y: 24 }}
           whileInView={{ opacity: 1, y: 0 }}

--- a/client/src/pages/sections/DigeratiContactSection.tsx
+++ b/client/src/pages/sections/DigeratiContactSection.tsx
@@ -133,7 +133,7 @@ export const DigeratiContactSection = ({
 
   return (
     <section
-      className="de-dark-well de-chapter-hairline relative overflow-hidden py-16 lg:py-24"
+      className="de-dark-well de-chapter-hairline de-field-grain relative overflow-hidden py-16 lg:py-24"
       data-testid="homepage-contact-chapter"
     >
       <div className="pointer-events-none absolute inset-0 overflow-hidden">
@@ -141,7 +141,8 @@ export const DigeratiContactSection = ({
           src={contactBgImage}
           alt=""
           loading="lazy"
-          className="absolute left-0 top-0 h-auto w-full opacity-[0.12]"
+          aria-hidden="true"
+          className="absolute inset-0 h-full w-full object-cover object-center opacity-[0.08]"
         />
       </div>
 

--- a/client/src/pages/sections/DigeratiFAQSection.tsx
+++ b/client/src/pages/sections/DigeratiFAQSection.tsx
@@ -36,7 +36,7 @@ export const DigeratiFAQSection = (): JSX.Element => {
   };
 
   return (
-    <section className="de-paper-chapter py-16 md:py-20 lg:py-24">
+    <section className="de-paper-chapter de-paper-hairline de-chapter-fade-to-surface de-field-grain-paper py-16 md:py-20 lg:py-24">
       <FAQJsonLd faqs={faqs} />
       <div className="max-w-4xl mx-auto px-3 sm:px-4 lg:px-6">
         {/* Header */}

--- a/client/src/pages/sections/DigeratiHowWeProtectSection.tsx
+++ b/client/src/pages/sections/DigeratiHowWeProtectSection.tsx
@@ -49,7 +49,7 @@ export const DigeratiHowWeProtectSection = (): JSX.Element => {
 
   return (
     <>
-      <section className="de-paper-chapter de-chapter-fade-from-dark relative py-16 lg:py-24">
+      <section className="de-paper-chapter de-chapter-fade-from-dark de-chapter-fade-to-surface de-field-grain-paper relative py-16 lg:py-24">
         <div className="container relative z-10 mx-auto px-3 sm:px-4 lg:px-6">
           <motion.div
             className="mb-12 max-w-2xl md:mb-16"
@@ -125,7 +125,7 @@ export const DigeratiHowWeProtectSection = (): JSX.Element => {
                 <li
                   key={step.number}
                   data-testid={step.testId}
-                  className={`lg:px-6 ${index > 0 ? "lg:border-l lg:border-[var(--de-hairline)]" : "lg:pl-0"}`}
+                  className={`flex h-full flex-col lg:px-6 ${index > 0 ? "lg:border-l lg:border-[var(--de-hairline)]" : "lg:pl-0"}`}
                 >
                   <p className="font-mono text-base font-semibold tracking-[0.18em] text-de-magenta-ink">
                     {String(step.number).padStart(2, "0")}

--- a/client/src/pages/sections/DigeratiIndustriesSection.tsx
+++ b/client/src/pages/sections/DigeratiIndustriesSection.tsx
@@ -127,7 +127,7 @@ export const DigeratiIndustriesSection = (): JSX.Element => {
   return (
     <section 
       ref={sectionRef}
-      className="de-dark-well relative overflow-hidden py-6 md:py-8"
+      className="de-dark-well de-field-grain relative overflow-hidden py-6 md:py-8"
       style={{ position: 'relative' }}
     >
       <div className="de-style-box relative z-10 mx-3 px-4 py-8 sm:mx-4 sm:px-8 md:py-14 lg:mx-6 lg:px-10 lg:py-16">

--- a/client/src/pages/sections/DigeratiLeadFormSection.tsx
+++ b/client/src/pages/sections/DigeratiLeadFormSection.tsx
@@ -84,7 +84,7 @@ export const DigeratiLeadFormSection = (): JSX.Element => {
   return (
     <section 
       id="assessment-form"
-      className="de-paper-chapter de-chapter-fade-from-dark relative overflow-hidden py-16 md:py-20 lg:py-24"
+      className="de-paper-chapter de-chapter-fade-from-dark de-field-grain-paper relative overflow-hidden py-16 md:py-20 lg:py-24"
     >
       <div className="container mx-auto px-3 sm:px-4 lg:px-6 relative z-10">
         <div className="max-w-4xl mx-auto">

--- a/client/src/pages/sections/DigeratiMeetExpertsSection.tsx
+++ b/client/src/pages/sections/DigeratiMeetExpertsSection.tsx
@@ -24,7 +24,7 @@ export const DigeratiMeetExpertsSection = (): JSX.Element => {
 
   return (
     <section
-      className="de-dark-well de-chapter-hairline relative overflow-hidden py-10 md:py-14 lg:py-16"
+      className="de-dark-well de-chapter-hairline de-field-grain relative overflow-hidden py-10 md:py-14 lg:py-16"
       data-testid="section-meet-experts"
     >
       <div

--- a/client/src/pages/sections/DigeratiNewsletterSection.tsx
+++ b/client/src/pages/sections/DigeratiNewsletterSection.tsx
@@ -79,7 +79,7 @@ export const DigeratiNewsletterSection = (): JSX.Element => {
   return (
     <section
       id="newsletter"
-      className="de-dark-chapter de-chapter-hairline relative overflow-hidden py-14 md:py-20 lg:py-24"
+      className="de-dark-chapter de-chapter-hairline de-field-grain relative overflow-hidden py-14 md:py-20 lg:py-24"
     >
       <div className="container relative z-10 mx-auto px-3 sm:px-4 lg:px-6">
         <motion.div

--- a/client/src/pages/sections/DigeratiPricingSection.tsx
+++ b/client/src/pages/sections/DigeratiPricingSection.tsx
@@ -10,7 +10,7 @@ export const DigeratiPricingSection = (): JSX.Element => {
   return (
     <section
       data-testid="homepage-pricing"
-      className="de-dark-chapter de-chapter-hairline relative py-10 md:py-20 lg:py-24"
+      className="de-dark-chapter de-chapter-hairline de-field-grain relative py-10 md:py-20 lg:py-24"
     >
       <div className="relative z-10 mx-auto max-w-[var(--de-canvas)] px-3 sm:px-4 lg:px-6">
         <motion.div

--- a/client/src/pages/sections/DigeratiServicesSection.tsx
+++ b/client/src/pages/sections/DigeratiServicesSection.tsx
@@ -113,7 +113,7 @@ export const DigeratiServicesSection = (): JSX.Element => {
   return (
     <section
       id="services"
-      className="de-dark-chapter de-chapter-hairline relative overflow-hidden py-10 md:py-18 lg:py-22"
+      className="de-dark-chapter de-chapter-hairline de-field-grain relative overflow-hidden py-10 md:py-18 lg:py-22"
     >
       <div className="container relative z-10 mx-auto px-3 sm:px-4 lg:px-6">
         <motion.div

--- a/client/src/pages/sections/DigeratiStatsSection.tsx
+++ b/client/src/pages/sections/DigeratiStatsSection.tsx
@@ -62,7 +62,7 @@ export const DigeratiStatsSection = (): JSX.Element => {
   const facts = getHomepageCyberFacts();
 
   return (
-    <section className="de-dark-well relative py-6 lg:py-8">
+    <section className="de-dark-well de-field-grain relative py-6 lg:py-8">
       <div className="de-style-box relative mx-3 px-4 py-8 sm:mx-4 sm:px-8 md:py-16 lg:mx-6 lg:px-10 lg:py-20">
         <motion.div
           initial={prefersReducedMotion ? {} : { opacity: 0, y: 16 }}

--- a/client/src/pages/sections/DigeratiTestimonialsSection.tsx
+++ b/client/src/pages/sections/DigeratiTestimonialsSection.tsx
@@ -136,7 +136,7 @@ export const DigeratiTestimonialsSection = (): JSX.Element => {
   return (
     <section
       id="testimonials"
-      className="de-dark-well de-chapter-hairline relative overflow-hidden py-14 md:py-18 lg:py-20"
+      className="de-dark-well de-chapter-hairline de-field-grain relative overflow-hidden py-14 md:py-18 lg:py-20"
       data-testid="section-client-proof"
     >
       <div className="mx-auto max-w-[var(--de-canvas)] px-3 sm:px-4 lg:px-6">

--- a/client/src/pages/sections/DigeratiThreatsInsightsSection.tsx
+++ b/client/src/pages/sections/DigeratiThreatsInsightsSection.tsx
@@ -135,7 +135,7 @@ export const DigeratiThreatsInsightsSection = (): JSX.Element => {
   return (
     <section
       ref={sectionRef}
-      className="de-dark-chapter de-chapter-hairline relative overflow-hidden py-10 md:py-14 lg:py-16"
+      className="de-dark-well de-chapter-hairline de-field-grain relative overflow-hidden py-10 md:py-14 lg:py-16"
       style={{ position: "relative" }}
     >
       <div className="container mx-auto px-3 sm:px-4 lg:px-6 relative z-10">

--- a/client/src/pages/sections/DigeratiTrustPhotoSection.tsx
+++ b/client/src/pages/sections/DigeratiTrustPhotoSection.tsx
@@ -1,5 +1,6 @@
 import { motion, useReducedMotion } from "framer-motion";
 import { Shield, ArrowRight, MapPin, UserCheck, Scale } from "lucide-react";
+import { ParallaxStill } from "@/components/visual/ParallaxStill";
 import trustDeskImg from "@assets/de-trust-assessment-desk.png";
 import { CTA } from "@/lib/ctaCopy";
 
@@ -25,9 +26,9 @@ export const DigeratiTrustPhotoSection = (): JSX.Element => {
   const prefersReducedMotion = useReducedMotion();
 
   return (
-    <section className="de-paper-chapter de-chapter-fade-from-dark overflow-hidden py-14 md:py-20 lg:py-24" data-testid="section-trust-photo">
+    <section className="de-paper-chapter de-chapter-fade-from-dark de-chapter-fade-to-dark de-field-grain-paper overflow-hidden py-14 md:py-20 lg:py-24" data-testid="section-trust-photo">
       <div className="max-w-[var(--de-canvas)] mx-auto px-3 sm:px-4 lg:px-6">
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-16 items-center">
+        <div className="grid grid-cols-1 items-stretch gap-12 lg:grid-cols-2 lg:gap-16">
           <motion.div
             initial={prefersReducedMotion ? {} : { opacity: 0, x: -20 }}
             whileInView={{ opacity: 1, x: 0 }}
@@ -78,24 +79,23 @@ export const DigeratiTrustPhotoSection = (): JSX.Element => {
           </motion.div>
 
           <motion.div
-            className="relative"
+            className="relative flex"
             initial={prefersReducedMotion ? {} : { opacity: 0, x: 20 }}
             whileInView={{ opacity: 1, x: 0 }}
             viewport={{ once: true, margin: "-80px" }}
             transition={{ duration: 0.5, delay: 0.1 }}
           >
-            <div className="relative overflow-hidden rounded-2xl border border-de-paper-hairline shadow-lg shadow-black/10">
-              <img
+            <div className="relative flex aspect-[4/3] w-full flex-col overflow-hidden rounded-2xl border border-de-paper-hairline shadow-lg shadow-black/10 lg:aspect-auto lg:min-h-full">
+              <ParallaxStill
                 src={trustDeskImg}
                 alt="Principal-led cyber risk assessment work for an Arizona business"
-                loading="lazy"
-                decoding="async"
+                travel={10}
                 width={960}
                 height={720}
-                className="w-full h-full object-cover aspect-[4/3]"
-                data-testid="img-trust-assessment-desk"
+                className="absolute inset-0"
+                testId="img-trust-assessment-desk"
               />
-              <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/75 via-black/35 to-transparent p-5">
+              <div className="relative mt-auto bg-gradient-to-t from-black/75 via-black/35 to-transparent p-5 pt-16">
                 <p className="text-white text-base font-medium">
                   Principal-led assessments sized to how your business runs
                 </p>

--- a/client/src/pages/sections/DigeratiWhatWeTackleSection.tsx
+++ b/client/src/pages/sections/DigeratiWhatWeTackleSection.tsx
@@ -53,7 +53,7 @@ export const DigeratiWhatWeTackleSection = (): JSX.Element => {
   const prefersReducedMotion = useReducedMotion();
 
   return (
-    <section className="de-dark-well de-chapter-hairline relative py-16 lg:py-24">
+    <section className="de-dark-well de-chapter-hairline de-field-grain relative py-16 lg:py-24">
       <div className="container relative z-10 mx-auto px-3 sm:px-4 lg:px-6">
         <div className="grid items-start gap-12 lg:grid-cols-12 lg:gap-16">
           <motion.div

--- a/client/src/pages/sections/HomepageProofSection.tsx
+++ b/client/src/pages/sections/HomepageProofSection.tsx
@@ -104,7 +104,7 @@ function ProofCta({
 
 export function HomepageProofSection() {
   return (
-    <section id="proof" className="de-dark-well de-chapter-hairline py-14 lg:py-20">
+    <section id="proof" className="de-dark-well de-chapter-hairline de-field-grain py-14 lg:py-20">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="mx-auto max-w-4xl text-center">
           <p className="mb-3 text-base font-semibold uppercase tracking-[0.2em] text-de-magenta-ink">

--- a/client/src/pages/sections/ModernHeroSection.tsx
+++ b/client/src/pages/sections/ModernHeroSection.tsx
@@ -5,6 +5,7 @@ import { analytics } from "@/lib/analytics";
 import { Button } from "@/components/ui/button";
 import { ArrowRight, CheckCircle, Building, FileCheck, Shield, Check } from "lucide-react";
 import { DashboardMockup } from "@/components/graphics";
+import { parallaxTravelRange } from "@/components/visual/ParallaxStill";
 import heroBgImage from "@assets/de-hero-arizona-dusk.png";
 import { useBooking } from "@/contexts/BookingContext";
 import { CTA } from "@/lib/ctaCopy";
@@ -20,7 +21,12 @@ export const ModernHeroSection = (): JSX.Element => {
   });
 
   const y = useTransform(scrollYProgress, [0, 1], [0, prefersReducedMotion ? 0 : 20]);
-  const backgroundY = useTransform(scrollYProgress, [0, 1], prefersReducedMotion ? ["0%", "0%"] : ["0%", "8%"]);
+  const backgroundY = useTransform(
+    scrollYProgress,
+    [0, 1],
+    parallaxTravelRange(prefersReducedMotion, 12),
+  );
+  const duskExtra = prefersReducedMotion ? 0 : 12;
 
   const features = [
     { icon: FileCheck, text: "Insurance & Compliance Ready" },
@@ -38,7 +44,7 @@ export const ModernHeroSection = (): JSX.Element => {
     <section
       ref={containerRef}
       id="home"
-      className="relative flex min-h-0 lg:min-h-screen flex-col overflow-hidden"
+      className="de-field-grain-film relative flex min-h-0 flex-col overflow-hidden lg:min-h-screen"
       style={{ position: "relative" }}
     >
       <div className="absolute inset-0 pointer-events-none overflow-hidden">
@@ -47,10 +53,13 @@ export const ModernHeroSection = (): JSX.Element => {
           alt=""
           loading="eager"
           decoding="async"
-          className="absolute inset-0 w-full h-full object-cover object-[center_82%]"
+          aria-hidden="true"
+          className="absolute left-0 w-full object-cover object-[center_82%]"
           style={{
             y: backgroundY,
-            opacity: 0.46,
+            top: duskExtra ? `-${duskExtra}%` : 0,
+            height: duskExtra ? `${100 + duskExtra * 2}%` : "100%",
+            opacity: 0.5,
             WebkitMaskImage:
               "linear-gradient(to bottom, rgba(0,0,0,0.18) 0%, rgba(0,0,0,0.38) 16%, rgba(0,0,0,0.88) 46%, black 72%)",
             maskImage:
@@ -219,7 +228,7 @@ export const ModernHeroSection = (): JSX.Element => {
         </div>
       </motion.div>
 
-      <div className="absolute bottom-0 left-0 right-0 h-16 bg-gradient-to-t from-[#050312]/80 to-transparent z-10 pointer-events-none" />
+      <div className="pointer-events-none absolute bottom-0 left-0 right-0 z-10 h-24 bg-gradient-to-t from-[#050312] to-transparent" />
     </section>
   );
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Texture the homepage as a sequence of neighboring chapters, not a stack of identical dark slabs.

## What changed

Each section keeps its job and copy. The work is field + motion:

- **Grain** on well / surface / paper chapters (opt-in CSS). Style boxes and the process band get the same film at a lower intensity.
- **Corner lighting** only on the detection chapter and the closing assessment CTA (magenta + violet as light, not fills).
- **Neighbor steps:** packages stay surface; insights recede to the well; the office photo lifts back to surface; FAQ paper fades into the newsletter surface; CTA is cinematic well; contact stays a quieter well with the same atmosphere still, static and dimmer so it does not repeat the CTA parallax.
- **Parallax** only where photography already exists and can carry it: Arizona dusk hero (12%), trust desk, office evening, CTA atmosphere. Card grids, stats, FAQ, forms, industries, and footer stay still. `prefers-reduced-motion` holds travel at 0%.
- **Not sourced:** no new AI cyber stills, no Meshy remount, no Envato pack (still not in repo). Existing DE photography is the source.

## Why this and not more

Industry-standard marketing sites use 2–3 parallax moments and a visible field ladder. Wrapping every chapter in a style-box, adding wave dividers, or generating stock “security” images would make this look like a template.

## Verify

- `npx vitest run client/src/lib/parallaxStill.test.ts client/src/lib/homepageFields.test.ts`
- Playwright at 390 / 768 / 1440: no horizontal overflow; reduced-motion holds stills; motion on shows hero `translateY` travel.

[Homepage hero at 1440](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage-fields-hero-1440.png)
[Stats style-box with grain](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage-fields-stats-1440.png)
[Process band lighting](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage-fields-process-1440.png)
[Trust desk parallax frame](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage-fields-trust-1440.png)
[CTA atmosphere](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage-fields-cta-1440.png)
[Hero at 390](https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage-fields-hero-390.png)

## Human input still required

- Envato `4THD2PH` and founder headshot still not in repo. Do not invent replacements.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55eac13a-e87f-4a00-9c34-f63bb77c3080?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55eac13a-e87f-4a00-9c34-f63bb77c3080&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

