### PR TITLE
Build: keep Replit runtime error overlay development-only

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,12 +3,17 @@ import react from "@vitejs/plugin-react";
 import path from "path";
 import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal";
 
+const isProduction = process.env.NODE_ENV === "production";
+const isReplitDevelopment = !isProduction && process.env.REPL_ID !== undefined;
+
 export default defineConfig({
   plugins: [
     react(),
-    runtimeErrorOverlay(),
-    ...(process.env.NODE_ENV !== "production" &&
-    process.env.REPL_ID !== undefined
+    // Replit's runtime error overlay is development tooling. Shipping it in a
+    // production build adds avoidable transforms/styles and can leak dev-only
+    // chrome into the public bundle.
+    ...(!isProduction ? [runtimeErrorOverlay()] : []),
+    ...(isReplitDevelopment
       ? [
           await import("@replit/vite-plugin-cartographer").then((m) =>
             m.cartographer(),


### PR DESCRIPTION
The Replit runtime error overlay was being registered for production Vite builds even though the other Replit development plugins were already gated. This makes the overlay development-only and leaves the public production build free of dev-error chrome/transforms.

CI will tell us whether this also removes the malformed generated `button:hover` CSS warnings and whether it changes bundle size.