### PR TITLE
Store: make client pricing durable and authoritative

### DIFF
--- a/client/src/hooks/useStoreAuth.ts
+++ b/client/src/hooks/useStoreAuth.ts
@@ -61,8 +61,10 @@ export function useStoreAuth(): StoreAuthState {
         setClientType(data.clientType || "public");
         return data.clientType as ClientType;
       }
+      setClientType("public");
     } catch (error) {
       console.error("Failed to fetch client info:", error);
+      setClientType("public");
     }
     return "public" as ClientType;
   }, []);
@@ -77,10 +79,13 @@ export function useStoreAuth(): StoreAuthState {
 
       if (response.ok) {
         const data = await response.json();
-        setClientPricing(data.pricing || []);
+        setClientPricing(Array.isArray(data.pricing) ? data.pricing : []);
+        return;
       }
+      setClientPricing([]);
     } catch (error) {
       console.error("Failed to fetch client pricing:", error);
+      setClientPricing([]);
     }
   }, []);
 
@@ -147,6 +152,8 @@ export function useStoreAuth(): StoreAuthState {
   const refreshPricing = useCallback(async () => {
     if (token) {
       await fetchClientPricing(token);
+    } else {
+      setClientPricing([]);
     }
   }, [token, fetchClientPricing]);
 

--- a/server/secureStoreCheckout.ts
+++ b/server/secureStoreCheckout.ts
@@ -1,6 +1,12 @@
 import type { Express, NextFunction, Request, Response } from "express";
 import { storeProducts, type StoreProduct } from "../client/src/data/storeProducts";
-import { resolveClientPricingRows, resolveUnitPrice, toPriceOverrides } from "./storeClientPricing";
+import {
+  removeClientPricing,
+  resolveClientPricingRows,
+  resolveUnitPrice,
+  setClientPricing,
+  toPriceOverrides,
+} from "./storeClientPricing";
 
 type StoreRole = "public" | "prospect" | "managed" | "comanaged" | "admin";
 
@@ -142,6 +148,119 @@ export function registerSecureZohoStoreCheckout(
     .catch((error) => {
       console.error("[ORDER FULFILLMENT RECONCILER START ERROR]", error);
     });
+
+  // Canonical client-pricing routes register before routes.ts. Authorization
+  // comes from authMiddleware's live Portal record; the browser never supplies
+  // the tenant whose negotiated pricing is returned.
+  app.get(
+    "/api/store/client-pricing",
+    [authMiddleware as any],
+    async (req: CheckoutRequest, res: Response) => {
+      try {
+        const pricing = await resolveClientPricingRows(req.user?.clientId);
+        return res.json({ pricing });
+      } catch (error: any) {
+        console.error("[STORE CLIENT PRICING ERROR]", error);
+        return res.status(503).json({
+          error: "Client pricing is temporarily unavailable. Catalog pricing remains visible until pricing can be verified.",
+        });
+      }
+    },
+  );
+
+  app.post(
+    "/api/admin/client-pricing/set",
+    [authMiddleware as any],
+    async (req: CheckoutRequest, res: Response) => {
+      if (req.user?.role !== "admin") {
+        return res.status(403).json({ error: "Admin access required" });
+      }
+      try {
+        const { clientId, productId, customPrice, discountPercent } = req.body || {};
+        const result = await setClientPricing({ clientId, productId, customPrice, discountPercent });
+        console.info("[SECURITY] CLIENT_PRICING_SET", {
+          adminId: req.userId,
+          adminEmail: req.user?.email,
+          clientId,
+          productId,
+          source: result.source,
+          oldPrice: result.previous?.customPrice ?? null,
+          oldDiscount: result.previous?.discountPercent ?? null,
+          newPrice: result.current?.customPrice ?? null,
+          newDiscount: result.current?.discountPercent ?? null,
+        });
+        return res.json({
+          success: true,
+          clientId,
+          productId,
+          pricing: result.current,
+          source: result.source,
+        });
+      } catch (error: any) {
+        const message = error?.message || "Failed to set client pricing";
+        const status = /required|unknown store product|must be|valid client price/i.test(message)
+          ? 400
+          : /database|pricing lookup failed/i.test(message)
+            ? 503
+            : 500;
+        console.error("[CLIENT PRICING SET ERROR]", error);
+        return res.status(status).json({ error: message });
+      }
+    },
+  );
+
+  app.get(
+    "/api/admin/client-pricing/:clientId",
+    [authMiddleware as any],
+    async (req: CheckoutRequest, res: Response) => {
+      if (req.user?.role !== "admin") {
+        return res.status(403).json({ error: "Admin access required" });
+      }
+      try {
+        const clientId = stringValue(req.params.clientId, 100);
+        if (!clientId) return res.status(400).json({ error: "Client ID is required" });
+        const pricing = await resolveClientPricingRows(clientId);
+        return res.json({ clientId, pricing });
+      } catch (error: any) {
+        console.error("[GET CLIENT PRICING ERROR]", error);
+        return res.status(503).json({ error: "Client pricing is temporarily unavailable" });
+      }
+    },
+  );
+
+  app.delete(
+    "/api/admin/client-pricing/:clientId/:productId",
+    [authMiddleware as any],
+    async (req: CheckoutRequest, res: Response) => {
+      if (req.user?.role !== "admin") {
+        return res.status(403).json({ error: "Admin access required" });
+      }
+      try {
+        const clientId = stringValue(req.params.clientId, 100);
+        const productId = stringValue(req.params.productId, 100);
+        const result = await removeClientPricing(clientId, productId);
+        console.info("[SECURITY] CLIENT_PRICING_REMOVED", {
+          adminId: req.userId,
+          adminEmail: req.user?.email,
+          clientId,
+          productId,
+          source: result.source,
+          oldPrice: result.previous?.customPrice ?? null,
+          oldDiscount: result.previous?.discountPercent ?? null,
+        });
+        return res.json({ success: true, clientId, productId, source: result.source });
+      } catch (error: any) {
+        const message = error?.message || "Failed to remove client pricing";
+        const status = /required/i.test(message)
+          ? 400
+          : /database|pricing lookup failed/i.test(message)
+            ? 503
+            : 500;
+        console.error("[DELETE CLIENT PRICING ERROR]", error);
+        return res.status(status).json({ error: message });
+      }
+    },
+  );
 
   app.post(
     "/api/store/checkout/zoho",

--- a/server/storeClientPricing.behavior.test.ts
+++ b/server/storeClientPricing.behavior.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { canonicalizeCheckoutLineItems } from "./secureStoreCheckout";
+import { buildClientPriceEntry, resolveUnitPrice } from "./storeClientPricing";
+
+describe("authoritative client pricing", () => {
+  it("gives explicit custom price precedence and derives its discount metadata", () => {
+    const pricing = buildClientPriceEntry({
+      productId: "prod-020",
+      customPrice: 600,
+      discountPercent: 99,
+    });
+
+    expect(pricing).toEqual({
+      productId: "prod-020",
+      customPrice: 600,
+      discountPercent: 20,
+    });
+  });
+
+  it("converts a percentage-only discount from the canonical catalog price", () => {
+    const pricing = buildClientPriceEntry({
+      productId: "prod-020",
+      discountPercent: 10,
+    });
+
+    expect(pricing.customPrice).toBe(675);
+    expect(pricing.discountPercent).toBe(10);
+  });
+
+  it("rejects a client override that is not a real discount", () => {
+    expect(() =>
+      buildClientPriceEntry({
+        productId: "prod-020",
+        customPrice: 750,
+      }),
+    ).toThrow(/lower than catalog price/);
+
+    expect(resolveUnitPrice(750, 900)).toBe(750);
+  });
+
+  it("ignores browser price fields and charges the authenticated client's server override", () => {
+    const [line] = canonicalizeCheckoutLineItems(
+      [
+        {
+          productId: "prod-020",
+          sku: "DE-SVC-CM-ONBOARD-S-OT",
+          quantity: 1,
+          unitPrice: 1,
+          total: 1,
+          discountPercent: 99,
+        },
+      ],
+      "comanaged",
+      { "prod-020": 600 },
+    );
+
+    expect(line.unitPrice).toBe(600);
+    expect(line.total).toBe(600);
+  });
+
+  it("does not leak another client's override when no override is supplied for this request", () => {
+    const [line] = canonicalizeCheckoutLineItems(
+      [
+        {
+          productId: "prod-020",
+          sku: "DE-SVC-CM-ONBOARD-S-OT",
+          quantity: 1,
+          unitPrice: 600,
+        },
+      ],
+      "comanaged",
+      {},
+    );
+
+    expect(line.unitPrice).toBe(750);
+    expect(line.total).toBe(750);
+  });
+});

--- a/server/storeClientPricing.ts
+++ b/server/storeClientPricing.ts
@@ -1,12 +1,19 @@
 import { and, eq } from "drizzle-orm";
 import { money } from "@shared/storeCommerce";
 import { storeClientPricing } from "@shared/schema";
+import { storeProducts as catalogProducts } from "../client/src/data/storeProducts";
 import { db, dbReady, initPromise } from "./db";
 
 export type ClientPriceEntry = {
   productId: string;
   customPrice: number;
   discountPercent: number;
+};
+
+export type ClientPricingMutationResult = {
+  previous: ClientPriceEntry | null;
+  current: ClientPriceEntry | null;
+  source: "database" | "demo";
 };
 
 /**
@@ -91,6 +98,21 @@ export function removeDemoClientPricing(clientId: string, productId: string): Cl
   return removed;
 }
 
+function rowToEntry(row: {
+  productId: string;
+  customPrice: string | number;
+  discountPercent?: string | number | null;
+}): ClientPriceEntry | null {
+  const customPrice = money(Number(row.customPrice));
+  const discountPercent = money(Number(row.discountPercent || 0));
+  if (!Number.isFinite(customPrice) || customPrice <= 0) return null;
+  return {
+    productId: row.productId,
+    customPrice,
+    discountPercent: Number.isFinite(discountPercent) ? discountPercent : 0,
+  };
+}
+
 async function loadDbClientPricing(clientId: string): Promise<ClientPriceEntry[]> {
   await initPromise;
   if (!dbReady || !db) return [];
@@ -100,13 +122,12 @@ async function loadDbClientPricing(clientId: string): Promise<ClientPriceEntry[]
       .from(storeClientPricing)
       .where(and(eq(storeClientPricing.clientId, clientId), eq(storeClientPricing.isActive, true)));
     return rows
-      .map((row: { productId: string; customPrice: string | number; discountPercent?: string | number | null }) => ({
-        productId: row.productId,
-        customPrice: Number(row.customPrice),
-        discountPercent: Number(row.discountPercent || 0),
-      }))
-      .filter((row: ClientPriceEntry) => Number.isFinite(row.customPrice) && row.customPrice > 0);
+      .map(rowToEntry)
+      .filter((row): row is ClientPriceEntry => row !== null);
   } catch (error: any) {
+    if (process.env.NODE_ENV === "production") {
+      throw new Error(`Client pricing lookup failed: ${error?.message || error}`);
+    }
     console.warn("[store-pricing] database lookup skipped:", error?.message || error);
     return [];
   }
@@ -143,4 +164,136 @@ export function resolveUnitPrice(listPrice: number, override?: number): number {
   const custom = money(Number(override));
   if (!Number.isFinite(custom) || custom <= 0 || custom >= list) return list;
   return custom;
+}
+
+/**
+ * Canonical precedence for negotiated pricing:
+ * 1. explicit custom price, when supplied;
+ * 2. otherwise a percentage discount converted from the canonical catalog price;
+ * 3. otherwise no override (catalog price remains authoritative).
+ *
+ * discountPercent is stored as derived metadata whenever customPrice is supplied,
+ * preventing the two fields from disagreeing about what checkout should charge.
+ */
+export function buildClientPriceEntry(input: {
+  productId: string;
+  customPrice?: unknown;
+  discountPercent?: unknown;
+}): ClientPriceEntry {
+  const product = catalogProducts.find((candidate) => candidate.id === input.productId);
+  if (!product) throw new Error("Unknown store product");
+
+  const listPrice = money(Number(product.basePrice));
+  if (!Number.isFinite(listPrice) || listPrice <= 0) {
+    throw new Error("Store product does not have a valid base price");
+  }
+
+  const hasCustom = input.customPrice !== undefined && input.customPrice !== null && input.customPrice !== "";
+  const hasDiscount = input.discountPercent !== undefined && input.discountPercent !== null && input.discountPercent !== "";
+  if (!hasCustom && !hasDiscount) {
+    throw new Error("Either custom price or discount percent is required");
+  }
+
+  if (hasCustom) {
+    const customPrice = money(Number(input.customPrice));
+    if (!Number.isFinite(customPrice) || customPrice <= 0 || customPrice >= listPrice) {
+      throw new Error("Custom price must be greater than zero and lower than catalog price");
+    }
+    const discountPercent = money(((listPrice - customPrice) / listPrice) * 100);
+    return { productId: product.id, customPrice, discountPercent };
+  }
+
+  const discountPercent = money(Number(input.discountPercent));
+  if (!Number.isFinite(discountPercent) || discountPercent <= 0 || discountPercent >= 100) {
+    throw new Error("Discount percent must be greater than zero and less than 100");
+  }
+  const customPrice = money(listPrice * (1 - discountPercent / 100));
+  if (!Number.isFinite(customPrice) || customPrice <= 0 || customPrice >= listPrice) {
+    throw new Error("Discount does not produce a valid client price");
+  }
+  return { productId: product.id, customPrice, discountPercent };
+}
+
+export async function setClientPricing(input: {
+  clientId: string;
+  productId: string;
+  customPrice?: unknown;
+  discountPercent?: unknown;
+}): Promise<ClientPricingMutationResult> {
+  const clientId = String(input.clientId || "").trim();
+  if (!clientId) throw new Error("Client ID is required");
+  const next = buildClientPriceEntry(input);
+
+  await initPromise;
+  if (dbReady && db) {
+    const [existing] = await db
+      .select()
+      .from(storeClientPricing)
+      .where(and(eq(storeClientPricing.clientId, clientId), eq(storeClientPricing.productId, next.productId)))
+      .limit(1);
+    const previous = existing ? rowToEntry(existing) : null;
+
+    if (existing) {
+      await db
+        .update(storeClientPricing)
+        .set({
+          customPrice: next.customPrice.toFixed(2),
+          discountPercent: next.discountPercent.toFixed(2),
+          isActive: true,
+          updatedAt: new Date(),
+        })
+        .where(eq(storeClientPricing.id, existing.id));
+    } else {
+      await db.insert(storeClientPricing).values({
+        clientId,
+        productId: next.productId,
+        customPrice: next.customPrice.toFixed(2),
+        discountPercent: next.discountPercent.toFixed(2),
+        isActive: true,
+      });
+    }
+
+    return { previous, current: next, source: "database" };
+  }
+
+  if (!isDemoClientPricingAllowed()) {
+    throw new Error("Durable client pricing database is unavailable");
+  }
+
+  const previous = listDemoClientPricing(clientId).find((row) => row.productId === next.productId) || null;
+  upsertDemoClientPricing(clientId, next);
+  return { previous, current: next, source: "demo" };
+}
+
+export async function removeClientPricing(
+  clientIdInput: string,
+  productIdInput: string,
+): Promise<ClientPricingMutationResult> {
+  const clientId = String(clientIdInput || "").trim();
+  const productId = String(productIdInput || "").trim();
+  if (!clientId || !productId) throw new Error("Client ID and Product ID are required");
+
+  await initPromise;
+  if (dbReady && db) {
+    const [existing] = await db
+      .select()
+      .from(storeClientPricing)
+      .where(and(eq(storeClientPricing.clientId, clientId), eq(storeClientPricing.productId, productId)))
+      .limit(1);
+    const previous = existing ? rowToEntry(existing) : null;
+    if (existing) {
+      await db
+        .update(storeClientPricing)
+        .set({ isActive: false, updatedAt: new Date() })
+        .where(eq(storeClientPricing.id, existing.id));
+    }
+    return { previous, current: null, source: "database" };
+  }
+
+  if (!isDemoClientPricingAllowed()) {
+    throw new Error("Durable client pricing database is unavailable");
+  }
+
+  const previous = removeDemoClientPricing(clientId, productId) || null;
+  return { previous, current: null, source: "demo" };
 }

--- a/server/storeClientPricing.ts
+++ b/server/storeClientPricing.ts
@@ -123,7 +123,7 @@ async function loadDbClientPricing(clientId: string): Promise<ClientPriceEntry[]
       .where(and(eq(storeClientPricing.clientId, clientId), eq(storeClientPricing.isActive, true)));
     return rows
       .map(rowToEntry)
-      .filter((row): row is ClientPriceEntry => row !== null);
+      .filter((row: ClientPriceEntry | null): row is ClientPriceEntry => row !== null);
   } catch (error: any) {
     if (process.env.NODE_ENV === "production") {
       throw new Error(`Client pricing lookup failed: ${error?.message || error}`);


### PR DESCRIPTION
Completes issue #14 using the negotiated-pricing model already chosen for DE.

What changes:
- keeps client-specific pricing as a real Store capability
- adds durable DB-backed set/remove mutations for `store_client_pricing`
- defines precedence: explicit custom price wins; otherwise discount % is converted from canonical catalog price; otherwise catalog price remains authoritative
- normalizes discount metadata so stored custom price and percentage cannot disagree
- registers canonical authenticated client-pricing and admin pricing routes before legacy routes
- derives the client whose pricing is returned from the live authenticated Portal user, never from a browser-supplied tenant id
- emits structured security/audit logs for admin pricing set/remove operations
- clears stale client pricing in the frontend when the pricing API fails
- adds regression coverage for list-price tampering, discounted-price tampering, precedence, invalid overrides, and no cross-client override leakage

Checkout and quote paths already use the same `resolveClientPricingRows` -> `toPriceOverrides` -> canonical pricing chain, so display/quote/checkout now share the same authoritative source.

Production demo pricing remains disabled.