### PR TITLE
chore: replace stale repo authority and naming tasks

### DIFF
--- a/.cursor/rules/digerati-naming.mdc
+++ b/.cursor/rules/digerati-naming.mdc
@@ -1,0 +1,39 @@
+---
+description: Canonical Digerati Experts company naming convention
+globs: ["**/*"]
+alwaysApply: true
+---
+# DIGERATI EXPERTS NAMING
+
+Use the company name consistently in customer-facing and operational copy.
+
+## Canonical names
+
+- **Full company name:** `Digerati Experts`
+- **Approved short form:** `DE`
+
+## Do not use
+
+Do not use `Digerati` by itself as the company label in user-facing copy, navigation, dialogs, help text, transactional copy, generated documents, or agent-written marketing content.
+
+Prefer:
+
+- `Digerati Experts` when the full brand name is useful for clarity, first mention, SEO, legal/business context, or external-facing headings.
+- `DE` when a short label is appropriate after context is established or space is constrained.
+
+Examples:
+
+- `Digerati agent` -> `DE agent`
+- `New to Digerati` -> `New to Digerati Experts`
+- `Contact Digerati` -> `Contact DE` or `Contact Digerati Experts`
+
+## Exceptions
+
+Do not rewrite:
+
+- repository/package/code identifiers solely because they contain `digerati`
+- domains, email addresses, API identifiers, database values, environment keys, or external vendor/product names
+- historical quotations or source material where changing the text would be inaccurate
+- the already-correct full string `Digerati Experts`
+
+When unsure whether a string is a company label or an identifier, preserve the identifier and fix only the visible customer-facing label.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,18 +1,34 @@
 # Agent workflow (Digerati Experts)
 
-Authoritative policy: **`.cursorrules`** (sections 1?42). Always-applied pointer: `.cursor/rules/00-follow-cursorrules.mdc`.
+Authoritative policy: **`.cursorrules`**. Always-applied pointer: `.cursor/rules/00-follow-cursorrules.mdc`.
 
 Design OS (execution layer, does not replace `.cursorrules`): `.cursor/rules/ui-ux.mdc`, `brand.mdc`, `frontend.mdc` + `design/DESIGN_SYSTEM.md`. Never judge UI from source code alone. Blog/Journal and Store colors are locked: `.cursor/rules/blog-store-color-lock.mdc`.
 
+## Repository authority â€” check this before starting work
+
+- This repository, `digeratiexperts/digeratiexperts-site`, is the **canonical public website repository**.
+- Website work branches from and opens PRs back to this repository's current `main`.
+- `Replit-Site` references are historical and must not redirect new website work.
+- `digeratiexperts/Intelligence-Hub` is the canonical internal Intelligence Hub / Tech Sales application repository.
+- `digeratiexperts/TechSales` is legacy/reference-only by default; do not start new work there or archive/delete it without an explicit migration decision.
+- Full authority matrix: `docs/REPOSITORY-AUTHORITY.md`.
+- Website source-of-truth details: `docs/SOURCE-OF-TRUTH.md`.
+
+If an old Cursor task, chat, PR description, screenshot, or migration note conflicts with current GitHub state and the authority files above, treat the old instruction as stale and re-check before acting.
+
+## Company naming
+
+Customer-facing company naming is **Digerati Experts** or **DE**, never standalone **Digerati** as the company label. See `.cursor/rules/digerati-naming.mdc`.
+
 ## Closed loop (UI work)
 
-0. **Visual audit first** ? read `.cursor/skills/visual-audit/SKILL.md` (and premium-saas-ui / responsive-review / image-art-direction as needed) before changing UI.
-1. **Inspect** ? existing components, tokens, routes, content (preserve ? elevate ? consolidate).
-2. **Implement** ? reuse before inventing; no content destruction without DE approval.
-3. **Browser verify** ? Playwright/browser tooling; desktop + tablet + mobile as required (390 / 768 / 1440 minimum).
-4. **Critique** ? separate UI/UX pass against `.cursorrules` + `design/approved|rejected`.
-5. **Repair** ? fix issues found; re-verify.
-6. **Report done** ? only after verification + critique + fixes (completion report per §40?41).
+0. **Visual audit first** -> read `.cursor/skills/visual-audit/SKILL.md` (and premium-saas-ui / responsive-review / image-art-direction as needed) before changing UI.
+1. **Inspect** -> existing components, tokens, routes, content (preserve -> elevate -> consolidate).
+2. **Implement** -> reuse before inventing; no content destruction without DE approval.
+3. **Browser verify** -> Playwright/browser tooling; desktop + tablet + mobile as required (390 / 768 / 1440 minimum).
+4. **Critique** -> separate UI/UX pass against `.cursorrules` + `design/approved|rejected`.
+5. **Repair** -> fix issues found; re-verify.
+6. **Report done** -> only after verification + critique + fixes.
 
 ## Role separation (same agent, distinct passes)
 

