### PR TITLE
Store: route recurring-payment blocks into quote flow

### DIFF
--- a/client/src/pages/store/Checkout.tsx
+++ b/client/src/pages/store/Checkout.tsx
@@ -117,6 +117,24 @@ const Checkout = () => {
             setPaymentMethod("quote_request");
             return;
           }
+          if (errorData.code === "SUBSCRIPTION_BILLING_REQUIRED" && errorData.quoteRequired) {
+            toast({
+              title: "Recurring services move through subscription setup",
+              description:
+                "Your solution is intact. We switched checkout to Request Quote so recurring billing can be provisioned correctly instead of charging it as a one-time purchase.",
+            });
+            setPaymentMethod("quote_request");
+            return;
+          }
+          if (errorData.code === "DURABLE_DATABASE_REQUIRED") {
+            toast({
+              title: "Online payment is temporarily unavailable",
+              description:
+                "We will not accept payment without durable order storage. Your solution is intact, and you can request a quote instead.",
+            });
+            setPaymentMethod("quote_request");
+            return;
+          }
           throw new Error(errorData.error || "Failed to create checkout session");
         }
 


### PR DESCRIPTION
The backend now blocks recurring services from one-time Zoho payment until authoritative subscription billing exists. This makes checkout handle that response intentionally instead of showing a generic failure.

Also routes durable-database checkout refusal into the existing quote path while preserving the cart/solution.

No payment rules or prices change in this PR.