### PR TITLE
P0: fail Store checkout closed around recurring billing and durable state

### DIFF
--- a/server/secureStoreCheckout.ts
+++ b/server/secureStoreCheckout.ts
@@ -4,6 +4,12 @@ import { resolveClientPricingRows, resolveUnitPrice, toPriceOverrides } from "./
 
 type StoreRole = "public" | "prospect" | "managed" | "comanaged" | "admin";
 
+const RECURRING_STORE_CATEGORIES = new Set<StoreProduct["category"]>([
+  "comanaged_subscriptions",
+  "networking_managed",
+  "ucaas_subscriptions",
+]);
+
 type CheckoutRequest = Request & {
   userId?: string;
   user?: {
@@ -42,6 +48,24 @@ function isPurchasableForRole(product: StoreProduct, role: StoreRole): boolean {
   if (role === "admin") return true;
   if (role !== "comanaged") return false;
   return product.requiredClientType === "public" || product.requiredClientType === "comanaged";
+}
+
+/**
+ * These catalog families are recurring services. Until the Store creates or
+ * amends an authoritative Zoho subscription, they must not be charged through
+ * a one-time hosted Payment Session.
+ */
+export function isRecurringSubscriptionProduct(product: StoreProduct): boolean {
+  return RECURRING_STORE_CATEGORIES.has(product.category);
+}
+
+export function recurringCheckoutSkus(items: CanonicalCheckoutLineItem[]): string[] {
+  return items
+    .filter((item) => {
+      const product = storeProducts.find((candidate) => candidate.id === item.productId);
+      return !!product && isRecurringSubscriptionProduct(product);
+    })
+    .map((item) => item.sku);
 }
 
 export function canonicalizeCheckoutLineItems(
@@ -110,6 +134,15 @@ export function registerSecureZohoStoreCheckout(
   authMiddleware: AuthMiddleware,
   requireRole: RoleMiddlewareFactory,
 ) {
+  // Registration happens during server boot. In production this starts the
+  // existing paid-order reconciler immediately, so a restart does not leave
+  // already-paid work stranded until another webhook happens to arrive.
+  void import("./services/orderFulfillment")
+    .then(({ startOrderFulfillmentReconciliation }) => startOrderFulfillmentReconciliation())
+    .catch((error) => {
+      console.error("[ORDER FULFILLMENT RECONCILER START ERROR]", error);
+    });
+
   app.post(
     "/api/store/checkout/zoho",
     [authMiddleware as any, requireRole("comanaged", "admin") as any],
@@ -138,6 +171,22 @@ export function registerSecureZohoStoreCheckout(
           return res.status(400).json({ error: error?.message || "Invalid checkout cart" });
         }
 
+        const recurringSkus = recurringCheckoutSkus(lineItems);
+        if (recurringSkus.length > 0) {
+          console.warn("[SECURITY] RECURRING_CHECKOUT_BLOCKED", {
+            userId: req.userId,
+            clientId: req.user?.clientId,
+            skus: recurringSkus,
+          });
+          return res.status(409).json({
+            code: "SUBSCRIPTION_BILLING_REQUIRED",
+            quoteRequired: true,
+            skus: recurringSkus,
+            error:
+              "Recurring services require subscription billing setup before online payment. Request a quote for these items.",
+          });
+        }
+
         const trustedTotal = canonicalCheckoutTotal(lineItems);
         const suppliedTotal = Number(req.body?.total);
         const suppliedSubtotal = Number(req.body?.subtotal);
@@ -157,6 +206,20 @@ export function registerSecureZohoStoreCheckout(
           });
         }
 
+        const dbModule = await import("./db");
+        await dbModule.initPromise;
+        if (!dbModule.dbReady || !dbModule.db) {
+          console.error("[SECURITY] CHECKOUT_DATABASE_UNAVAILABLE", {
+            userId: req.userId,
+            clientId: req.user?.clientId,
+          });
+          return res.status(503).json({
+            code: "DURABLE_DATABASE_REQUIRED",
+            error: "Checkout is temporarily unavailable because durable order storage is not connected.",
+          });
+        }
+        const db = dbModule.db;
+
         const { zohoPayments } = await import("./zohoPayments");
         if (!zohoPayments.isConfigured()) {
           return res.status(503).json({
@@ -170,7 +233,6 @@ export function registerSecureZohoStoreCheckout(
           .toUpperCase()}`;
         const baseUrl = process.env.APP_URL || "https://digeratiexperts.com";
 
-        const { db } = await import("./db");
         const { storeOrders } = await import("@shared/schema");
         const { eq } = await import("drizzle-orm");
 

--- a/server/storeClientPricing.ts
+++ b/server/storeClientPricing.ts
@@ -10,8 +10,8 @@ export type ClientPriceEntry = {
 };
 
 /**
- * Demo / admin overlay. Used when Postgres has no active rows for the client.
- * Not a public pricing API — checkout still ignores browser unit prices.
+ * Demo / admin overlay for local development only.
+ * Production commerce must never derive a client price from this map.
  */
 const demoClientPricing = new Map<string, ClientPriceEntry[]>([
   [
@@ -55,11 +55,20 @@ const demoClientPricing = new Map<string, ClientPriceEntry[]>([
   ],
 ]);
 
+export function isDemoClientPricingAllowed(): boolean {
+  return process.env.NODE_ENV !== "production";
+}
+
 export function listDemoClientPricing(clientId: string): ClientPriceEntry[] {
+  if (!isDemoClientPricingAllowed()) return [];
   return [...(demoClientPricing.get(clientId) || [])];
 }
 
 export function upsertDemoClientPricing(clientId: string, entry: ClientPriceEntry): ClientPriceEntry {
+  if (!isDemoClientPricingAllowed()) {
+    throw new Error("Demo client pricing is disabled in production; persist pricing to store_client_pricing");
+  }
+
   const current = listDemoClientPricing(clientId);
   const index = current.findIndex((row) => row.productId === entry.productId);
   if (index >= 0) current[index] = entry;
@@ -69,6 +78,10 @@ export function upsertDemoClientPricing(clientId: string, entry: ClientPriceEntr
 }
 
 export function removeDemoClientPricing(clientId: string, productId: string): ClientPriceEntry | undefined {
+  if (!isDemoClientPricingAllowed()) {
+    throw new Error("Demo client pricing is disabled in production; persist pricing to store_client_pricing");
+  }
+
   const current = listDemoClientPricing(clientId);
   const removed = current.find((row) => row.productId === productId);
   demoClientPricing.set(
@@ -99,11 +112,15 @@ async function loadDbClientPricing(clientId: string): Promise<ClientPriceEntry[]
   }
 }
 
-/** DB rows win when present; otherwise the in-memory overlay. */
+/**
+ * Production pricing is DB-authoritative. The in-memory demo overlay exists only
+ * for local development/test data and can never influence a production charge.
+ */
 export async function resolveClientPricingRows(clientId: string | null | undefined): Promise<ClientPriceEntry[]> {
   if (!clientId) return [];
   const fromDb = await loadDbClientPricing(clientId);
   if (fromDb.length) return fromDb;
+  if (!isDemoClientPricingAllowed()) return [];
   return listDemoClientPricing(clientId);
 }
 

--- a/server/storeCommerceSafety.test.ts
+++ b/server/storeCommerceSafety.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { storeProducts } from "../client/src/data/storeProducts";
+import {
+  canonicalizeCheckoutLineItems,
+  isRecurringSubscriptionProduct,
+  recurringCheckoutSkus,
+} from "./secureStoreCheckout";
+import {
+  isDemoClientPricingAllowed,
+  listDemoClientPricing,
+  upsertDemoClientPricing,
+} from "./storeClientPricing";
+
+const originalNodeEnv = process.env.NODE_ENV;
+
+afterEach(() => {
+  if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+  else process.env.NODE_ENV = originalNodeEnv;
+});
+
+describe("Store commerce safety", () => {
+  it("rebuilds checkout pricing from the server catalog", () => {
+    const [line] = canonicalizeCheckoutLineItems(
+      [
+        {
+          productId: "prod-020",
+          sku: "DE-SVC-CM-ONBOARD-S-OT",
+          quantity: 1,
+          unitPrice: 0.01,
+          total: 0.01,
+        },
+      ],
+      "comanaged",
+    );
+
+    expect(line.unitPrice).toBe(750);
+    expect(line.total).toBe(750);
+  });
+
+  it("enforces catalog minimum quantities", () => {
+    expect(() =>
+      canonicalizeCheckoutLineItems(
+        [
+          {
+            productId: "prod-036",
+            sku: "DE-SVC-NET-ONSITE-HR",
+            quantity: 1,
+          },
+        ],
+        "comanaged",
+      ),
+    ).toThrow(/Invalid quantity/);
+  });
+
+  it("identifies recurring catalog families before one-time payment", () => {
+    const recurringProduct = storeProducts.find((product) => product.id === "prod-010");
+    const oneTimeProduct = storeProducts.find((product) => product.id === "prod-020");
+
+    expect(recurringProduct).toBeDefined();
+    expect(oneTimeProduct).toBeDefined();
+    expect(isRecurringSubscriptionProduct(recurringProduct!)).toBe(true);
+    expect(isRecurringSubscriptionProduct(oneTimeProduct!)).toBe(false);
+
+    const recurringLines = canonicalizeCheckoutLineItems(
+      [
+        {
+          productId: "prod-010",
+          sku: "DE-SVC-CM-ENDPOINT-CORE-MO",
+          quantity: 2,
+        },
+      ],
+      "comanaged",
+    );
+    expect(recurringCheckoutSkus(recurringLines)).toEqual(["DE-SVC-CM-ENDPOINT-CORE-MO"]);
+
+    const oneTimeLines = canonicalizeCheckoutLineItems(
+      [
+        {
+          productId: "prod-020",
+          sku: "DE-SVC-CM-ONBOARD-S-OT",
+          quantity: 1,
+        },
+      ],
+      "comanaged",
+    );
+    expect(recurringCheckoutSkus(oneTimeLines)).toEqual([]);
+  });
+
+  it("never exposes demo client pricing in production", () => {
+    process.env.NODE_ENV = "production";
+
+    expect(isDemoClientPricingAllowed()).toBe(false);
+    expect(listDemoClientPricing("client-1")).toEqual([]);
+    expect(() =>
+      upsertDemoClientPricing("client-1", {
+        productId: "prod-020",
+        customPrice: 1,
+        discountPercent: 99,
+      }),
+    ).toThrow(/disabled in production/);
+  });
+});


### PR DESCRIPTION
## What this stabilizes

- Prevents demo client pricing from influencing production checkout.
- Makes the secure Zoho checkout explicitly require durable PostgreSQL state before creating a payable order.
- Starts the existing paid-order reconciliation scheduler during Store route registration, so production restart recovery no longer waits for another webhook import.
- Blocks recurring Store families from being charged as a one-time Zoho Payment Session until authoritative subscription billing is implemented; callers get `SUBSCRIPTION_BILLING_REQUIRED` and can fall back to the existing quote flow.
- Adds Vitest coverage for catalog-authoritative pricing, minimum quantities, recurring-family detection, and production demo-pricing isolation.

## Deliberately not solved here

- Tax calculation remains unimplemented; no tax behavior is invented in this PR.
- Zoho subscription creation/amendment is still a separate follow-up.
- Legacy duplicate Store routes and global readiness semantics are not changed in this slice.
- No production deployment is included.

## Release rule

Do not merge until CI passes and the diff is reviewed for Store checkout behavior.