--- a/docs/REPOSITORY-AUTHORITY.md
+++ b/docs/REPOSITORY-AUTHORITY.md
@@ -1,0 +1,35 @@
+# Digerati Experts repository authority
+
+This file defines which repository owns which active product. It exists to prevent stale agent tasks, old migration notes, and historical repository names from redirecting new work.
+
+## Current authority matrix
+
+| Product / role | Canonical repository | Default branch | Status | New work? |
+| --- | --- | --- | --- | --- |
+| Public website / Store / public portal entry surfaces | `digeratiexperts/digeratiexperts-site` | `main` | **Active / canonical** | Yes |
+| Intelligence Hub / internal Tech Sales application | `digeratiexperts/Intelligence-Hub` | `master` | **Active / canonical** | Yes |
+| Legacy TechSales codebase | `digeratiexperts/TechSales` | legacy repository state | **Legacy / reference pending migration verification** | No, unless explicitly directed |
+| `Replit-Site` name/repository references | historical migration-era website source | n/a | **Obsolete authority** | No |
+
+## Rules for agents and humans
+
+1. **Inspect current repository state before acting.** Old Cursor tasks, chats, PR descriptions, screenshots, branch names, or migration notes are not stronger authority than this matrix plus current GitHub state.
+2. **Website work belongs here.** New website branches and PRs must originate from `digeratiexperts/digeratiexperts-site` and target `main` unless an explicit release procedure says otherwise.
+3. **Intelligence Hub work belongs in `Intelligence-Hub`.** Do not create Hub work in the website repository or in the legacy `TechSales` repository.
+4. **Do not revive `Replit-Site` as canonical.** Treat any instruction saying "canonical website: Replit-Site" as stale unless this authority file is deliberately changed in a reviewed PR.
+5. **TechSales is reference-only by default.** It may be inspected to verify historical behavior or migration gaps. Do not add new features there by default.
+6. **Do not archive or delete legacy repositories automatically.** Retirement requires a completed migration ledger and an explicit decision.
+7. **One task = one owner = one branch.** Before editing shared files, check current `main`/`master` and open work to avoid overwriting another agent.
+8. **No blind cherry-picks across products.** Historical commits must be compared to the current architecture and ported intentionally when still needed.
+
+## Known stale work superseded by this policy
+
+The old Cursor/Cloud Agent task that said its environment only had `Replit-Site`, could not see `Intelligence-Hub`, and therefore needed repository access changes is obsolete. Current repository access must be checked directly rather than preserving that blocked-state assumption.
+
+The old website PRs created from that blocked state should not be merged merely to preserve the old instructions. Replacement work should be based on current canonical repositories.
+
+## Related policy
+
+- Website source of truth: [`docs/SOURCE-OF-TRUTH.md`](./SOURCE-OF-TRUTH.md)
+- Site/agent workflow: [`AGENTS.md`](../AGENTS.md)
+- Brand naming rule: [`.cursor/rules/digerati-naming.mdc`](../.cursor/rules/digerati-naming.mdc)

--- a/docs/SOURCE-OF-TRUTH.md
+++ b/docs/SOURCE-OF-TRUTH.md
@@ -1,33 +1,38 @@
-# Source of truth (stop Replit from overwriting Cursor work)
+# Website source of truth
 
-**Canonical repo:** GitHub `digeratiexperts/Replit-Site`  
-**Canonical authoring:** Cursor / local clone → git push → VPS deploy  
-**Not canonical:** Replit Agent auto-commits or Replit GitHub sync pushing over our branches
+This repository is the canonical source for the Digerati Experts public website.
 
-## Prevent Replit from syncing over us
+- **Canonical repository:** `github.com/digeratiexperts/digeratiexperts-site`
+- **Default / production integration branch:** `main`
+- **Public website:** `https://digeratiexperts.com`
+- **Production deployment:** CyberPanel + systemd `digeratiexperts-site` on the DE VPS. See `deploy/vps/README.md` for the current deploy procedure.
 
-Do these in the Replit UI for **digerati Experts Offical Website**:
+## Repository authority
 
