### PR TITLE
Use Digerati Experts or DE, never standalone Digerati

### DIFF
--- a/client/src/components/MegaMenu.tsx
+++ b/client/src/components/MegaMenu.tsx
@@ -325,7 +325,7 @@ export function MegaMenu() {
           title: 'Learn',
           items: [
             { title: 'Case Studies', description: 'Real Arizona success stories', icon: <TrendingUp className="h-5 w-5" />, url: '/resources/case-studies' },
-            { title: 'Digerati Journal', description: 'Cybersecurity & managed IT field notes', icon: <FileCheck className="h-5 w-5" />, url: '/resources/blog' },
+            { title: 'DE Journal', description: 'Cybersecurity & managed IT field notes', icon: <FileCheck className="h-5 w-5" />, url: '/resources/blog' },
             { title: 'Cyber Facts', description: 'Interactive credibility stats & sources', icon: <Shield className="h-5 w-5" />, url: '/resources/cyber-facts' },
             { title: 'Videos & Webinars', description: 'Educational content library', icon: <Monitor className="h-5 w-5" />, url: '/resources/videos' },
           ]

--- a/client/src/components/ZohoASAPWidget.tsx
+++ b/client/src/components/ZohoASAPWidget.tsx
@@ -330,7 +330,7 @@ export const ZohoASAPWidget = ({
 
   useEffect(() => {
     // Keep the existing Zoho ASAP bootstrap available for Desk integrations, but
-    // do not make it responsible for the custom Digerati support experience.
+    // do not make it responsible for the custom Digerati Experts support experience.
     if (!isEnabled || !accountId || !portalId) return;
     if (typeof document === "undefined") return;
     if (document.querySelector('script[data-zoho-asap="1"]')) return;
@@ -1634,7 +1634,7 @@ export const ZohoASAPWidget = ({
                 <p className="de-desk-composer-caption">
                   <Lock aria-hidden="true" />
                   {agentLive
-                    ? "A Digerati agent is in this thread. Never share passwords or MFA codes."
+                    ? "A DE agent is in this thread. Never share passwords or MFA codes."
                     : "Never share passwords, MFA codes, or private keys."}
                 </p>
               </>

--- a/client/src/data/companyContact.test.ts
+++ b/client/src/data/companyContact.test.ts
@@ -15,6 +15,8 @@ describe("companyContact", () => {
   });
 
   it("keeps canonical company identity on digeratexperts.com", () => {
+    expect(COMPANY.legalName).toBe("Digerati Experts");
+    expect(COMPANY.shortName).toBe("DE");
     expect(COMPANY.website).toBe("https://digeratiexperts.com");
     expect(COMPANY.addressLocality).toBe("Chandler");
     expect(COMPANY.addressRegion).toBe("AZ");

--- a/client/src/data/cyberAwarenessFacts.ts
+++ b/client/src/data/cyberAwarenessFacts.ts
@@ -2,7 +2,7 @@
  * Canonical industry cybersecurity awareness facts for the public site.
  *
  * Rules:
- * - Industry context only — never present as Digerati performance proof.
+ * - Industry context only — never present as Digerati Experts performance proof.
  * - Every fact must include a named source + year.
  * - Do not invent DE customer counts, SLAs, savings, or testimonials here.
  * - Never reinstate the indefensible small-business post-attack closure myth (see ban list below).

--- a/client/src/data/storeMerchandising.guided.test.ts
+++ b/client/src/data/storeMerchandising.guided.test.ts
@@ -4,6 +4,7 @@ import { validatePortalOrderSelection } from "@shared/portalOrderCatalog";
 import { storeProducts } from "./storeProducts";
 import {
   DEFAULT_GUIDED_ANSWERS,
+  GUIDED_BUYER_OPTIONS,
   buildGuidedRecommendation,
   filterProductsForGuidance,
   recommendProactiveSku,
@@ -20,6 +21,14 @@ const prospectProtect: GuidedBuyingAnswers = {
 };
 
 describe("consultative store guidance", () => {
+  it("names buyer types as DE or Digerati Experts", () => {
+    expect(GUIDED_BUYER_OPTIONS.map((option) => option.label)).toEqual([
+      "New to DE",
+      "Existing DE client",
+      "In-house IT",
+    ]);
+  });
+
   it("does not dump the unfiltered catalog as the default recommendation", () => {
     const rec = buildGuidedRecommendation(prospectProtect);
     const filtered = filterProductsForGuidance(storeProducts, rec, { fullCatalog: false });

--- a/client/src/data/storeMerchandising.ts
+++ b/client/src/data/storeMerchandising.ts
@@ -1287,12 +1287,12 @@ export const GUIDED_BUYER_OPTIONS: {
 }[] = [
   {
     value: "prospect",
-    label: "New to Digerati",
+    label: "New to DE",
     blurb: "Looking for managed IT or a first security read — Solutions, not a hardware wall.",
   },
   {
     value: "existing_client",
-    label: "Existing Digerati client",
+    label: "Existing DE client",
     blurb: "Add tools from the Client Marketplace without replacing your current stack.",
   },
   {
@@ -1515,7 +1515,7 @@ export function buildGuidedRecommendation(answers: GuidedBuyingAnswers): GuidedR
     family === "solutions"
       ? `One ProActive tier (consultative — packages are mutually exclusive), the $2,500 Cybersecurity Risk Assessment when relevant, and a few related add-ons. List rates × ~${seats} seats where unit-priced; checkout uses canonical SKUs and prices.`
       : `Client Marketplace picks for ${
-          answers.buyerType === "in_house_it" ? "an in-house IT team" : "an existing Digerati client"
+          answers.buyerType === "in_house_it" ? "an in-house IT team" : "an existing DE client"
         }. We are not stacking a second ProActive package. Estimates are list rates; checkout still confirms server prices.`;
 
   return {

--- a/client/src/lib/visualAssets.ts
+++ b/client/src/lib/visualAssets.ts
@@ -1,5 +1,5 @@
 /**
- * Public visual-system registry for Digerati website stills.
+ * Public visual-system registry for Digerati Experts website stills.
  *
  * Rules:
  * - Only optimized derivatives under `/images/...` (never licensed ORIGINAL paths)

--- a/client/src/pages/NetworkPlannerOfficial.tsx
+++ b/client/src/pages/NetworkPlannerOfficial.tsx
@@ -77,7 +77,7 @@ function InternalToolGate({ children }: { children: React.ReactNode }) {
           </div>
           <h1 className="text-xl font-bold">Internal tool — sign-in required</h1>
           <p className="text-slate-400 text-sm leading-relaxed">
-            The Networking Planner is for authorized Digerati staff and partners. It is not a public
+            The Networking Planner is for authorized Digerati Experts staff and partners. It is not a public
             marketing calculator. Sign in through the Client Portal to continue.
           </p>
           <a

--- a/client/src/pages/about/ComplianceCertifications.tsx
+++ b/client/src/pages/about/ComplianceCertifications.tsx
@@ -152,7 +152,7 @@ export default function ComplianceCertifications() {
   useSEO({
     title: "Compliance Frameworks We Support",
     description:
-      "HIPAA, CMMC, PCI DSS, SOC 2, and FTC Safeguards support from Digerati Experts. Framework names describe customer requirements — not Digerati certifications.",
+      "HIPAA, CMMC, PCI DSS, SOC 2, and FTC Safeguards support from Digerati Experts. Framework names describe customer requirements — not Digerati Experts certifications.",
     canonical: "/about/compliance-certifications",
   });
 

--- a/client/src/pages/industries/Accounting.tsx
+++ b/client/src/pages/industries/Accounting.tsx
@@ -148,7 +148,7 @@ export default function Accounting() {
           <div className="grid gap-4 md:grid-cols-4">
             {[
               { title: "HIPAA-aligned support", label: "Security and compliance support for practices handling PHI" },
-              { title: "SOC 2 readiness", label: "Control mapping and evidence — not a Digerati certification" },
+              { title: "SOC 2 readiness", label: "Control mapping and evidence — not a Digerati Experts certification" },
               { title: "Cyber insurance readiness", label: "Documentation carriers typically request in underwriting" },
               { title: "Security reporting", label: "Repeatable evidence for audits and client questionnaires" },
             ].map((item) => (

--- a/client/src/pages/industries/Healthcare.tsx
+++ b/client/src/pages/industries/Healthcare.tsx
@@ -141,7 +141,7 @@ export default function Healthcare() {
   return (
     <PageTemplate
       title="Keep Patient Data Protected Without Becoming a HIPAA Expert"
-      subtitle="Digerati manages security, backups, access controls, documentation, and ongoing IT behind Arizona practices so owners can focus on patients."
+      subtitle="Digerati Experts manages security, backups, access controls, documentation, and ongoing IT behind Arizona practices so owners can focus on patients."
       icon={<Stethoscope className="w-10 h-10 text-de-accent-ink" />}
       breadcrumbs={[{ label: "Industries", href: "/industries" }, { label: "Healthcare" }]}
       actions={
@@ -300,7 +300,7 @@ export default function Healthcare() {
         <section data-testid="section-how-we-solve">
           <div className="mb-3 flex items-center gap-3">
             <IconWell icon={Layers} size="sm" surface="dark" />
-            <h2 className="text-3xl font-bold text-white">How Digerati solves them</h2>
+            <h2 className="text-3xl font-bold text-white">How Digerati Experts solves them</h2>
           </div>
           <p className="mb-8 max-w-3xl text-white/70">
             IT, cybersecurity, and compliance as one operating program — so security is not bolted onto
@@ -327,7 +327,7 @@ export default function Healthcare() {
         </section>
 
         <section data-testid="section-differentiation">
-          <h2 className="mb-6 text-3xl font-bold text-white">Why Digerati instead of ordinary IT support</h2>
+          <h2 className="mb-6 text-3xl font-bold text-white">Why Digerati Experts instead of ordinary IT support</h2>
           <div className="max-w-4xl space-y-3">
             {differentiation.map((item, idx) => (
               <motion.div

--- a/client/src/pages/portal/AdminAgents.tsx
+++ b/client/src/pages/portal/AdminAgents.tsx
@@ -23,7 +23,7 @@ interface Agent {
 const sampleAgents: Agent[] = [
   {
     id: "1",
-    name: "Digerati Expert Desktop Agent",
+    name: "Digerati Experts Desktop Agent",
     type: "custom",
     version: "1.0.0",
     downloadUrl: "https://agents.digerati.com/digerati-agent-1.0.0.exe",

--- a/client/src/pages/portal/PortalAdvancedForms.tsx
+++ b/client/src/pages/portal/PortalAdvancedForms.tsx
@@ -618,7 +618,7 @@ export function PortalAdvancedForms() {
               <div className="text-sm text-blue-800 dark:text-blue-300 space-y-2">
                 <p>
                   Submitting starts an approval workflow (your manager → optional skip-level → IT Contact) before
-                  Digerati provisions access. For break/fix issues, open a regular support ticket instead.
+                  DE provisions access. For break/fix issues, open a regular support ticket instead.
                 </p>
                 <p>
                   <strong>Manager / approver email</strong> is optional but recommended for admin/privileged

--- a/client/src/pages/portal/PortalAgent.tsx
+++ b/client/src/pages/portal/PortalAgent.tsx
@@ -14,7 +14,7 @@ interface Agent {
 
 const agents: Agent[] = [
   {
-    name: "Digerati Expert Desktop Agent",
+    name: "Digerati Experts Desktop Agent",
     version: "1.0.0",
     downloadUrl: "/api/portal/agent/download",
     description: "Our native desktop agent for quick support access",
@@ -178,9 +178,9 @@ export default function PortalAgent() {
           </CardContent>
         </Card>
 
-        {/* Digerati Agent Features */}
+        {/* DE Agent Features */}
         <div>
-          <h3 className="text-lg font-bold mb-4">Digerati Expert Agent Features</h3>
+          <h3 className="text-lg font-bold mb-4">Digerati Experts Agent Features</h3>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {digeratiFeatures.map((feature) => {
               const Icon = feature.icon;

--- a/client/src/pages/portal/PortalApprovals.tsx
+++ b/client/src/pages/portal/PortalApprovals.tsx
@@ -109,7 +109,7 @@ export function PortalApprovals() {
       <div className="max-w-5xl mx-auto space-y-4">
         <p className="text-sm text-slate-600">
           Access and spend-style requests route to your manager, optional skip-level (high priority or
-          $1,000+), then your Department or Company IT Contact before Digerati fulfills the work.
+          $1,000+), then your Department or Company IT Contact before DE fulfills the work.
         </p>
 
         {showQueues && (
@@ -229,7 +229,7 @@ export function PortalApprovals() {
 
               {selected.fulfillmentTicketId && (
                 <p className="text-sm text-slate-600">
-                  Fulfillment ticket created for Digerati after final approval.
+                  Fulfillment ticket created for DE after final approval.
                 </p>
               )}
             </CardContent>

--- a/client/src/pages/portal/PortalInfrastructure.tsx
+++ b/client/src/pages/portal/PortalInfrastructure.tsx
@@ -23,7 +23,7 @@ const ISSUE_TYPES = [
   {
     value: "Infrastructure - Onsite Outage",
     label: "Request IT onsite (outage)",
-    help: "Active outage or major disruption — ask Digerati to come onsite.",
+    help: "Active outage or major disruption — ask DE to come onsite.",
   },
   {
     value: "Infrastructure - Project Onsite",
@@ -162,7 +162,7 @@ export function PortalInfrastructure() {
                   onChange={(e) => setDescription(e.target.value)}
                   required
                   rows={6}
-                  placeholder="Who is affected, when it started, and what you need from Digerati."
+                  placeholder="Who is affected, when it started, and what you need from DE."
                 />
               </div>
 
@@ -173,7 +173,7 @@ export function PortalInfrastructure() {
               )}
 
               <Button type="submit" disabled={submitting} className="w-full sm:w-auto">
-                {submitting ? "Submitting…" : "Submit to Digerati"}
+                {submitting ? "Submitting…" : "Submit to DE"}
               </Button>
             </form>
           </CardContent>

--- a/client/src/pages/portal/PortalPeople.tsx
+++ b/client/src/pages/portal/PortalPeople.tsx
@@ -107,7 +107,7 @@ export function PortalPeople() {
         <Card>
           <CardContent className="py-10 text-center space-y-3">
             <p className="text-slate-600">
-              Only your Company IT Contact (or a Digerati admin) can manage managers, departments, and
+              Only your Company IT Contact (or a DE admin) can manage managers, departments, and
               IT Contacts.
             </p>
             <Link
@@ -127,7 +127,7 @@ export function PortalPeople() {
       <div className="max-w-5xl mx-auto space-y-6">
         <p className="text-sm text-slate-600">
           Assign each person a manager (boss), optional department, and designate the Company IT Contact
-          who owns day-to-day communication with Digerati. Department IT Contacts are optional.
+          who owns day-to-day communication with DE. Department IT Contacts are optional.
         </p>
 
         {error && (

--- a/client/src/pages/resources/Blog.tsx
+++ b/client/src/pages/resources/Blog.tsx
@@ -89,10 +89,10 @@ export default function Blog() {
   return (
     <div className="min-h-screen bg-[#0a0a0a]">
       <Helmet>
-        <title>The Digerati Journal — Cybersecurity & Managed IT Insights | Digerati Experts</title>
+        <title>The DE Journal — Cybersecurity & Managed IT Insights | Digerati Experts</title>
         <meta
           name="description"
-          content="The Digerati Journal: cybersecurity-first insights for Arizona small and growing businesses — managed IT, ransomware defense, cyber risk assessments, AI governance, and compliance."
+          content="The DE Journal: cybersecurity-first insights for Arizona small and growing businesses — managed IT, ransomware defense, cyber risk assessments, AI governance, and compliance."
         />
       </Helmet>
       <MegaMenu />
@@ -100,7 +100,7 @@ export default function Blog() {
       {/* Branded publication banner */}
       <section
         className="relative de-nav-clear overflow-hidden"
-        aria-label="The Digerati Journal masthead"
+        aria-label="The DE Journal masthead"
       >
         <div
           aria-hidden
@@ -140,7 +140,7 @@ export default function Blog() {
                   the
                 </span>
                 <span className="block text-5xl md:text-7xl lg:text-8xl">
-                  Digerati{" "}
+                  DE{" "}
                   <span className="text-de-accent-ink">
                     Journal
                   </span>

--- a/client/src/pages/resources/Ebook.tsx
+++ b/client/src/pages/resources/Ebook.tsx
@@ -615,7 +615,7 @@ export default function Ebook() {
               <div className="mt-12">
                 <ConversionPathBar
                   headline="Ready to assess your environment?"
-                  body="Use this framework with a Digerati Cyber Risk Assessment — not a generic checklist."
+                  body="Use this framework with a Digerati Experts Cyber Risk Assessment — not a generic checklist."
                 />
               </div>
             </motion.div>

--- a/client/src/pages/resources/ResourcesIndex.tsx
+++ b/client/src/pages/resources/ResourcesIndex.tsx
@@ -17,7 +17,7 @@ import { Button } from "@/components/ui/button";
 
 const resources = [
   {
-    name: "Digerati Journal",
+    name: "DE Journal",
     href: "/resources/blog",
     description: "Field notes on managed IT, cybersecurity, and Arizona business risk.",
     icon: BookOpen,

--- a/client/src/pages/routes/servicePages.tsx
+++ b/client/src/pages/routes/servicePages.tsx
@@ -383,7 +383,7 @@ export const industryPageData = {
 
 export const resourcePageData = {
   'blog': {
-    title: "Digerati Journal",
+    title: "DE Journal",
     subtitle: "Cybersecurity & managed IT field notes for Arizona businesses",
     description: "Stay informed with our latest articles on cybersecurity threats, IT best practices, and technology trends affecting Arizona businesses.",
     features: [

--- a/client/src/pages/sections/DigeratiEnhancedFooterSection.tsx
+++ b/client/src/pages/sections/DigeratiEnhancedFooterSection.tsx
@@ -35,7 +35,7 @@ const serviceLinks = [
 ];
 
 const resourceLinks = [
-  { name: "Digerati Journal", href: "/resources/blog" },
+  { name: "DE Journal", href: "/resources/blog" },
   { name: "Cyber Facts", href: "/resources/cyber-facts" },
   { name: "Knowledge Base", href: "/support/knowledge-base" },
   { name: "Contact", href: "/contact" },

--- a/client/src/pages/sections/DigeratiFooterSection.tsx
+++ b/client/src/pages/sections/DigeratiFooterSection.tsx
@@ -41,7 +41,7 @@ export const DigeratiFooterSection = (): JSX.Element => {
           <div>
             <h4 className="text-lg font-semibold mb-4">Resources</h4>
             <ul className="space-y-2">
-              <li><a href="/resources/blog" className="text-gray-400 hover:text-white transition-colors">Digerati Journal</a></li>
+              <li><a href="/resources/blog" className="text-gray-400 hover:text-white transition-colors">DE Journal</a></li>
               <li><a href="/resources/security-updates" className="text-gray-400 hover:text-white transition-colors">Threat Intelligence</a></li>
               <li><a href="/resources/case-studies" className="text-gray-400 hover:text-white transition-colors">Case Studies</a></li>
               <li><a href="/legal/privacy-policy" className="text-gray-400 hover:text-white transition-colors">Privacy Policy</a></li>

--- a/client/src/pages/sections/DigeratiThreatsInsightsSection.tsx
+++ b/client/src/pages/sections/DigeratiThreatsInsightsSection.tsx
@@ -20,7 +20,7 @@ const categoryIcon: Record<ThreatCategory, JSX.Element> = {
   "Malware Activity": <Bug className="h-5 w-5" />,
   Ransomware: <AlertCircle className="h-5 w-5" />,
   "Microsoft Security": <Lock className="h-5 w-5" />,
-  "Digerati Advisory": <Shield className="h-5 w-5" />,
+  "DE Advisory": <Shield className="h-5 w-5" />,
 };
 
 function categoryBadgeClass(item: ThreatItem): string {
@@ -296,7 +296,7 @@ export const DigeratiThreatsInsightsSection = (): JSX.Element => {
             className="inline-flex min-h-11 items-center gap-2 rounded-lg border border-de-hairline bg-transparent px-6 py-2.5 text-base font-semibold text-white transition-colors hover:border-white/25 md:px-8 md:py-3"
             data-testid="view-digerati-journal"
           >
-            Read the Digerati Journal
+            Read the DE Journal
             <ArrowRight className="h-4 w-4" />
           </Link>
         </motion.div>

--- a/client/src/pages/sections/HomepageTrustRail.tsx
+++ b/client/src/pages/sections/HomepageTrustRail.tsx
@@ -36,7 +36,7 @@ export function HomepageTrustRail() {
     <section id="trust-rail" className="py-12 lg:py-16 bg-[#0a0a0a] border-y border-white/5">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <p className="text-xs font-semibold uppercase tracking-[0.2em] text-pink-300/90 mb-3">
-          Why Digerati is different
+          Why Digerati Experts is different
         </p>
         <h2 className="text-2xl md:text-3xl font-bold text-white mb-8 max-w-2xl">
           Credible managed IT and cybersecurity — without the lock-in theater

--- a/client/src/pages/store/CoManagedStore.tsx
+++ b/client/src/pages/store/CoManagedStore.tsx
@@ -910,7 +910,7 @@ const CoManagedStore = () => {
             </h2>
             <p className="mx-auto mb-8 max-w-xl text-white/60">
               Looking for full-service managed IT instead of à la carte products? Explore ProActive
-              Ecosystem plans for all-inclusive support — or ask Digerati to recommend a stack.
+              Ecosystem plans for all-inclusive support — or ask DE to recommend a stack.
             </p>
             <div className="flex flex-col justify-center gap-4 sm:flex-row">
               <Link href="/store/managed">

--- a/client/src/pages/trust/TrustCenter.tsx
+++ b/client/src/pages/trust/TrustCenter.tsx
@@ -13,7 +13,7 @@ export default function TrustCenter() {
   useSEO({
     title: "Trust Center",
     description:
-      "Digerati Experts Trust Center: security practices, compliance support, and how to request questionnaires. Framework names describe customer requirements — not Digerati certifications.",
+      "Digerati Experts Trust Center: security practices, compliance support, and how to request questionnaires. Framework names describe customer requirements — not Digerati Experts certifications.",
     canonical: "/trust/trust-center",
   });
   

--- a/docs/THREAT-INTEL-FEED.md
+++ b/docs/THREAT-INTEL-FEED.md
@@ -35,7 +35,7 @@ Archive: score ≥ 15, age ≤ 90 days, max 40 items.
 
 Categories are **not** all called “alert”:
 
-`Active Exploitation · Threat Advisory · Critical Vulnerability · Malware Activity · Ransomware · Microsoft Security · Digerati Advisory`
+`Active Exploitation · Threat Advisory · Critical Vulnerability · Malware Activity · Ransomware · Microsoft Security · DE Advisory`
 
 ## Refresh
 

--- a/server/portalAuthStore.ts
+++ b/server/portalAuthStore.ts
@@ -278,7 +278,7 @@ function seedDemoIfNotProduction() {
     contactEmail: "admin@digeratiexperts.com",
     contactPhone: PRIMARY_PHONE.display,
     industry: "MSP/MSSP",
-    primaryContact: "Digerati Admin",
+    primaryContact: "DE Admin",
     status: "active",
     type: "msp",
     serviceType: "managed",
@@ -409,7 +409,7 @@ export function listClients(): PortalAuthClient[] {
 
 const INTERNAL_MSP_ID = "msp-digerati";
 
-/** Live Digerati org if one exists; otherwise create the internal MSP tenant. */
+/** Live Digerati Experts org if one exists; otherwise create the internal MSP tenant. */
 export function findInternalMspClient(): PortalAuthClient | undefined {
   const all = listClients();
   return (
@@ -428,7 +428,7 @@ export function ensureInternalMspClient(): PortalAuthClient {
     contactEmail: "admin@digeratiexperts.com",
     contactPhone: PRIMARY_PHONE.display,
     industry: "MSP/MSSP",
-    primaryContact: "Digerati Admin",
+    primaryContact: "DE Admin",
     status: "active",
     type: "msp",
     serviceType: "managed",

--- a/server/portalTicketCreate.test.ts
+++ b/server/portalTicketCreate.test.ts
@@ -26,7 +26,7 @@ describe("resolveTicketCreateTarget", () => {
     expect(ticketCompanyName(undefined, INTERNAL_COMPANY_NAME)).toBe(INTERNAL_COMPANY_NAME);
   });
 
-  it("lets admin create without clientId as an internal Digerati ticket", () => {
+  it("lets admin create without clientId as an internal Digerati Experts ticket", () => {
     const result = resolveTicketCreateTarget({
       actor: { role: "admin", clientId: null },
       ...deps(),

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -515,7 +515,7 @@ export async function registerRoutes(app: Express) {
         items: [],
         sources: {},
         attribution:
-          "Sources: CISA, NIST NVD, FIRST, and Microsoft MSRC. Digerati prioritizes items based on active exploitation, exploit probability, and relevance to SMB environments.",
+          "Sources: CISA, NIST NVD, FIRST, and Microsoft MSRC. Digerati Experts prioritizes items based on active exploitation, exploit probability, and relevance to SMB environments.",
         message: "Unable to load the threat feed",
       });
     }
@@ -4306,7 +4306,7 @@ export async function registerRoutes(app: Express) {
           companyName: null,
           matchedDeals: [],
           source: "none",
-          message: "No company profile on this portal user. Contact your Company IT Contact or Digerati.",
+          message: "No company profile on this portal user. Contact your Company IT Contact or DE.",
         });
       }
 
@@ -4402,7 +4402,7 @@ export async function registerRoutes(app: Express) {
     try {
       return res.status(501).json({
         message:
-          "E-signature is completed through the Zoho Sign link sent for this document (managed in TechSales). Contact your Company IT Contact or Digerati if you need the signing link resent.",
+          "E-signature is completed through the Zoho Sign link sent for this document (managed in TechSales). Contact your Company IT Contact or DE if you need the signing link resent.",
       });
     } catch (error: any) {
       logger.error("Failed to sign contract", error);
@@ -4414,7 +4414,7 @@ export async function registerRoutes(app: Express) {
     try {
       return res.status(501).json({
         message:
-          "To decline a pending agreement, use the Zoho Sign email link or ask Digerati / your Company IT Contact to recall the request in TechSales.",
+          "To decline a pending agreement, use the Zoho Sign email link or ask DE / your Company IT Contact to recall the request in TechSales.",
       });
     } catch (error: any) {
       logger.error("Failed to decline contract", error);
@@ -4432,7 +4432,7 @@ export async function registerRoutes(app: Express) {
         companyName: client.companyName,
         contactEmail: client.contactEmail,
         status: client.status || "active",
-        type: client.type || "client", // "msp" for Digerati, "client" for customers
+        type: client.type || "client", // "msp" for Digerati Experts, "client" for customers
         userCount: Array.from(portalUsers.values()).filter(u => u.clientId === client.id).length,
         createdAt: client.createdAt,
       }));

--- a/server/services/msp-advisor/advisor.ts
+++ b/server/services/msp-advisor/advisor.ts
@@ -151,7 +151,7 @@ export async function handleAdvisorChat(req: AdvisorChatRequest): Promise<Adviso
     } catch (err: any) {
       console.warn("[msp-advisor] agent-live persist failed:", err?.message || err);
     }
-    const agentLabel = agentStatus.agentName || "a Digerati specialist";
+    const agentLabel = agentStatus.agentName || "a DE specialist";
     const reply = `${agentLabel} is with you now — your message was delivered. They’ll reply in this chat shortly.`;
     // Persist the ack so portal sees it; visitor already shows it from this response.
     let messageId: string | undefined;

--- a/shared/brandName.test.ts
+++ b/shared/brandName.test.ts
@@ -1,0 +1,57 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { describe, expect, it } from "vitest";
+import { COMPANY } from "./companyContact";
+
+const ROOT = join(import.meta.dirname, "..");
+const SCAN_DIRS = ["client/src", "server", "shared"];
+const SCAN_FILES = ["client/index.html"];
+
+/**
+ * Whole-word “Digerati” that is not immediately followed by “ Experts”.
+ * CamelCase identifiers (DigeratiHomepage) and DigeratiExperts do not match.
+ */
+const STANDALONE = /\bDigerati\b(?! Experts)/g;
+
+function walk(dir: string, acc: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      if (name === "node_modules" || name === "dist") continue;
+      walk(full, acc);
+    } else if (/\.(ts|tsx|js|mjs|html)$/.test(name)) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+describe("brand name", () => {
+  it("exposes Digerati Experts and DE as the only spoken forms", () => {
+    expect(COMPANY.legalName).toBe("Digerati Experts");
+    expect(COMPANY.shortName).toBe("DE");
+  });
+
+  it("does not use standalone Digerati in app source", () => {
+    const hits: string[] = [];
+    const files = [
+      ...SCAN_DIRS.flatMap((dir) => walk(join(ROOT, dir))),
+      ...SCAN_FILES.map((rel) => join(ROOT, rel)),
+    ];
+    for (const file of files) {
+      const rel = relative(ROOT, file).replace(/\\/g, "/");
+      if (rel === "shared/brandName.test.ts") continue;
+      if (/\.test\.(ts|tsx|js)$/.test(rel)) continue;
+      const text = readFileSync(file, "utf8");
+      const lines = text.split("\n");
+      lines.forEach((line, index) => {
+        if (STANDALONE.test(line)) {
+          hits.push(`${rel}:${index + 1}:${line.trim()}`);
+        }
+        STANDALONE.lastIndex = 0;
+      });
+    }
+    expect(hits).toEqual([]);
+  });
+});

--- a/shared/companyContact.ts
+++ b/shared/companyContact.ts
@@ -26,6 +26,8 @@ export interface CompanyPhone {
 
 export const COMPANY = {
   legalName: "Digerati Experts",
+  /** Spoken / UI short form. Always “Digerati Experts” or “DE”. */
+  shortName: "DE",
   email: "info@digeratiexperts.com",
   supportEmail: "support@digeratiexperts.com",
   privacyEmail: "privacy@digeratiexperts.com",

--- a/shared/portalTicketOrg.test.ts
+++ b/shared/portalTicketOrg.test.ts
@@ -16,7 +16,7 @@ describe("ticketCompanyName", () => {
 });
 
 describe("isInternalPortalOrg", () => {
-  it("treats the Digerati MSP org as internal", () => {
+  it("treats the Digerati Experts MSP org as internal", () => {
     expect(isInternalPortalOrg({ id: "msp-digerati", companyName: "Digerati Experts" })).toBe(true);
     expect(isInternalPortalOrg({ id: "client-1", type: "msp" })).toBe(true);
     expect(isInternalPortalOrg({ id: "x", companyName: "Digerati Experts (Internal)" })).toBe(true);

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -48,7 +48,7 @@ export const approvalStepStatusEnum = pgEnum("portal_approval_step_status", [
 // - prospect: Registered but unverified users
 // - managed: Managed service clients (can't purchase managed services, schedule only)
 // - comanaged: Co-Managed clients (can purchase co-managed products)
-// - admin: Digerati admin (full access)
+// - admin: Digerati Experts admin (full access)
 export const storeRoleEnum = pgEnum("store_role", ["public", "prospect", "managed", "comanaged", "admin"]);
 
 export const ticketStatusEnum = pgEnum("ticket_status", ["open", "in_progress", "pending_client", "resolved", "closed"]);
@@ -926,7 +926,7 @@ export const externalIntegrationMappings = pgTable("external_integration_mapping
 export const desktopAgents = pgTable("desktop_agents", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
   clientId: varchar("client_id").notNull().references(() => portalClients.id, { onDelete: "cascade" }),
-  agentName: text("agent_name").notNull(), // "Digerati", "JumpCloud", "Coro", "BlackPoint"
+  agentName: text("agent_name").notNull(), // "Digerati Experts", "JumpCloud", "Coro", "BlackPoint"
   agentType: text("agent_type").notNull(), // "jumpcloud", "coro", "blackpoint", "other"
   downloadUrl: text("download_url"),
   version: text("version"),

--- a/shared/threatFeed.ts
+++ b/shared/threatFeed.ts
@@ -1,5 +1,5 @@
 /**
- * Digerati Threat Relevance Engine — shared types and scoring.
+ * Digerati Experts Threat Relevance Engine — shared types and scoring.
  *
  * Homepage cards are a scored subset of authoritative feeds (CISA KEV,
  * CISA advisories, FIRST EPSS, NIST NVD, Microsoft MSRC). Do not invent
@@ -13,7 +13,7 @@ export const THREAT_CATEGORIES = [
   "Malware Activity",
   "Ransomware",
   "Microsoft Security",
-  "Digerati Advisory",
+  "DE Advisory",
 ] as const;
 
 export type ThreatCategory = (typeof THREAT_CATEGORIES)[number];
@@ -28,7 +28,7 @@ export const HOMEPAGE_THREAT_LIMIT = 4;
 export const ARCHIVE_THREAT_LIMIT = 40;
 
 export const THREAT_ATTRIBUTION =
-  "Sources: CISA, NIST NVD, FIRST, and Microsoft MSRC. Digerati prioritizes items based on active exploitation, exploit probability, and relevance to SMB environments.";
+  "Sources: CISA, NIST NVD, FIRST, and Microsoft MSRC. Digerati Experts prioritizes items based on active exploitation, exploit probability, and relevance to SMB environments.";
 
 export interface ThreatItem {
   id: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Public and in-app copy no longer refers to the company as **Digerati** by itself. User-facing strings now use **Digerati Experts** or **DE**.

The store questionnaire cards that previously said “New to Digerati” and “Existing Digerati client” now say **New to DE** and **Existing DE client**. The journal lockup, nav/footer labels, portal messages, threat-feed attribution, and related headings follow the same rule.

`COMPANY.shortName` is now `DE`. A source scan in `shared/brandName.test.ts` fails if standalone `Digerati` reappears in app source.

## Why

DE does not use “Digerati” as a standalone brand name.

## Files

- Store guidance: `client/src/data/storeMerchandising.ts`
- Journal / nav / footer / homepage / industries / store / portal / server messages
- `shared/companyContact.ts`, `shared/threatFeed.ts`
- Guard: `shared/brandName.test.ts`

## Preserved

- Legal name remains **Digerati Experts**
- Domains, emails, and code identifiers (`DigeratiHomepage`, `digeratiexperts.com`) are unchanged
- No pricing, services, or content sections were removed

## Testing

- `vitest` brand-name and merchandising tests
- Browser verification of `/store` questionnaire at 390 / 768 / 1440 after this PR is opened

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b286a545-0bfc-4e43-a400-f13e828623d4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b286a545-0bfc-4e43-a400-f13e828623d4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

