### PR TITLE
Restore the expanding homepage bottom dock

### DIFF
--- a/client/src/components/HomepageSectionNav.tsx
+++ b/client/src/components/HomepageSectionNav.tsx
@@ -1,8 +1,22 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
+import { ArrowRight, Phone, Shield } from "lucide-react";
 import { useOptionalFullPageScroll } from "@/components/FullPageScroll";
+import { useBooking } from "@/contexts/BookingContext";
+import { PRIMARY_PHONE } from "@/data/companyContact";
+import { CTA } from "@/lib/ctaCopy";
 
 /** Homepage chapters in the thin top table of contents. */
 const TOP_CHAPTERS = new Set([
+  "hero",
+  "stats",
+  "services",
+  "pricing",
+  "industries",
+  "contact",
+]);
+
+/** Concise dock chapters — same system as the top TOC. */
+const DOCK_CHAPTERS = new Set([
   "hero",
   "stats",
   "services",
@@ -32,11 +46,6 @@ function nearestNavIndex(
  * Slim homepage table of contents under the global MegaMenu.
  * Desktop secondary row only — never inside the compact logo bar below lg.
  * Mobile/tablet jumps live in the MegaMenu drawer.
- *
- * This is the only homepage section-jump surface. A second, floating
- * version used to also live in the bottom chrome (SiteBottomBar); it was
- * removed as a duplicate that caused real overlap bugs — see the comment
- * in SiteBottomBar.tsx.
  */
 export function HomepageOnPageNav() {
   const ctx = useOptionalFullPageScroll();
@@ -112,4 +121,161 @@ export function HomepageOnPageNav() {
       </div>
     </nav>
   );
+}
+
+export function useHomepageDockVisibility() {
+  const ctx = useOptionalFullPageScroll();
+  const [scrolledAway, setScrolledAway] = useState(false);
+  const [nearFooter, setNearFooter] = useState(false);
+  const [isDesktop, setIsDesktop] = useState(false);
+  const [cookieClear, setCookieClear] = useState(() => {
+    try {
+      return !!localStorage.getItem("de_cookie_consent_v2") || !!localStorage.getItem("de_cookie_consent");
+    } catch {
+      return true;
+    }
+  });
+
+  const sections = ctx?.sections ?? [];
+  const items = sections
+    .map((section, index) => ({ section, index }))
+    .filter(({ section }) => DOCK_CHAPTERS.has(section.id));
+
+  useEffect(() => {
+    const onConsent = () => setCookieClear(true);
+    window.addEventListener("de-cookie-consent", onConsent);
+    return () => window.removeEventListener("de-cookie-consent", onConsent);
+  }, []);
+
+  useEffect(() => {
+    const mq = window.matchMedia("(min-width: 1024px)");
+    const sync = () => setIsDesktop(mq.matches);
+    sync();
+    mq.addEventListener("change", sync);
+    return () => mq.removeEventListener("change", sync);
+  }, []);
+
+  useEffect(() => {
+    const onScroll = () => setScrolledAway(window.scrollY > 72);
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  useEffect(() => {
+    const footer = document.querySelector("footer");
+    if (!footer || typeof IntersectionObserver === "undefined") return;
+    const observer = new IntersectionObserver(
+      ([entry]) => setNearFooter(entry.isIntersecting && entry.intersectionRatio > 0.28),
+      { threshold: [0, 0.28, 0.5] }
+    );
+    observer.observe(footer);
+    return () => observer.disconnect();
+  }, []);
+
+  const showMenu =
+    Boolean(ctx) && isDesktop && scrolledAway && !nearFooter && cookieClear && items.length > 0;
+
+  return { showMenu, nearFooter, isDesktop };
+}
+
+/**
+ * Homepage chapters for the unified bottom bar.
+ * Protected? stays a fixed lead-in; chapter links flex across leftover
+ * width so the row fills instead of clustering left of the actions.
+ */
+export function HomepageDockMenu() {
+  const ctx = useOptionalFullPageScroll();
+  const sections = ctx?.sections ?? [];
+  const currentSection = ctx?.currentSection ?? 0;
+  const scrollToSection = ctx?.scrollToSection;
+  const items = sections
+    .map((section, index) => ({ section, index }))
+    .filter(({ section }) => DOCK_CHAPTERS.has(section.id));
+  const topItems = sections
+    .map((section, index) => ({ section, index }))
+    .filter(({ section }) => TOP_CHAPTERS.has(section.id));
+  const conceptualActiveIndex = nearestNavIndex(topItems, currentSection);
+  const conceptualActiveId = sections[conceptualActiveIndex]?.id;
+
+  if (!ctx || items.length === 0) return null;
+
+  return (
+    <nav
+      className="flex w-full min-w-0 items-center gap-2 overflow-hidden"
+      aria-label="On this page"
+      data-testid="homepage-section-dock"
+    >
+      <div className="hidden h-10 shrink-0 items-center gap-2 border-r border-white/20 pr-3 xl:flex">
+        <Shield className="h-4 w-4 text-de-magenta-ink" aria-hidden="true" />
+        <span className="whitespace-nowrap text-base font-semibold text-white">Protected?</span>
+      </div>
+
+      <div className="flex min-w-0 flex-1 items-center overflow-x-auto scrollbar-none">
+        {items.map(({ section, index }) => {
+          const isActive = section.id === conceptualActiveId;
+          return (
+            <div key={section.id} className="flex shrink-0 justify-center">
+              <a
+                href={`#${section.id}`}
+                onClick={(event) => {
+                  event.preventDefault();
+                  scrollToSection?.(index);
+                }}
+                className={`relative inline-flex h-10 shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full px-2.5 text-base font-semibold transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-de-magenta-ink ${
+                  isActive
+                    ? "bg-de-magenta text-white shadow-lg shadow-[#D3126A]/40"
+                    : "text-de-muted-soft hover:bg-white/10 hover:text-white"
+                }`}
+                aria-current={isActive ? "true" : undefined}
+                data-testid={`nav-dock-${section.id}`}
+              >
+                {isActive && (
+                  <span
+                    className="h-1.5 w-1.5 rounded-full bg-white shadow-[0_0_8px_rgba(255,255,255,0.85)]"
+                    aria-hidden="true"
+                  />
+                )}
+                {section.label}
+              </a>
+            </div>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}
+
+/** Phone + Risk Assessment — sits in the bottom-bar action cluster. */
+export function HomepageDockActions() {
+  const { openBooking } = useBooking();
+
+  return (
+    <div className="flex items-center gap-1.5" data-testid="homepage-dock-actions">
+      <a
+        href={PRIMARY_PHONE.telHref}
+        className="flex h-10 shrink-0 items-center gap-1.5 rounded-full px-2.5 text-base font-medium text-white/90 transition-colors hover:bg-white/10 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-de-magenta-ink"
+        data-testid="nav-phone"
+        aria-label={`Call ${PRIMARY_PHONE.display}`}
+      >
+        <Phone className="h-4 w-4 text-de-magenta-ink" aria-hidden="true" />
+        <span className="hidden xl:inline">{PRIMARY_PHONE.display}</span>
+      </a>
+
+      <button
+        type="button"
+        onClick={() => openBooking("homepage_section_dock")}
+        className="flex h-10 shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full bg-de-magenta px-3.5 text-base font-semibold text-white shadow-lg shadow-[#D3126A]/35 transition-colors duration-200 hover:bg-de-magenta-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-de-magenta-ink"
+        data-testid="nav-cta-assessment"
+      >
+        {CTA.primaryNavCompact}
+        <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+      </button>
+    </div>
+  );
+}
+
+/** @deprecated Use SiteBottomBar — kept so existing homepage imports stay safe during the swap. */
+export function HomepageSectionDock() {
+  return null;
 }

--- a/client/src/components/SiteBottomBar.tsx
+++ b/client/src/components/SiteBottomBar.tsx
@@ -1,10 +1,17 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { ArrowUp } from "lucide-react";
 import { useLocation } from "wouter";
+import {
+  HomepageDockActions,
+  HomepageDockMenu,
+  useHomepageDockVisibility,
+} from "@/components/HomepageSectionNav";
 import { openMspAdvisor } from "@/lib/openMspAdvisor";
 
-const FADE_S = 0.4;
+/** Original used 0.28s easeOut layout + 300ms grid. Keep that pacing without transform. */
+const EXPAND_S = 0.4;
+const EXPAND_EASE = "easeOut" as const;
 
 function AskDELauncherButton() {
   return (
@@ -29,26 +36,23 @@ function AskDELauncherButton() {
 }
 
 /**
- * One bottom chrome shell: scroll-to-top and the Ask DE launcher. Desk window
- * stays in ZohoASAPWidget.
+ * One bottom chrome shell: homepage chapter menu (after scroll), scroll-to-top,
+ * and the Ask DE launcher. Desk window stays in ZohoASAPWidget.
  *
- * This used to also expand into a homepage section-jump menu + phone/CTA
- * cluster once scrolled past the hero. Removed: DESIGN_SYSTEM.md and the
- * approved homepage spec both say section jumps belong in the MegaMenu (see
- * HomepageOnPageNav, already mounted there and doing this job in-flow with
- * no overlap risk), and the floating expanded copy was a confirmed-live bug
- * — its own height reservation logic didn't stop it from painting over page
- * content id like the "Why We Exist" paragraph or the assessment card's
- * recommendation list, since a fixed-position capsule has no way to know
- * what text is about to scroll under it. Keeping this shell compact-only
- * removes the duplicate nav and the bug in one move.
+ * Width is tweened as CSS width (not Framer `layout` / scale) so backdrop-filter
+ * on the static glass layer does not smear text while the capsule grows.
  */
 export function SiteBottomBar() {
   const [location] = useLocation();
   const prefersReducedMotion = useReducedMotion();
+  const { showMenu } = useHomepageDockVisibility();
   const [farDown, setFarDown] = useState(false);
   const [deskOpen, setDeskOpen] = useState(false);
   const barRef = useRef<HTMLDivElement>(null);
+  const trackRef = useRef<HTMLDivElement>(null);
+  const actionsRef = useRef<HTMLDivElement>(null);
+  const [trackW, setTrackW] = useState(0);
+  const [compactW, setCompactW] = useState(0);
   const isPortal = location.startsWith("/portal");
 
   const syncFarDown = useCallback(() => {
@@ -81,7 +85,26 @@ export function SiteBottomBar() {
 
   const showScrollTop = farDown;
   const showAskDE = !deskOpen;
-  const showBar = !isPortal && (showAskDE || showScrollTop);
+  const expanded = showMenu;
+  const showBar = !isPortal && (showAskDE || expanded || showScrollTop);
+
+  useLayoutEffect(() => {
+    const track = trackRef.current;
+    const actions = actionsRef.current;
+    if (!track) return;
+    const publish = () => {
+      setTrackW(Math.round(track.getBoundingClientRect().width));
+      if (actions) {
+        // Compact capsule = action cluster + even 6px padding + 2px border each side.
+        setCompactW(Math.round(actions.getBoundingClientRect().width + 16));
+      }
+    };
+    publish();
+    const ro = new ResizeObserver(publish);
+    ro.observe(track);
+    if (actions) ro.observe(actions);
+    return () => ro.disconnect();
+  }, [showAskDE, showScrollTop, location]);
 
   useEffect(() => {
     const root = document.documentElement;
@@ -93,7 +116,9 @@ export function SiteBottomBar() {
     }
 
     const publish = () => {
-      root.style.setProperty("--de-unified-bar-h", `${Math.round(el.offsetHeight)}px`);
+      const height = `${Math.round(el.offsetHeight)}px`;
+      root.style.setProperty("--de-unified-bar-h", height);
+      root.style.setProperty("--de-section-dock-h", expanded ? height : "0px");
     };
     publish();
     const ro = new ResizeObserver(publish);
@@ -103,7 +128,7 @@ export function SiteBottomBar() {
       root.style.setProperty("--de-unified-bar-h", "0px");
       root.style.setProperty("--de-section-dock-h", "0px");
     };
-  }, [showBar]);
+  }, [showBar, expanded, showAskDE, showScrollTop]);
 
   const scrollToTop = () => {
     window.scrollTo({
@@ -114,48 +139,87 @@ export function SiteBottomBar() {
 
   if (!showBar) return null;
 
-  const duration = prefersReducedMotion ? 0 : FADE_S;
+  const duration = prefersReducedMotion ? 0 : EXPAND_S;
 
   return (
     <div
+      ref={trackRef}
       className="de-unified-bar pointer-events-none flex items-end justify-end"
       data-testid="site-bottom-bar"
     >
-      <div
+      <motion.div
         ref={barRef}
-        className="de-unified-bar-shell pointer-events-auto relative flex shrink-0 items-center justify-end gap-1.5 rounded-full border-2 border-[#D3126A]/60 py-1.5 pl-1.5 pr-1.5 shadow-[0_0_24px_rgba(211,18,106,0.35),0_4px_24px_rgba(0,0,0,0.5)]"
+        className={`de-unified-bar-shell pointer-events-auto relative flex items-center rounded-full border-2 border-[#D3126A]/60 py-1.5 shadow-[0_0_24px_rgba(211,18,106,0.35),0_4px_24px_rgba(0,0,0,0.5)] ${
+          expanded
+            ? "w-full min-w-0 justify-between gap-6 pl-3 pr-2.5"
+            : "shrink-0 justify-end gap-0 pl-1.5 pr-1.5"
+        }`}
+        initial={false}
+        layout={false}
+        transformTemplate={() => "none"}
+        animate={{
+          width: expanded ? (trackW > 0 ? trackW : "100%") : compactW > 0 ? compactW : "auto",
+        }}
+        transition={
+          prefersReducedMotion
+            ? { duration: 0 }
+            : { duration: EXPAND_S, ease: EXPAND_EASE }
+        }
       >
         <span className="de-unified-bar-glass" aria-hidden="true" />
 
-        <div className="relative z-[1] flex shrink-0 items-center gap-1.5">
-          {location === "/" && !showScrollTop && (
-            <span
-              className="ml-0.5 hidden h-2 w-2 shrink-0 rounded-full bg-[#D3126A] shadow-[0_0_8px_rgba(211,18,106,0.8)] sm:block"
-              aria-hidden="true"
-            />
-          )}
-          <AnimatePresence initial={false}>
-            {showScrollTop && (
-              <motion.button
-                key="scroll-top"
-                type="button"
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                transition={{ duration }}
-                onClick={scrollToTop}
-                className="flex h-10 w-10 items-center justify-center rounded-full bg-white/[0.06] text-white/85 transition-colors hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-de-magenta-ink"
-                aria-label="Scroll to top"
-                data-testid="button-scroll-to-top"
-              >
-                <ArrowUp className="h-4 w-4 shrink-0" aria-hidden="true" />
-              </motion.button>
-            )}
-          </AnimatePresence>
-
-          {showAskDE && <AskDELauncherButton />}
+        <div
+          className={`relative z-[1] grid min-w-0 ${
+            prefersReducedMotion ? "" : "transition-[grid-template-columns,opacity] duration-[400ms] ease-out"
+          } ${
+            expanded
+              ? "w-full min-w-0 flex-1 grid-cols-[minmax(0,1fr)] opacity-100"
+              : "pointer-events-none w-0 flex-none grid-cols-[0fr] overflow-hidden opacity-0"
+          }`}
+          aria-hidden={!expanded}
+        >
+          <div className="w-full min-w-0 overflow-hidden">
+            <HomepageDockMenu />
+          </div>
         </div>
-      </div>
+
+        <div className="relative z-[1] flex shrink-0 items-center gap-1.5">
+          {expanded && (
+            <>
+              <div className="h-6 w-px shrink-0 bg-white/20" aria-hidden="true" />
+              <HomepageDockActions />
+            </>
+          )}
+          <div ref={actionsRef} className="flex shrink-0 items-center gap-1.5">
+            {!expanded && location === "/" && !showScrollTop && (
+              <span
+                className="ml-0.5 hidden h-2 w-2 shrink-0 rounded-full bg-[#D3126A] shadow-[0_0_8px_rgba(211,18,106,0.8)] sm:block"
+                aria-hidden="true"
+              />
+            )}
+            <AnimatePresence initial={false}>
+              {showScrollTop && (
+                <motion.button
+                  key="scroll-top"
+                  type="button"
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  transition={{ duration }}
+                  onClick={scrollToTop}
+                  className="flex h-10 w-10 items-center justify-center rounded-full bg-white/[0.06] text-white/85 transition-colors hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-de-magenta-ink"
+                  aria-label="Scroll to top"
+                  data-testid="button-scroll-to-top"
+                >
+                  <ArrowUp className="h-4 w-4 shrink-0" aria-hidden="true" />
+                </motion.button>
+              )}
+            </AnimatePresence>
+
+            {showAskDE && <AskDELauncherButton />}
+          </div>
+        </div>
+      </motion.div>
     </div>
   );
 }

--- a/design/DESIGN_SYSTEM.md
+++ b/design/DESIGN_SYSTEM.md
@@ -86,7 +86,7 @@ Do not introduce a new purple, magenta, or near-black. Reuse these.
 
 - Container: centered, padding `1rem`, `2xl` max `1680px`
 - Sticky nav clearance: `--de-nav-offset` (MegaMenu ResizeObserver)
-- Homepage section jumps live in MegaMenu (`HomepageOnPageNav`) — no floating bottom dock
+- Homepage section jumps: MegaMenu `HomepageOnPageNav` at rest, plus the expanding `SiteBottomBar` dock after scroll. Keep both — DE restored the dock 2026-08-27.
 - Dark marketing cards: `rounded-2xl border border-de-hairline bg-de-raised` with Lucide in `IconWell` (quiet well, magenta icon)
 - Section padding pattern: `py-10 md:py-14 lg:py-16` (and nearby variants already in sections)
 - Touch targets: ~44×44px where practical (`min-h-11`)

--- a/design/approved/homepage-visual-rhythm-2026-08.md
+++ b/design/approved/homepage-visual-rhythm-2026-08.md
@@ -11,7 +11,7 @@ with the locked engage-path sculpture set.
 - Engage path cards and small cards (Tackle, capabilities, Protect stack, `/solutions`) use Lucide `IconWell`
 - Homepage engage-path cards no longer bleed 3D sculptures — DE: IconWell reads as a principal-led firm, not a tech demo
 - Meshy Batch 01 retired from public marketing placement
-- Homepage section jumps live in MegaMenu (`Protected?` / On this page) — no floating bottom dock
+- Homepage section jumps: MegaMenu spy at rest, plus the expanding charcoal/magenta `SiteBottomBar` dock after scroll. Keep both — DE restored the dock 2026-08-27.
 - Assessment CTA uses the same brand gradient as MegaMenu (`from-fuchsia-600 via-pink-600 to-rose-500`)
 
 ## Rules kept


### PR DESCRIPTION
## Summary
- Puts the charcoal/magenta homepage chapter bar back (Home / Why DE / How It Works / Industries / Packages / Contact + phone / Risk Assessment) on scroll, using the exact 2:48 live copy.
- Leaves today's Visual System, Store, Desk, and other chrome untouched.
- Updates the two spec lines that told agents to strip the dock, so it is not removed again.

## Test plan
- [ ] Homepage at rest still shows the top On this page row and compact Ask DE capsule
- [ ] After scrolling past the hero on desktop, the bottom bar expands to the chapter row
- [ ] Store, Desk, and inner pages still look like the 10:46 release
- [ ] Mobile keeps the compact Ask DE capsule (dock was desktop-only)


Made with [Cursor](https://cursor.com)