-1. **Pause or disconnect GitHub sync** (Settings → Git / Version control) so Replit cannot push to `main` or `fix/*` from the Repl.
-2. **Do not click “Publish / Deploy from Replit”** for production — production is CyberPanel + systemd `digeratiexperts-site` as `diger7051` on de-vps (`/home/digeratiexperts.com/current` → :3300). See `deploy/vps/README.md`.
-3. If the Repl must stay open for reference, treat it as **read-only**. Pull from GitHub into Replit only when you explicitly want a preview; never let Replit be the push source.
-4. Prefer working on GitHub branches (`fix/homepage-hero-nav-2026-08-08`, `preserve/*`) and merge via PR.
+The authoritative repository matrix is maintained in [`docs/REPOSITORY-AUTHORITY.md`](./REPOSITORY-AUTHORITY.md).
 
-## Preserve branches (do not delete)
+For website work:
 
-| Branch | Why |
-|--------|-----|
-| `preserve/live-pink-sticky-nav` | Pink sticky section bar chrome |
-| `preserve/internal-pages-pre-redact` | Internal sales pages removed in Aug 2026 cleanup (renamed from replit-prefixed branch) |
+1. Branch from the current `digeratiexperts/digeratiexperts-site` `main`.
+2. Push the branch to this repository.
+3. Open the pull request against this repository's `main`.
+4. Reconcile against current `main` before merge because multiple agents may be working concurrently.
+5. Do not redirect new website work to a historical repository name because an old Cursor/Cloud Agent task says to do so.
 
-## Recovered from Replit (do not full-sync)
+## `Replit-Site` is historical, not authoritative
 
-**Digerati Journal + read-aloud** was restored from the live Replit preview into git (not via full Repl sync):
+`digeratiexperts/Replit-Site` and references to it as the "canonical website repo" are historical migration-era instructions. They must **not** be used as the target for new branches, pull requests, agent environments, deployment decisions, or source-of-truth checks.
 
-- `client/src/pages/resources/Blog.tsx` / `BlogPost.tsx`
-- `client/src/components/BlogAudioPlayer.tsx` (OpenAI `/api/tts` + browser `speechSynthesis` failover, word highlight, play/pause/stop/speed/voice)
-- `client/src/data/resourceRegistry.ts` + `resourceRegistry.v2.json` (16 articles)
-- `client/public/assets/covers/blog/*`
-- `server` `POST /api/tts` + `generateSpeech` in `openaiService.ts`
+If an old task, chat, PR, branch, or document conflicts with this file and `REPOSITORY-AUTHORITY.md`, treat the old instruction as stale and re-check current repository state before taking action.
 
-If something else is still missing from git, recover surgically from Replit Checkpoints — never let Replit push over Cursor/git HEAD.
+Replit may still be useful as historical/reference material where explicitly needed, but it is not an authoring or push authority for the production website.
+
+## Preserve recovered content without restoring stale authority
+
+Historical content recovered from Replit or older branches can remain in this repository when it is still valid. Recover content surgically; do not restore old repository-authority instructions along with it.
+
+Examples of previously recovered website content include Journal/read-aloud assets and resource registry material. Their presence does not make Replit the source of truth.
+
+## Non-destructive rule
+
+Do not archive, delete, force-push, or replace another DE repository merely because it is not canonical for the website. Repository retirement is a separate decision and requires explicit verification/approval.


### PR DESCRIPTION
## Why

Two old Cursor/Cloud Agent tasks are still surfacing stale assumptions:

- website work belongs in `Replit-Site`
- the agent cannot access `Intelligence-Hub`
- repository migration state should be preserved from that blocked environment

Those assumptions no longer match current GitHub state and are causing agents to work from obsolete authority.

## What this PR changes

- makes `digeratiexperts/digeratiexperts-site` the explicit canonical public website repository
- marks `Replit-Site` authority as historical/obsolete for new website work
- adds `docs/REPOSITORY-AUTHORITY.md` with the current DE repository matrix
- updates `AGENTS.md` so future agents check current repository authority before following old tasks/screenshots/PR descriptions
- ports the still-valid naming rule onto current `main`:
  - full name: **Digerati Experts**
  - approved short form: **DE**
  - never standalone **Digerati** as the customer-facing company label
- preserves `TechSales` non-destructively as legacy/reference-only pending verified migration decisions

## Supersedes

- #57 — old naming-convention branch; valid policy is ported here onto current main
- #72 — old repository-authority migration PR created from the blocked Replit-only environment

A companion PR in `digeratiexperts/Intelligence-Hub` records the current Hub authority and the disposition of the old TechSales password/auth branch.

## Safety

- no repository is archived or deleted
- no force-pushes
- no blind cherry-picks from legacy TechSales
- current application code is unchanged; this is authority/governance plus the Cursor naming rule