### PR TITLE
P0 Portal auth: fail closed and enforce live authorization

### DIFF
--- a/server/portalAuthFailClosed.test.ts
+++ b/server/portalAuthFailClosed.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import jwt from "jsonwebtoken";
 
 vi.mock("./portalAuthStore", async () => {
@@ -19,28 +19,31 @@ vi.mock("./portalOrg", async () => {
 
 process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret-for-fail-closed-auth-test";
 
-describe("portal authMiddleware fails closed when no live user record exists", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+type LiveUser = {
+  id: string;
+  email: string;
+  role: string;
+  storeRole?: string | null;
+  clientId?: string | null;
+  orgRole?: string | null;
+  departmentId?: string | null;
+  managerUserId?: string | null;
+  isCompanyItContact?: boolean;
+  isActive?: boolean;
+  fullName?: string;
+  disabled?: boolean;
+  status?: string;
+};
 
-  it("denies a validly-signed JWT whose user has no live record", async () => {
-    const { authMiddleware } = await import("./routes");
-    const { getUser } = await import("./portalAuthStore");
-    const { findUserById } = await import("./portalOrg");
-    (getUser as any).mockReturnValue(undefined);
-    (findUserById as any).mockReturnValue(undefined);
+function signToken(claims: Record<string, unknown>) {
+  return jwt.sign(claims, process.env.JWT_SECRET as string, { expiresIn: "24h" });
+}
 
-    const token = jwt.sign(
-      { userId: "ghost-user", email: "ghost@example.com", role: "admin", storeRole: "admin" },
-      process.env.JWT_SECRET as string,
-      { expiresIn: "24h" },
-    );
-
-    const req: any = { headers: { authorization: `Bearer ${token}` }, cookies: {} };
-    let statusCode: number | undefined;
-    let body: any;
-    const res: any = {
+function mockResponse() {
+  let statusCode: number | undefined;
+  let body: any;
+  return {
+    res: {
       status(code: number) {
         statusCode = code;
         return this;
@@ -49,52 +52,209 @@ describe("portal authMiddleware fails closed when no live user record exists", (
         body = payload;
         return this;
       },
-    };
-    const next = vi.fn();
+    } as any,
+    status: () => statusCode,
+    body: () => body,
+  };
+}
 
-    authMiddleware(req, res, next);
+async function authenticate(live: LiveUser | undefined, claims: Record<string, unknown>) {
+  const { authMiddleware } = await import("./routes");
+  const { getUser } = await import("./portalAuthStore");
+  const { findUserById } = await import("./portalOrg");
+  (getUser as any).mockReturnValue(live);
+  (findUserById as any).mockReturnValue(undefined);
 
-    expect(next).not.toHaveBeenCalled();
-    expect(statusCode).toBe(401);
-    expect(body?.error).toBeTruthy();
-    expect(req.user).toBeUndefined();
+  const token = signToken(claims);
+  const req: any = { headers: { authorization: `Bearer ${token}` }, cookies: {} };
+  const response = mockResponse();
+  const next = vi.fn();
+  authMiddleware(req, response.res, next);
+  return { req, next, ...response };
+}
+
+const activeLiveUser: LiveUser = {
+  id: "u1",
+  email: "real@example.com",
+  role: "user",
+  storeRole: "managed",
+  clientId: "client-new",
+  orgRole: "staff",
+  departmentId: "dept-new",
+  managerUserId: "manager-new",
+  isCompanyItContact: false,
+  isActive: true,
+  fullName: "Real User",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("Portal authorization uses the live user as the source of truth", () => {
+  it("denies a validly signed JWT whose user has no live record", async () => {
+    const result = await authenticate(undefined, {
+      userId: "ghost-user",
+      email: "ghost@example.com",
+      role: "admin",
+      storeRole: "admin",
+      clientId: "client-old",
+    });
+
+    expect(result.next).not.toHaveBeenCalled();
+    expect(result.status()).toBe(401);
+    expect(result.body()?.error).toBeTruthy();
+    expect(result.req.user).toBeUndefined();
   });
 
-  it("still authorizes when a live, non-disabled record exists", async () => {
-    const { authMiddleware } = await import("./routes");
-    const { getUser } = await import("./portalAuthStore");
-    const { findUserById } = await import("./portalOrg");
-    (getUser as any).mockReturnValue({
-      id: "u1",
+  it("applies live role and storeRole immediately after a downgrade", async () => {
+    const { requireAdmin, requireRole } = await import("./routes");
+    const result = await authenticate(activeLiveUser, {
+      userId: "u1",
+      email: "real@example.com",
+      role: "admin",
+      storeRole: "comanaged",
+      clientId: "client-old",
+    });
+
+    expect(result.next).toHaveBeenCalledTimes(1);
+    expect(result.req.user.role).toBe("user");
+    expect(result.req.user.storeRole).toBe("managed");
+
+    const adminResponse = mockResponse();
+    const adminNext = vi.fn();
+    requireAdmin(result.req, adminResponse.res, adminNext);
+    expect(adminNext).not.toHaveBeenCalled();
+    expect(adminResponse.status()).toBe(403);
+
+    const checkoutResponse = mockResponse();
+    const checkoutNext = vi.fn();
+    requireRole("comanaged", "admin")(result.req, checkoutResponse.res, checkoutNext);
+    expect(checkoutNext).not.toHaveBeenCalled();
+    expect(checkoutResponse.status()).toBe(403);
+  });
+
+  it("uses the live client assignment instead of the stale JWT client", async () => {
+    const result = await authenticate(activeLiveUser, {
+      userId: "u1",
+      email: "real@example.com",
+      role: "user",
+      storeRole: "managed",
+      clientId: "client-old",
+    });
+
+    expect(result.next).toHaveBeenCalledTimes(1);
+    expect(result.req.user.clientId).toBe("client-new");
+  });
+
+  it("does not resurrect an old client when the live clientId was cleared", async () => {
+    const result = await authenticate(
+      { ...activeLiveUser, clientId: null },
+      {
+        userId: "u1",
+        email: "real@example.com",
+        role: "user",
+        storeRole: "managed",
+        clientId: "client-old",
+      },
+    );
+
+    expect(result.next).toHaveBeenCalledTimes(1);
+    expect(result.req.user.clientId).toBeNull();
+  });
+
+  it("derives organization authorization fields only from the live user", async () => {
+    const result = await authenticate(activeLiveUser, {
+      userId: "u1",
+      email: "real@example.com",
+      role: "user",
+      storeRole: "managed",
+      clientId: "client-old",
+      orgRole: "company_it_contact",
+      departmentId: "dept-old",
+      managerUserId: "manager-old",
+      isCompanyItContact: true,
+    });
+
+    expect(result.req.user.orgRole).toBe("staff");
+    expect(result.req.user.departmentId).toBe("dept-new");
+    expect(result.req.user.managerUserId).toBe("manager-new");
+    expect(result.req.user.isCompanyItContact).toBe(false);
+  });
+
+  it("denies a live user explicitly marked inactive", async () => {
+    const result = await authenticate(
+      { ...activeLiveUser, isActive: false },
+      {
+        userId: "u1",
+        email: "real@example.com",
+        role: "user",
+        storeRole: "managed",
+      },
+    );
+
+    expect(result.next).not.toHaveBeenCalled();
+    expect(result.status()).toBe(401);
+  });
+
+  it("does not preserve impersonation authority after a live admin downgrade", async () => {
+    const result = await authenticate(activeLiveUser, {
+      userId: "u1",
       email: "real@example.com",
       role: "admin",
       storeRole: "admin",
-      clientId: null,
+      impersonatingCompanyId: "client-victim",
+      impersonatingCompanyName: "Victim Co",
     });
-    (findUserById as any).mockReturnValue(undefined);
 
-    const token = jwt.sign(
-      { userId: "u1", email: "real@example.com", role: "user", storeRole: "prospect" },
-      process.env.JWT_SECRET as string,
-      { expiresIn: "24h" },
-    );
+    expect(result.next).toHaveBeenCalledTimes(1);
+    expect(result.req.user.role).toBe("user");
+    expect(result.req.user.impersonatingCompanyId).toBeNull();
+    expect(result.req.user.impersonatingCompanyName).toBeNull();
+  });
 
-    const req: any = { headers: { authorization: `Bearer ${token}` }, cookies: {} };
-    const res: any = {
-      status() {
-        return this;
-      },
-      json() {
-        return this;
-      },
-    };
-    const next = vi.fn();
+  it("keeps an unchanged active user authenticated with live fields", async () => {
+    const result = await authenticate(activeLiveUser, {
+      userId: "u1",
+      email: "real@example.com",
+      role: "user",
+      storeRole: "managed",
+      clientId: "client-new",
+    });
 
-    authMiddleware(req, res, next);
+    expect(result.next).toHaveBeenCalledTimes(1);
+    expect(result.status()).toBeUndefined();
+    expect(result.req.user).toMatchObject({
+      id: "u1",
+      email: "real@example.com",
+      role: "user",
+      storeRole: "managed",
+      clientId: "client-new",
+    });
+  });
 
-    expect(next).toHaveBeenCalled();
-    // Live record wins over stale token claims (role/storeRole).
-    expect(req.user.role).toBe("admin");
-    expect(req.user.storeRole).toBe("admin");
+  it("treats password and Zoho-issued sessions the same once the JWT reaches middleware", async () => {
+    const password = await authenticate(activeLiveUser, {
+      userId: "u1",
+      email: "real@example.com",
+      role: "admin",
+      storeRole: "admin",
+      clientId: "client-old",
+      authMethod: "password",
+    });
+    const zoho = await authenticate(activeLiveUser, {
+      userId: "u1",
+      email: "real@example.com",
+      role: "admin",
+      storeRole: "admin",
+      clientId: "client-old",
+      authMethod: "zoho_sso",
+    });
+
+    expect(password.next).toHaveBeenCalledTimes(1);
+    expect(zoho.next).toHaveBeenCalledTimes(1);
+    expect(password.req.user).toEqual(zoho.req.user);
+    expect(password.req.user.role).toBe("user");
+    expect(password.req.user.clientId).toBe("client-new");
   });
 });

--- a/server/portalAuthFailClosed.test.ts
+++ b/server/portalAuthFailClosed.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import jwt from "jsonwebtoken";
+
+vi.mock("./portalAuthStore", async () => {
+  const actual = await vi.importActual<typeof import("./portalAuthStore")>("./portalAuthStore");
+  return {
+    ...actual,
+    getUser: vi.fn(),
+  };
+});
+
+vi.mock("./portalOrg", async () => {
+  const actual = await vi.importActual<typeof import("./portalOrg")>("./portalOrg");
+  return {
+    ...actual,
+    findUserById: vi.fn(),
+  };
+});
+
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret-for-fail-closed-auth-test";
+
+describe("portal authMiddleware fails closed when no live user record exists", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("denies a validly-signed JWT whose user has no live record", async () => {
+    const { authMiddleware } = await import("./routes");
+    const { getUser } = await import("./portalAuthStore");
+    const { findUserById } = await import("./portalOrg");
+    (getUser as any).mockReturnValue(undefined);
+    (findUserById as any).mockReturnValue(undefined);
+
+    const token = jwt.sign(
+      { userId: "ghost-user", email: "ghost@example.com", role: "admin", storeRole: "admin" },
+      process.env.JWT_SECRET as string,
+      { expiresIn: "24h" },
+    );
+
+    const req: any = { headers: { authorization: `Bearer ${token}` }, cookies: {} };
+    let statusCode: number | undefined;
+    let body: any;
+    const res: any = {
+      status(code: number) {
+        statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        body = payload;
+        return this;
+      },
+    };
+    const next = vi.fn();
+
+    authMiddleware(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(statusCode).toBe(401);
+    expect(body?.error).toBeTruthy();
+    expect(req.user).toBeUndefined();
+  });
+
+  it("still authorizes when a live, non-disabled record exists", async () => {
+    const { authMiddleware } = await import("./routes");
+    const { getUser } = await import("./portalAuthStore");
+    const { findUserById } = await import("./portalOrg");
+    (getUser as any).mockReturnValue({
+      id: "u1",
+      email: "real@example.com",
+      role: "admin",
+      storeRole: "admin",
+      clientId: null,
+    });
+    (findUserById as any).mockReturnValue(undefined);
+
+    const token = jwt.sign(
+      { userId: "u1", email: "real@example.com", role: "user", storeRole: "prospect" },
+      process.env.JWT_SECRET as string,
+      { expiresIn: "24h" },
+    );
+
+    const req: any = { headers: { authorization: `Bearer ${token}` }, cookies: {} };
+    const res: any = {
+      status() {
+        return this;
+      },
+      json() {
+        return this;
+      },
+    };
+    const next = vi.fn();
+
+    authMiddleware(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    // Live record wins over stale token claims (role/storeRole).
+    expect(req.user.role).toBe("admin");
+    expect(req.user.storeRole).toBe("admin");
+  });
+});

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -204,7 +204,13 @@ export function authMiddleware(req: AuthenticatedRequest, res: Response, next: N
   try {
     const decoded = jwt.verify(token, JWT_SECRET) as JWTPayload;
     const live = portalAuthGetUser(decoded.email) || (decoded.userId ? findUserById(decoded.userId) : null);
-    if (live && ((live as any).disabled || (live as any).status === "disabled" || (live as any).status === "revoked")) {
+    // Fail closed: a validly-signed JWT for a user with no live record (deleted, never
+    // indexed, or a store that has not finished loading) must be denied, not fall back to
+    // trusting the token's embedded role/storeRole/clientId claims. See docs/MASTER-GUARDRAILS.md #7-8.
+    if (!live) {
+      return res.status(401).json({ error: "Account not found. Please log in again." });
+    }
+    if ((live as any).disabled || (live as any).status === "disabled" || (live as any).status === "revoked") {
       return res.status(401).json({ error: "Account disabled or revoked" });
     }
     req.user = {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -210,24 +210,44 @@ export function authMiddleware(req: AuthenticatedRequest, res: Response, next: N
     if (!live) {
       return res.status(401).json({ error: "Account not found. Please log in again." });
     }
-    if ((live as any).disabled || (live as any).status === "disabled" || (live as any).status === "revoked") {
+    if (
+      (live as any).disabled ||
+      (live as any).status === "disabled" ||
+      (live as any).status === "revoked" ||
+      (live as any).isActive === false
+    ) {
       return res.status(401).json({ error: "Account disabled or revoked" });
     }
+
+    // JWT proves the session; the live Portal record is authoritative for
+    // authorization and tenancy on every request.
+    const liveRole = live.role || "user";
+    const isLiveAdmin = liveRole === "admin";
+
     req.user = {
-      id: live?.id ?? decoded.userId,
-      email: live?.email ?? decoded.email,
-      role: live?.role ?? decoded.role,
-      storeRole: (live as any)?.storeRole ?? decoded.storeRole ?? "public",
-      clientId: live?.clientId ?? decoded.clientId ?? null,
-      orgRole: live?.orgRole ?? decoded.orgRole ?? "staff",
-      departmentId: live?.departmentId ?? decoded.departmentId ?? null,
-      managerUserId: live?.managerUserId ?? decoded.managerUserId ?? null,
-      isCompanyItContact: live?.isCompanyItContact ?? decoded.isCompanyItContact ?? false,
-      fullName: live?.fullName,
-      impersonatingCompanyId: (decoded as any).impersonatingCompanyId || null,
-      impersonatingCompanyName: (decoded as any).impersonatingCompanyName || null,
+      id: live.id,
+      email: live.email,
+      role: liveRole,
+      storeRole:
+        (live as any).storeRole ??
+        (isLiveAdmin ? "admin" : "public"),
+      clientId: live.clientId ?? null,
+      orgRole:
+        live.orgRole ??
+        (isLiveAdmin ? "company_it_contact" : "staff"),
+      departmentId: live.departmentId ?? null,
+      managerUserId: live.managerUserId ?? null,
+      isCompanyItContact:
+        live.isCompanyItContact ?? isLiveAdmin,
+      fullName: live.fullName,
+      impersonatingCompanyId: isLiveAdmin
+        ? (decoded as any).impersonatingCompanyId || null
+        : null,
+      impersonatingCompanyName: isLiveAdmin
+        ? (decoded as any).impersonatingCompanyName || null
+        : null,
     };
-    req.userId = live?.id ?? decoded.userId;
+    req.userId = live.id;
     
     // Optional session validation from cookies
     const sessionId = req.cookies?.sessionId;


### PR DESCRIPTION
Transplants Cowork's fail-closed Portal auth fix onto the current `main` without carrying the stale branch history.

Current slice:
- deny a valid JWT when its Portal user no longer exists in the live store
- preserve live-user authorization when the record exists
- add regression coverage for missing-live-user denial and live-role precedence

Important: this PR is intentionally not considered complete for issue #10 yet. During review, we found the middleware still falls back to JWT values for some null/undefined live authorization fields (notably `clientId`), so cross-client reassignment/removal can retain stale token tenancy. Before merge, this PR must also make role/storeRole/client/org authorization exclusively live-derived, deny `isActive === false`, and clear impersonation authority when the live user is no longer admin. Additional regression tests are required for the full #10 acceptance matrix.

This branch is based on current `main`; Cowork's original local branch was 10 commits behind and was not used directly.