### PR TITLE
Store: restore DE branding in buyer selector

### DIFF
--- a/client/src/data/storeMerchandising.guided.test.ts
+++ b/client/src/data/storeMerchandising.guided.test.ts
@@ -4,6 +4,7 @@ import { validatePortalOrderSelection } from "@shared/portalOrderCatalog";
 import { storeProducts } from "./storeProducts";
 import {
   DEFAULT_GUIDED_ANSWERS,
+  GUIDED_BUYER_OPTIONS,
   buildGuidedRecommendation,
   filterProductsForGuidance,
   recommendProactiveSku,
@@ -20,6 +21,14 @@ const prospectProtect: GuidedBuyingAnswers = {
 };
 
 describe("consultative store guidance", () => {
+  it("names buyer types as DE or Digerati Experts", () => {
+    expect(GUIDED_BUYER_OPTIONS.map((option) => option.label)).toEqual([
+      "New to DE",
+      "Existing DE client",
+      "In-house IT",
+    ]);
+  });
+
   it("does not dump the unfiltered catalog as the default recommendation", () => {
     const rec = buildGuidedRecommendation(prospectProtect);
     const filtered = filterProductsForGuidance(storeProducts, rec, { fullCatalog: false });

--- a/client/src/data/storeMerchandising.ts
+++ b/client/src/data/storeMerchandising.ts
@@ -1287,12 +1287,12 @@ export const GUIDED_BUYER_OPTIONS: {
 }[] = [
   {
     value: "prospect",
-    label: "New to Digerati",
+    label: "New to DE",
     blurb: "Looking for managed IT or a first security read — Solutions, not a hardware wall.",
   },
   {
     value: "existing_client",
-    label: "Existing Digerati client",
+    label: "Existing DE client",
     blurb: "Add tools from the Client Marketplace without replacing your current stack.",
   },
   {
@@ -1515,7 +1515,7 @@ export function buildGuidedRecommendation(answers: GuidedBuyingAnswers): GuidedR
     family === "solutions"
       ? `One ProActive tier (consultative — packages are mutually exclusive), the $2,500 Cybersecurity Risk Assessment when relevant, and a few related add-ons. List rates × ~${seats} seats where unit-priced; checkout uses canonical SKUs and prices.`
       : `Client Marketplace picks for ${
-          answers.buyerType === "in_house_it" ? "an in-house IT team" : "an existing Digerati client"
+          answers.buyerType === "in_house_it" ? "an in-house IT team" : "an existing DE client"
         }. We are not stacking a second ProActive package. Estimates are list rates; checkout still confirms server prices.`;
 
   return {


### PR DESCRIPTION
Restores the branding change that existed in PR #57 but never made it into current main.

Changes:
- `New to Digerati` → `New to DE`
- `Existing Digerati client` → `Existing DE client`
- matching recommendation copy → `existing DE client`
- restores the guided-store regression test so these buyer labels cannot silently revert again

Scope is exactly two files and is based on current `main` (71130fa).