### PR TITLE
Document canonical Hub vs legacy TechSales freeze

### DIFF
--- a/.cursor/rules/00-follow-cursorrules.mdc
+++ b/.cursor/rules/00-follow-cursorrules.mdc
@@ -12,3 +12,4 @@ The authoritative project policy is the root **`.cursorrules`** file (DIGERATI E
 - For all UI work: inspect existing system ? implement ? launch and visually inspect with browser tooling ? separate UI/UX critique ? fix issues ? only then report completion.
 - Preserve existing DE website content/CTAs/nav/stats unless DE explicitly approves removal.
 - Canonical portal login: `https://portal.digeratiexperts.com/portal/login` — never invent `//login`.
+- Before touching another DE repo, read `docs/REPOSITORY-AUTHORITY.md`. Hub = `Intelligence-Hub`. `TechSales` is legacy read-only.

--- a/.cursor/rules/repository-authority.mdc
+++ b/.cursor/rules/repository-authority.mdc
@@ -1,0 +1,15 @@
+---
+description: Canonical vs legacy DE repositories — read before touching Hub or TechSales
+alwaysApply: true
+---
+
+# Repository authority
+
+Read `docs/REPOSITORY-AUTHORITY.md` before touching another Digerati Experts repository.
+
+- **Hub / TechSales work:** `digeratiexperts/Intelligence-Hub` only (`master`, `https://techsales.digerati-experts.com`, `/opt/intelligence-hub`).
+- **Website / Store / Client Portal:** `digeratiexperts/digeratiexperts-site` only.
+- **`digeratiexperts/TechSales`:** LEGACY — READ ONLY. Do not edit, merge, cherry-pick, deploy, or auto-sync. Inspect and report if a historical comparison is required.
+- **`digeratiexperts/intelligencehub-`:** empty. Do not use.
+- Committed ≠ merged ≠ deployed ≠ production-verified. Website PRs #57 and #59 are not live until they are on `main` and deployed.
+- Portal login is `https://portal.digeratiexperts.com/portal/login`. Never invent `//login`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # Agent workflow (Digerati Experts)
 
+Read **`docs/REPOSITORY-AUTHORITY.md`** before touching another Digerati Experts repository. Hub work is `digeratiexperts/Intelligence-Hub` only. `digeratiexperts/TechSales` is legacy and read-only.
+
 Authoritative policy: **`.cursorrules`** (sections 1?42). Always-applied pointer: `.cursor/rules/00-follow-cursorrules.mdc`.
 
 Design OS (execution layer, does not replace `.cursorrules`): `.cursor/rules/ui-ux.mdc`, `brand.mdc`, `frontend.mdc` + `design/DESIGN_SYSTEM.md`. Never judge UI from source code alone. Blog/Journal and Store colors are locked: `.cursor/rules/blog-store-color-lock.mdc`.
@@ -27,6 +29,7 @@ Design OS (execution layer, does not replace `.cursorrules`): `.cursor/rules/ui-
 
 - Site: `https://digeratiexperts.com`
 - Portal login: `https://portal.digeratiexperts.com/portal/login` (never `//login`)
+- Hub / TechSales: `https://techsales.digerati-experts.com` (source is `digeratiexperts/Intelligence-Hub` only)
 
 ## Next steps (out of scope here)
 

--- a/docs/DE-SYSTEM-INTEGRATION.md
+++ b/docs/DE-SYSTEM-INTEGRATION.md
@@ -1,7 +1,7 @@
 # DE system integration
 
-**Systems:** Replit-Site (website + Client Portal, `:3300`) and Intelligence-Hub / TechSales (`techsales.digerati-experts.com`, `:3100`).  
-**Not used:** legacy `digeratiexperts/TechSales`.  
+**Systems:** Replit-Site / `digeratiexperts-site` (website + Client Portal, `:3300`) and Intelligence-Hub / TechSales (`techsales.digerati-experts.com`, `:3100`).  
+**Legacy — freeze, do not delete:** `digeratiexperts/TechSales`. See `docs/REPOSITORY-AUTHORITY.md`.  
 **Do not rotate** live `TECHSALES_SYNC_TOKEN` / `WEBSITE_LEAD_WEBHOOK_SECRET` in this change.
 
 ## Ownership

--- a/docs/LEGACY-TECHSALES-AUDIT.md
+++ b/docs/LEGACY-TECHSALES-AUDIT.md
@@ -1,0 +1,101 @@
+# Legacy TechSales audit ledger
+
+**Purpose:** Prevent both resurrecting obsolete TechSales code and discarding something unique before `digeratiexperts/TechSales` is GitHub-archived (not deleted).
+
+**Rule:** Inspect TechSales read-only. Do not merge, cherry-pick, or deploy it. If something is truly missing, port it on Intelligence-Hub using current Hub architecture.
+
+**Status of this file:** Partial. Endpoint classifications below are from DE’s 2026-08-26 history review plus this agent’s access check. A commit-by-commit cherry / patch-id ledger is **blocked** in this Cloud Agent environment: the GitHub token can see `digeratiexperts-site` / `Replit-Site` only. `Intelligence-Hub` and `TechSales` return “Repository not found.”
+
+Do **not** archive TechSales until the unique-commit table is filled and no row is `PORT REQUIRED` without a Hub follow-up PR.
+
+---
+
+## Verdict key
+
+| Verdict | Meaning |
+|---------|---------|
+| **PRESERVED** | The commit (or its exact tree) exists in Intelligence-Hub. Keep the SHA; do not port again. |
+| **SUPERSEDED** | Later Hub work covers the same capability. Keep the SHA for history; do not merge. |
+| **PORT REQUIRED** | Hub master lacks a capability this commit introduced. Port using current Hub code — do not merge the old branch. |
+| **DO NOT USE** | Obsolete frontend, unused OAuth stub, or deploy-dangerous. Keep the SHA; never deploy. |
+| **AUDIT BLOCKED** | This environment could not clone the remotes to prove equivalence. |
+
+---
+
+## Endpoints that must remain recoverable
+
+| Source | SHA | Verdict | Evidence |
+|--------|-----|---------|----------|
+| TechSales `master` | `cfcc915db3ccaad0e3079813265cc44940749071` | **PRESERVED** | DE confirmed this exact SHA exists in Intelligence-Hub with the same 2026-04-05 commit and files. Hub did not start from a blank tree. |
+| TechSales `cursor/password-reset-auth-47ec` | `6838b17471b34587df3003285b6dad23d34af5f6` | **PRESERVE / AUDIT BLOCKED** | Head updated 2026-07-27, after TechSales `master` froze. Own PR warned not to deploy the old repo wholesale (would replace live SalesOS with an older Vendor Intelligence dashboard). Branch was never VPS-deployed. |
+| Intelligence-Hub password-reset (2026-07-28) | (Hub commit; confirm after clone) | **SUPERSEDED (claimed)** | DE: Hub received hashed reset tokens, 30-minute expiry, lockout, session revocation, URL-fragment handling, operator reset command, and tests the day after the TechSales auth branch. |
+| Intelligence-Hub auth branch vs `master` | — | **SUPERSEDED (claimed)** | DE: that Hub auth branch is **0 commits ahead, 236 behind** `master` — an ancestor, not a fork still carrying unique commits. |
+| Intelligence-Hub `master` (acceptance target) | `5703465e2f6e8385921f9adede7582df5e4f2fc9` | **NOT PRODUCTION-PROVEN HERE** | Acceptance record 2026-08-18: 10 automated passes, 0 failures, 15 blocked checks. Full issue remains open. Confirm `/opt/intelligence-hub/current/RELEASE_SHA` on the VPS. |
+| `digeratiexperts/intelligencehub-` | (no commits) | **DO NOT USE** | Empty (0 bytes). Archive candidate. |
+
+---
+
+## Unique commits on `cursor/password-reset-auth-47ec`
+
+Fill this table after a read-only clone. Commands (do not push to TechSales):
+
+```bash
+# Read-only
+git clone --no-checkout git@github.com:digeratiexperts/TechSales.git /tmp/techsales-ro
+git -C /tmp/techsales-ro fetch origin cursor/password-reset-auth-47ec
+git clone git@github.com:digeratiexperts/Intelligence-Hub.git /tmp/intelligence-hub
+
+LEGACY_MASTER=cfcc915db3ccaad0e3079813265cc44940749071
+AUTH=6838b17471b34587df3003285b6dad23d34af5f6
+
+# Unique commits on the July auth line after frozen master
+git -C /tmp/techsales-ro log --oneline --reverse ${LEGACY_MASTER}..${AUTH}
+
+# Patch equivalence vs Hub master (no merge)
+git -C /tmp/intelligence-hub fetch /tmp/techsales-ro ${AUTH}:refs/legacy/techsales-auth
+git -C /tmp/intelligence-hub cherry master refs/legacy/techsales-auth
+git -C /tmp/intelligence-hub log --format='%H %s' ${LEGACY_MASTER}..${AUTH} | while read sha subject; do
+  echo "---- $sha $subject"
+  git -C /tmp/intelligence-hub log --all --grep="$(printf '%s' "$subject" | head -c 60)" --oneline | head
+done
+```
+
+Preserve the endpoints inside Intelligence-Hub **without merging**:
+
+```bash
+git -C /tmp/intelligence-hub tag -a legacy/techsales-master-cfcc915 $LEGACY_MASTER -m "Frozen TechSales master 2026-04-05"
+git -C /tmp/intelligence-hub fetch /tmp/techsales-ro $AUTH
+git -C /tmp/intelligence-hub tag -a legacy/techsales-auth-6838b17 $AUTH -m "TechSales cursor/password-reset-auth-47ec 2026-07-27 — do not merge or deploy"
+```
+
+| SHA | Subject | Verdict | Notes |
+|-----|---------|---------|-------|
+| *unpopulated* | — | **AUDIT BLOCKED** | Token in this environment cannot list TechSales commits. |
+
+---
+
+## Capabilities already named (semantic, not patch-id)
+
+These are feature names from the July auth PR and the July 28 Hub work. Names alone are **not** a port order.
+
+| Capability | TechSales July branch | Intelligence-Hub (claimed) | Next action |
+|------------|----------------------|----------------------------|-------------|
+| Secure admin auth | Present | Present on `master` (ancestor of current) | Confirm with patch-id; expected **SUPERSEDED** |
+| Operator password-reset utilities | Present | Operator reset command + tests (2026-07-28) | Confirm; expected **SUPERSEDED** |
+| User operations / session handling | Present | Session revocation on Hub | Confirm; expected **SUPERSEDED** |
+| Hashed reset tokens, 30-min expiry, lockout | Not asserted as identical | Present 2026-07-28 | Hub version is the one to keep |
+| Production bundles / Vendor Intelligence dashboard | Present | **DO NOT USE** | Old frontend. Deploying TechSales would replace live SalesOS. |
+| Live OAuth / production SalesOS `/assistant` | Explicitly **absent** on TechSales | Lives on Intelligence-Hub | **DO NOT USE** TechSales for this |
+
+---
+
+## Archive gate
+
+Archive `digeratiexperts/TechSales` on GitHub (settings → Archive) only when all of the following are true:
+
+1. Both endpoint SHAs are tagged or otherwise reachable from Intelligence-Hub without a merge.
+2. Every unique commit in `${LEGACY_MASTER}..${AUTH}` has a verdict other than **AUDIT BLOCKED**.
+3. Every **PORT REQUIRED** row has a Hub PR that ports the capability on current architecture.
+4. `digeratiexperts/intelligencehub-` may be archived independently (empty).
+
+Do not delete either repository.

--- a/docs/REPOSITORY-AUTHORITY.md
+++ b/docs/REPOSITORY-AUTHORITY.md
@@ -1,0 +1,77 @@
+# Repository authority
+
+Read this file before touching any other Digerati Experts repository.
+
+Committed ≠ merged ≠ deployed ≠ production-verified.
+
+---
+
+## CANONICAL TECHSALES / INTERNAL HUB
+
+**Repository:** `digeratiexperts/Intelligence-Hub`  
+**Default production branch:** `master`  
+**Production root:** `/opt/intelligence-hub`  
+**Production service:** `intelligence-hub.service`  
+**Production URL:** `https://techsales.digerati-experts.com`  
+**Production port:** `3100`  
+**Deploy:** VPS-local release script (GitHub Actions verifies the production build only — it does not deploy)
+
+Agents **may** implement TechSales / Internal Hub work here, on a feature branch, after reading this file.
+
+The last production-acceptance target DE recorded was `master` SHA `5703465e2f6e8385921f9adede7582df5e4f2fc9` (2026-08-18). That does **not** prove the VPS is on that SHA. Confirm with `/opt/intelligence-hub/current/RELEASE_SHA` before claiming production is current.
+
+---
+
+## CANONICAL WEBSITE / STORE / CLIENT PORTAL
+
+**Repository:** `digeratiexperts/digeratiexperts-site`  
+**Historical remote name:** `digeratiexperts/Replit-Site` (same product; do not treat as a third site)  
+**Default branch:** `main`  
+**Production app:** same Node process on `:3300`  
+**Website:** `https://digeratiexperts.com`  
+**Portal:** `https://portal.digeratiexperts.com/portal/login` (never invent `//login`)
+
+Agents **may** implement public Website, Store, and Client Portal work here.
+
+Open website PRs are **not** live until they are on `main` **and** deployed. As of 2026-08-26, #57 (brand naming) and #59 (campaign landers) are still open drafts.
+
+---
+
+## LEGACY — DO NOT MODIFY OR DEPLOY
+
+**Repository:** `digeratiexperts/TechSales`
+
+- Classification: **LEGACY — FREEZE**
+- Agents: **READ ONLY**
+- Do not edit, merge from, cherry-pick from, deploy from, or synchronize automatically
+- Do not delete the GitHub repository
+- Archive on GitHub only after `docs/LEGACY-TECHSALES-AUDIT.md` is a complete commit ledger (PRESERVED / SUPERSEDED / PORT REQUIRED / DO NOT USE)
+
+Preserved endpoints (do not drop these SHAs):
+
+| Ref | SHA | Role |
+|-----|-----|------|
+| TechSales `master` (stopped 2026-04-05) | `cfcc915db3ccaad0e3079813265cc44940749071` | Carried into Intelligence-Hub (same April 5 commit). **PRESERVED.** |
+| TechSales `cursor/password-reset-auth-47ec` | `6838b17471b34587df3003285b6dad23d34af5f6` | July 27 auth/password-reset work. Never VPS-deployed. **PRESERVE until semantic audit completes.** |
+
+---
+
+## EMPTY / HISTORICAL — DO NOT USE
+
+**Repository:** `digeratiexperts/intelligencehub-`
+
+Created/pushed 2026-07-14. Size 0. No commits. Archive candidate. Do not develop here.
+
+---
+
+## Agent rules
+
+Use `digeratiexperts/Intelligence-Hub` exclusively for TechSales / Internal Hub work. `digeratiexperts/TechSales` is legacy and READ-ONLY. Do not edit, merge from, cherry-pick from, deploy from, or synchronize it automatically. If a historical comparison is needed, inspect it read-only and report findings. Use `digeratiexperts/digeratiexperts-site` only for the public Website, Store, and Client Portal portions of the implementation.
+
+If a Hub capability is missing, port it using **current Intelligence-Hub architecture**. Do not revive the Vendor Intelligence dashboard or any old SalesOS frontend from TechSales.
+
+---
+
+## Twin copy
+
+The same policy belongs in `digeratiexperts/Intelligence-Hub` at `docs/REPOSITORY-AUTHORITY.md`. This website copy exists so agents already inside `digeratiexperts-site` cannot miss it. If the two files ever diverge, treat the Hub file as authoritative for Hub deploy facts and this file as authoritative for website/portal facts; reconcile immediately.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Adds `docs/REPOSITORY-AUTHORITY.md` so agents read the repo map before touching another Digerati Experts repository.

- **Canonical Hub:** `digeratiexperts/Intelligence-Hub` (`master`, `/opt/intelligence-hub`, `https://techsales.digerati-experts.com`)
- **Canonical website / store / portal:** this repo (`main`)
- **Legacy freeze:** `digeratiexperts/TechSales` — read-only, do not delete
- **Empty:** `digeratiexperts/intelligencehub-` — do not use

Preserved endpoints (do not drop):

- TechSales `master` `cfcc915db3ccaad0e3079813265cc44940749071` — already in Intelligence-Hub (**PRESERVED**)
- TechSales `cursor/password-reset-auth-47ec` `6838b17471b34587df3003285b6dad23d34af5f6` — keep until semantic/patch audit completes

`docs/LEGACY-TECHSALES-AUDIT.md` is the ledger. Unique-commit rows are **AUDIT BLOCKED** in this Cloud Agent because the GitHub token cannot see Intelligence-Hub or TechSales. Do not archive TechSales until that table is filled.

Website PRs #57 and #59 remain unmerged; they are not live.

## Why

DE confirmed Intelligence-Hub is the active Hub and that TechSales `master` was carried forward. Archive only after a commit ledger. Do not merge or deploy the old repo.

## Tests

Documentation and agent-rule pointers only. No runtime change.

## Human input still required

- Grant this agent write access to `digeratiexperts/Intelligence-Hub` and read-only access to `digeratiexperts/TechSales` so the Hub twin of `REPOSITORY-AUTHORITY.md`, legacy tags, and cherry/patch ledger can be completed there
- Confirm VPS `/opt/intelligence-hub/current/RELEASE_SHA` against `5703465e2f6e8385921f9adede7582df5e4f2fc9`
- Do not archive TechSales until the ledger has no **AUDIT BLOCKED** or unanswered **PORT REQUIRED** rows
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b286a545-0bfc-4e43-a400-f13e828623d4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b286a545-0bfc-4e43-a400-f13e828623d4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

