### PR TITLE
Fix Your Solution cart: show line items, not coverage Add rows

### DIFF
--- a/client/src/components/store/CoverageScorePanel.tsx
+++ b/client/src/components/store/CoverageScorePanel.tsx
@@ -1,9 +1,11 @@
+import { useState } from "react";
 import { Link } from "wouter";
-import { Check, Shield } from "lucide-react";
+import { Check, ChevronDown, Shield } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import type { StoreProduct } from "@/data/storeProducts";
 import { computeCoverageScore } from "@/data/storeMerchandising";
 import { analytics } from "@/lib/analytics";
+import { cartIdentityKeys, suggestionAlreadyInSolution } from "@/components/store/solutionCartUx";
 
 interface CoverageScorePanelProps {
   products: StoreProduct[];
@@ -17,32 +19,17 @@ interface CoverageScorePanelProps {
 export function CoverageScorePanel({
   products,
   onAddSuggestion,
+  compact = false,
 }: CoverageScorePanelProps) {
   const score = computeCoverageScore(products);
+  const [expanded, setExpanded] = useState(!compact);
+  const inSolution = cartIdentityKeys(products);
 
   if (products.length === 0) return null;
 
-  return (
-    <div
-      className="rounded-xl border border-[color:var(--dp-border-10,#ffffff1a)] bg-[color:var(--dp-card-bg,#141414)] p-4"
-      data-testid="coverage-score-panel"
-    >
-      <div className="mb-3 flex items-center justify-between gap-2">
-        <div className="flex items-center gap-2">
-          <Shield className="h-4 w-4 text-de-accent-ink" />
-          <h3 className="text-sm font-semibold text-[color:var(--dp-text-primary,#ffffff)]">Solution coverage</h3>
-        </div>
-        <div className="text-right">
-          <span className="text-lg font-bold text-[color:var(--dp-text-primary,#ffffff)]" data-testid="text-coverage-score">
-            {score.total}
-            <span className="text-sm font-medium text-[color:var(--dp-text-55,#ffffff8c)]"> / 100</span>
-          </span>
-          <p className="text-sm text-[color:var(--dp-text-55,#ffffff8c)]" data-testid="text-coverage-areas">
-            {score.coveredCount} of {score.dimensionCount} areas
-          </p>
-        </div>
-      </div>
-      <p className="mb-4 text-xs leading-relaxed text-[color:var(--dp-text-55,#ffffff8c)]">
+  const details = (
+    <>
+      <p className={`${compact ? "mb-3" : "mb-4"} text-xs leading-relaxed text-[color:var(--dp-text-55,#ffffff8c)]`}>
         Heuristic stack coverage (endpoint, identity, email, backup, network, compliance) —
         not a security audit or certification claim.
       </p>
@@ -73,12 +60,15 @@ export function CoverageScorePanel({
 
       {score.suggestions.length > 0 ? (
         <div className="mt-4 space-y-2 border-t border-[color:var(--dp-border-10,#ffffff1a)] pt-4">
-          <p className="text-xs font-medium text-[color:var(--dp-text-70,#ffffffb3)]">Recommended because this layer is missing</p>
+          <p className="text-xs font-medium text-[color:var(--dp-text-70,#ffffffb3)]">
+            Recommended because this layer is missing
+          </p>
           {score.suggestions.map((s) =>
             s.product ? (
               <div
                 key={s.sku}
                 className="flex items-start justify-between gap-2 rounded-lg border border-[color:var(--dp-border-10,#ffffff1a)] bg-[color:var(--dp-card-bg,#141414)] p-3"
+                data-testid={`coverage-suggestion-${s.product.id}`}
               >
                 <div className="min-w-0">
                   <p className="text-xs uppercase tracking-wide text-[color:var(--dp-text-55,#ffffff8c)]">{s.label}</p>
@@ -87,10 +77,23 @@ export function CoverageScorePanel({
                     Coverage {s.from} → {s.to}
                   </p>
                 </div>
-                {onAddSuggestion ? (
+                {suggestionAlreadyInSolution(s.product, inSolution) ? (
+                  <span
+                    className="inline-flex h-10 shrink-0 items-center gap-1 px-2 text-xs text-[color:var(--dp-success,#34d399)]"
+                    data-testid={`coverage-in-solution-${s.product.id}`}
+                  >
+                    <Check className="h-3.5 w-3.5" />
+                    In solution
+                  </span>
+                ) : onAddSuggestion ? (
                   <Button
                     size="sm"
-                    className="h-8 shrink-0 bg-de-accent text-xs text-white hover:bg-[#6548ff]"
+                    variant={compact ? "outline" : "default"}
+                    className={
+                      compact
+                        ? "h-10 shrink-0 border-[color:var(--dp-border-15,#ffffff26)] bg-transparent text-xs text-[color:var(--dp-text-primary,#ffffff)] hover:bg-[color:var(--dp-hover-bg,#ffffff14)]"
+                        : "h-8 shrink-0 bg-de-accent text-xs text-white hover:bg-[#6548ff]"
+                    }
                     onClick={() => {
                       analytics.storeCoverageGapViewed(s.label);
                       analytics.storeAcceptRecommendation(s.product!.name, `Closes ${s.label} coverage gap`);
@@ -114,6 +117,68 @@ export function CoverageScorePanel({
           All six coverage areas are represented in this solution.
         </p>
       )}
+    </>
+  );
+
+  if (compact) {
+    return (
+      <div
+        className="shrink-0 border-b border-[color:var(--dp-border-10,#ffffff1a)] bg-[color:var(--dp-card-bg,#141414)]"
+        data-testid="coverage-score-panel"
+        data-compact="true"
+      >
+        <button
+          type="button"
+          className="flex min-h-11 w-full items-center justify-between gap-2 px-4 py-2 text-left sm:px-5"
+          onClick={() => setExpanded((open) => !open)}
+          aria-expanded={expanded}
+          data-testid="button-toggle-coverage"
+        >
+          <span className="flex min-w-0 items-center gap-2">
+            <Shield className="h-4 w-4 shrink-0 text-de-accent-ink" />
+            <span className="truncate text-sm font-semibold text-[color:var(--dp-text-primary,#ffffff)]">
+              Solution coverage
+            </span>
+          </span>
+          <span className="flex shrink-0 items-center gap-2">
+            <span className="text-sm tabular-nums text-[color:var(--dp-text-primary,#ffffff)]" data-testid="text-coverage-score">
+              {score.total}
+              <span className="text-xs font-medium text-[color:var(--dp-text-55,#ffffff8c)]"> / 100</span>
+            </span>
+            <span className="hidden text-xs text-[color:var(--dp-text-55,#ffffff8c)] sm:inline" data-testid="text-coverage-areas">
+              {score.coveredCount} of {score.dimensionCount} areas
+            </span>
+            <ChevronDown
+              className={`h-4 w-4 text-[color:var(--dp-text-55,#ffffff8c)] transition-transform ${expanded ? "rotate-180" : ""}`}
+            />
+          </span>
+        </button>
+        {expanded && <div className="px-4 pb-3 sm:px-5">{details}</div>}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="rounded-xl border border-[color:var(--dp-border-10,#ffffff1a)] bg-[color:var(--dp-card-bg,#141414)] p-4"
+      data-testid="coverage-score-panel"
+    >
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <Shield className="h-4 w-4 text-de-accent-ink" />
+          <h3 className="text-sm font-semibold text-[color:var(--dp-text-primary,#ffffff)]">Solution coverage</h3>
+        </div>
+        <div className="text-right">
+          <span className="text-lg font-bold text-[color:var(--dp-text-primary,#ffffff)]" data-testid="text-coverage-score">
+            {score.total}
+            <span className="text-sm font-medium text-[color:var(--dp-text-55,#ffffff8c)]"> / 100</span>
+          </span>
+          <p className="text-sm text-[color:var(--dp-text-55,#ffffff8c)]" data-testid="text-coverage-areas">
+            {score.coveredCount} of {score.dimensionCount} areas
+          </p>
+        </div>
+      </div>
+      {details}
     </div>
   );
 }

--- a/client/src/components/store/ShoppingCart.tsx
+++ b/client/src/components/store/ShoppingCart.tsx
@@ -286,7 +286,7 @@ export function ShoppingCart() {
                                     </div>
                                   </div>
 
-                                  <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
+                                  <div className="mt-2 flex items-center justify-between gap-2">
                                     <div className="flex items-center gap-1">
                                       <Button
                                         variant="outline"
@@ -595,7 +595,8 @@ export function ShoppingCart() {
                     >
                       <a href="/book" className="inline-flex items-center justify-center whitespace-normal text-center leading-tight">
                         <Calendar className="mr-1 h-4 w-4 shrink-0" />
-                        {CTA.primaryShort}
+                        <span className="sm:hidden">{CTA.primaryNavCompact}</span>
+                        <span className="hidden sm:inline">{CTA.primaryShort}</span>
                       </a>
                     </Button>
                     <Button

--- a/client/src/components/store/ShoppingCart.tsx
+++ b/client/src/components/store/ShoppingCart.tsx
@@ -250,52 +250,43 @@ export function ShoppingCart() {
                               const visual = getProductVisual(item.product);
                               const recurring = isRecurringPricing(item.product.pricingType);
                               const detailsOpen = openItemId === item.product.id;
+                              const lineTotal = (
+                                (item.clientPrice ?? item.product.basePrice) * item.quantity
+                              ).toFixed(2);
                               return (
                                 <div
                                   key={item.product.id}
-                                  className="rounded-lg border border-[color:var(--dp-border-10)] bg-[color:var(--dp-card-bg)] p-3"
+                                  className="rounded-lg border border-[color:var(--dp-border-10)] bg-[color:var(--dp-card-bg)] px-3 py-2.5"
                                   data-testid={`cart-item-${item.product.id}`}
                                 >
-                                  <div className="mb-2 flex items-start gap-3">
+                                  <div className="flex items-start gap-3">
                                     <img
                                       src={visual.logoUrl || visual.cardUrl}
                                       alt=""
-                                      className="h-11 w-11 shrink-0 rounded-md border border-[color:var(--dp-border-10)] bg-white object-contain p-1"
+                                      className="h-10 w-10 shrink-0 rounded-md border border-[color:var(--dp-border-10)] bg-white object-contain p-1"
                                     />
                                     <div className="min-w-0 flex-1">
-                                      <h4 className="line-clamp-2 font-medium text-[color:var(--dp-text-primary)]">
-                                        {item.product.name}
-                                      </h4>
+                                      <div className="flex items-start justify-between gap-2">
+                                        <h4 className="line-clamp-2 font-medium leading-snug text-[color:var(--dp-text-primary)]">
+                                          {item.product.name}
+                                        </h4>
+                                        <span className="shrink-0 text-sm font-semibold tabular-nums text-de-accent-ink">
+                                          ${lineTotal}
+                                          {recurring
+                                            ? item.product.pricingType === "yearly"
+                                              ? "/yr"
+                                              : "/mo"
+                                            : ""}
+                                        </span>
+                                      </div>
                                       <p className="text-xs text-[color:var(--dp-text-50)]">
                                         {categoryLabels[item.product.category]} ·{" "}
                                         {billingLabel(item.product.pricingType, item.product.pricingUnit)}
                                       </p>
-                                      <p className="text-sm text-[color:var(--dp-text-50)]">{formatPrice(item.product)}</p>
                                     </div>
-                                    <Button
-                                      variant="ghost"
-                                      size="sm"
-                                      className="h-10 shrink-0 px-2 text-[color:var(--dp-text-60)] hover:text-[color:var(--dp-text-hover)]"
-                                      onClick={() =>
-                                        setOpenItemId(detailsOpen ? null : item.product.id)
-                                      }
-                                      aria-expanded={detailsOpen}
-                                      data-testid={`button-item-details-${item.product.id}`}
-                                    >
-                                      Details
-                                      <ChevronDown
-                                        className={`ml-1 h-3.5 w-3.5 transition-transform ${detailsOpen ? "rotate-180" : ""}`}
-                                      />
-                                    </Button>
                                   </div>
 
-                                  {detailsOpen && item.product.shortDescription && (
-                                    <p className="mb-2 text-xs leading-relaxed text-[color:var(--dp-text-55)]">
-                                      {item.product.shortDescription}
-                                    </p>
-                                  )}
-
-                                  <div className="flex flex-wrap items-center justify-between gap-2">
+                                  <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
                                     <div className="flex items-center gap-1">
                                       <Button
                                         variant="outline"
@@ -330,41 +321,54 @@ export function ShoppingCart() {
                                         <Plus className="h-3 w-3" />
                                       </Button>
                                     </div>
-                                    <span className="text-sm font-semibold text-de-accent-ink">
-                                      $
-                                      {(
-                                        (item.clientPrice ?? item.product.basePrice) * item.quantity
-                                      ).toFixed(2)}
-                                      {recurring
-                                        ? item.product.pricingType === "yearly"
-                                          ? "/yr"
-                                          : "/mo"
-                                        : ""}
-                                    </span>
+                                    <div className="flex items-center">
+                                      <Button
+                                        variant="ghost"
+                                        size="sm"
+                                        className="h-11 px-2 text-[color:var(--dp-text-60)] hover:text-[color:var(--dp-text-hover)]"
+                                        onClick={() =>
+                                          setOpenItemId(detailsOpen ? null : item.product.id)
+                                        }
+                                        aria-expanded={detailsOpen}
+                                        data-testid={`button-item-details-${item.product.id}`}
+                                      >
+                                        Details
+                                        <ChevronDown
+                                          className={`ml-1 h-3.5 w-3.5 transition-transform ${detailsOpen ? "rotate-180" : ""}`}
+                                        />
+                                      </Button>
+                                      <Button
+                                        variant="ghost"
+                                        size="sm"
+                                        onClick={() => removeFromCart(item.product.id)}
+                                        className="h-11 px-2 text-[color:var(--dp-danger)] hover:bg-[color:var(--dp-danger-hover-bg)]"
+                                        data-testid={`button-remove-${item.product.id}`}
+                                      >
+                                        <Trash2 className="mr-1 h-3.5 w-3.5" />
+                                        Remove
+                                      </Button>
+                                    </div>
                                   </div>
 
-                                  <div className="mt-2 flex flex-wrap gap-2">
-                                    <Button
-                                      variant="ghost"
-                                      size="sm"
-                                      className="h-10 px-2 text-[color:var(--dp-text-60)] hover:text-[color:var(--dp-text-hover)]"
-                                      onClick={() => saveForLater(item.product.id)}
-                                      data-testid={`button-save-later-${item.product.id}`}
-                                    >
-                                      <BookmarkPlus className="mr-1 h-3.5 w-3.5" />
-                                      Save for later
-                                    </Button>
-                                    <Button
-                                      variant="ghost"
-                                      size="sm"
-                                      onClick={() => removeFromCart(item.product.id)}
-                                      className="h-10 px-2 text-[color:var(--dp-danger)] hover:bg-[color:var(--dp-danger-hover-bg)]"
-                                      data-testid={`button-remove-${item.product.id}`}
-                                    >
-                                      <Trash2 className="mr-1 h-3.5 w-3.5" />
-                                      Remove
-                                    </Button>
-                                  </div>
+                                  {detailsOpen && (
+                                    <div className="mt-2 border-t border-[color:var(--dp-border-10)] pt-2">
+                                      {item.product.shortDescription && (
+                                        <p className="mb-2 text-xs leading-relaxed text-[color:var(--dp-text-55)]">
+                                          {item.product.shortDescription}
+                                        </p>
+                                      )}
+                                      <Button
+                                        variant="ghost"
+                                        size="sm"
+                                        className="h-11 px-2 text-[color:var(--dp-text-60)] hover:text-[color:var(--dp-text-hover)]"
+                                        onClick={() => saveForLater(item.product.id)}
+                                        data-testid={`button-save-later-${item.product.id}`}
+                                      >
+                                        <BookmarkPlus className="mr-1 h-3.5 w-3.5" />
+                                        Save for later
+                                      </Button>
+                                    </div>
+                                  )}
                                 </div>
                               );
                             })}
@@ -573,10 +577,10 @@ export function ShoppingCart() {
                     <FileText className="mr-2 h-4 w-4" />
                     Request Formal Quote
                   </Button>
-                  <div className="grid grid-cols-2 gap-1">
+                  <div className="grid grid-cols-3 gap-1">
                     <Button
                       variant="ghost"
-                      className="h-auto min-h-11 whitespace-normal text-center text-sm leading-tight text-[color:var(--dp-text-70)] hover:bg-[color:var(--dp-hover-bg)] hover:text-[color:var(--dp-text-hover)]"
+                      className="h-auto min-h-11 whitespace-normal px-1 text-center text-sm leading-tight text-[color:var(--dp-text-70)] hover:bg-[color:var(--dp-hover-bg)] hover:text-[color:var(--dp-text-hover)]"
                       onClick={closeCart}
                       data-testid="button-continue-shopping"
                     >
@@ -585,24 +589,24 @@ export function ShoppingCart() {
                     <Button
                       asChild
                       variant="ghost"
-                      className="h-auto min-h-11 whitespace-normal text-center text-sm leading-tight text-[color:var(--dp-text-70)] hover:bg-de-accent/10 hover:text-[color:var(--dp-text-hover)]"
+                      className="h-auto min-h-11 whitespace-normal px-1 text-center text-sm leading-tight text-[color:var(--dp-text-70)] hover:bg-de-accent/10 hover:text-[color:var(--dp-text-hover)]"
                       onClick={closeCart}
                       data-testid="button-schedule-from-cart"
                     >
-                      <a href="/book" className="whitespace-normal text-center leading-tight">
+                      <a href="/book" className="inline-flex items-center justify-center whitespace-normal text-center leading-tight">
                         <Calendar className="mr-1 h-4 w-4 shrink-0" />
                         {CTA.primaryShort}
                       </a>
                     </Button>
+                    <Button
+                      variant="ghost"
+                      onClick={clearCart}
+                      className="h-auto min-h-11 whitespace-normal px-1 text-center text-sm leading-tight text-[color:var(--dp-text-50)] hover:bg-[color:var(--dp-hover-bg)] hover:text-[color:var(--dp-text-hover)]"
+                      data-testid="button-clear-cart"
+                    >
+                      Clear solution
+                    </Button>
                   </div>
-                  <Button
-                    variant="ghost"
-                    onClick={clearCart}
-                    className="h-10 w-full text-[color:var(--dp-text-50)] hover:bg-[color:var(--dp-hover-bg)] hover:text-[color:var(--dp-text-hover)]"
-                    data-testid="button-clear-cart"
-                  >
-                    Clear solution
-                  </Button>
                 </div>
               </div>
             )}

--- a/client/src/components/store/ShoppingCart.tsx
+++ b/client/src/components/store/ShoppingCart.tsx
@@ -30,6 +30,7 @@ import {
 import { Link, useLocation } from "wouter";
 import { useToast } from "@/hooks/use-toast";
 import { CoverageScorePanel } from "@/components/store/CoverageScorePanel";
+import { shouldShowOngoingEquivalent } from "@/components/store/solutionCartUx";
 import { analytics } from "@/lib/analytics";
 import { CTA } from "@/lib/ctaCopy";
 import { PRIMARY_PHONE } from "@/data/companyContact";
@@ -57,6 +58,8 @@ export function ShoppingCart() {
     togglePanelTheme,
   } = useCart();
   const [isMinimized, setIsMinimized] = useState(false);
+  const [billingOpen, setBillingOpen] = useState(false);
+  const [openItemId, setOpenItemId] = useState<string | null>(null);
   const prefersReducedMotion = useReducedMotion();
   const { toast } = useToast();
   const [, setLocation] = useLocation();
@@ -68,6 +71,7 @@ export function ShoppingCart() {
   const cartProducts = useMemo(() => items.map((item) => item.product), [items]);
   const complements = useMemo(() => getCartComplements(cartProducts, { limit: 3 }), [cartProducts]);
   const missing = useMemo(() => getMissingRequirements(cartProducts), [cartProducts]);
+  const showOngoing = shouldShowOngoingEquivalent(totals);
 
   const grouped = useMemo(() => {
     const map = new Map<string, typeof items>();
@@ -134,18 +138,18 @@ export function ShoppingCart() {
             transition={
               prefersReducedMotion ? { duration: 0 } : { type: "spring", damping: 26, stiffness: 320 }
             }
-            className={`de-panel fixed right-0 z-[61] flex w-full flex-col border-l border-[color:var(--dp-border-10)] bg-[color:var(--dp-panel-bg)] sm:max-w-xl ${
+            className={`de-panel de-solution-drawer fixed right-0 z-[61] flex w-full flex-col border-l border-[color:var(--dp-border-10)] bg-[color:var(--dp-panel-bg)] sm:max-w-xl ${
               isMinimized ? "bottom-0 top-auto rounded-tl-2xl" : "inset-y-0 max-sm:inset-0"
             }`}
             data-theme={panelTheme}
             style={getPanelThemeStyle(panelTheme)}
             data-testid="shopping-cart-panel"
           >
-            <div className="flex items-center justify-between border-b border-[color:var(--dp-border-10)] p-5 sm:p-6">
-              <div className="flex items-center gap-3">
-                <Layers className="h-5 w-5 text-de-accent-ink" />
-                <div>
-                  <h2 id="solution-drawer-title" className="text-xl font-semibold text-[color:var(--dp-text-primary)]">
+            <div className="flex shrink-0 items-center justify-between border-b border-[color:var(--dp-border-10)] px-4 py-3 sm:px-5">
+              <div className="flex min-w-0 items-center gap-3">
+                <Layers className="h-5 w-5 shrink-0 text-de-accent-ink" />
+                <div className="min-w-0">
+                  <h2 id="solution-drawer-title" className="text-lg font-semibold text-[color:var(--dp-text-primary)] sm:text-xl">
                     Your Solution
                   </h2>
                   <span className="text-sm text-[color:var(--dp-text-50)]">
@@ -173,6 +177,7 @@ export function ShoppingCart() {
                   className="hidden h-11 w-11 text-[color:var(--dp-text-60)] hover:bg-de-accent/10 hover:text-[color:var(--dp-text-hover)] sm:inline-flex"
                   data-testid="button-minimize-cart"
                   title={isMinimized ? "Expand solution" : "Minimize"}
+                  aria-label={isMinimized ? "Expand solution" : "Minimize"}
                 >
                   <ChevronDown
                     className={`h-5 w-5 transition-transform ${isMinimized ? "rotate-180" : ""}`}
@@ -185,6 +190,7 @@ export function ShoppingCart() {
                   onClick={closeCart}
                   className="h-11 w-11 text-[color:var(--dp-text-60)] hover:bg-de-accent/10 hover:text-[color:var(--dp-text-hover)]"
                   data-testid="button-close-cart"
+                  aria-label="Close Your Solution"
                 >
                   <X className="h-5 w-5" />
                 </Button>
@@ -196,9 +202,9 @@ export function ShoppingCart() {
             </div>
 
             {!isMinimized && (
-              <div className="flex-1 space-y-5 overflow-y-auto p-5 sm:p-6">
+              <div className="de-solution-drawer__body">
                 {items.length === 0 ? (
-                  <div className="flex h-full flex-col items-center justify-center text-center">
+                  <div className="flex h-full flex-col items-center justify-center px-4 text-center">
                     <div className="mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-[color:var(--dp-card-bg)]">
                       <Layers className="h-10 w-10 text-[color:var(--dp-text-55)]" />
                     </div>
@@ -208,7 +214,7 @@ export function ShoppingCart() {
                     </p>
                     <Button
                       asChild
-                      className="bg-de-accent text-white hover:bg-[#6548ff]"
+                      className="bg-[#D3126A] text-white hover:bg-[#b80f5c]"
                       onClick={closeCart}
                       data-testid="button-browse-products"
                     >
@@ -221,6 +227,7 @@ export function ShoppingCart() {
                 ) : (
                   <>
                     <CoverageScorePanel
+                      compact
                       products={cartProducts}
                       onAddSuggestion={(product) => {
                         addToCart(product, Math.max(1, product.minimumQuantity), product.basePrice);
@@ -228,247 +235,275 @@ export function ShoppingCart() {
                       }}
                     />
 
-                    {missing.length > 0 && (
-                      <div
-                        className="rounded-xl border border-[color:var(--dp-warn-border)] bg-[color:var(--dp-warn-bg)] p-4"
-                        data-testid="solution-missing-requirements"
-                      >
-                        <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-[color:var(--dp-warn-text)]">
-                          Missing prerequisites
-                        </p>
-                        {missing.map((warning) => (
-                          <div key={`${warning.forSku}-${warning.sku}`} className="mb-2 last:mb-0">
-                            <p className="text-sm text-[color:var(--dp-text-80)]">{warning.message}</p>
-                            {warning.product && (
-                              <Button
-                                size="sm"
-                                variant="outline"
-                                className="mt-2 h-10 border-[color:var(--dp-border-15)] bg-transparent text-[color:var(--dp-text-primary)] hover:bg-[color:var(--dp-hover-bg)]"
-                                onClick={() =>
-                                  addToCart(
-                                    warning.product!,
-                                    Math.max(1, warning.product!.minimumQuantity),
-                                    warning.product!.basePrice,
-                                  )
-                                }
-                              >
-                                Add required item
-                              </Button>
-                            )}
-                          </div>
-                        ))}
-                      </div>
-                    )}
+                    <div
+                      className="de-solution-drawer__list space-y-4 px-4 py-3 sm:px-5"
+                      data-testid="solution-line-items"
+                      aria-label="Solution line items"
+                    >
+                      {grouped.map(([group, groupItems]) => (
+                        <div key={group}>
+                          <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[color:var(--dp-text-55)]">
+                            {group}
+                          </h3>
+                          <div className="space-y-2">
+                            {groupItems.map((item) => {
+                              const visual = getProductVisual(item.product);
+                              const recurring = isRecurringPricing(item.product.pricingType);
+                              const detailsOpen = openItemId === item.product.id;
+                              return (
+                                <div
+                                  key={item.product.id}
+                                  className="rounded-lg border border-[color:var(--dp-border-10)] bg-[color:var(--dp-card-bg)] p-3"
+                                  data-testid={`cart-item-${item.product.id}`}
+                                >
+                                  <div className="mb-2 flex items-start gap-3">
+                                    <img
+                                      src={visual.logoUrl || visual.cardUrl}
+                                      alt=""
+                                      className="h-11 w-11 shrink-0 rounded-md border border-[color:var(--dp-border-10)] bg-white object-contain p-1"
+                                    />
+                                    <div className="min-w-0 flex-1">
+                                      <h4 className="line-clamp-2 font-medium text-[color:var(--dp-text-primary)]">
+                                        {item.product.name}
+                                      </h4>
+                                      <p className="text-xs text-[color:var(--dp-text-50)]">
+                                        {categoryLabels[item.product.category]} ·{" "}
+                                        {billingLabel(item.product.pricingType, item.product.pricingUnit)}
+                                      </p>
+                                      <p className="text-sm text-[color:var(--dp-text-50)]">{formatPrice(item.product)}</p>
+                                    </div>
+                                    <Button
+                                      variant="ghost"
+                                      size="sm"
+                                      className="h-10 shrink-0 px-2 text-[color:var(--dp-text-60)] hover:text-[color:var(--dp-text-hover)]"
+                                      onClick={() =>
+                                        setOpenItemId(detailsOpen ? null : item.product.id)
+                                      }
+                                      aria-expanded={detailsOpen}
+                                      data-testid={`button-item-details-${item.product.id}`}
+                                    >
+                                      Details
+                                      <ChevronDown
+                                        className={`ml-1 h-3.5 w-3.5 transition-transform ${detailsOpen ? "rotate-180" : ""}`}
+                                      />
+                                    </Button>
+                                  </div>
 
-                    {grouped.map(([group, groupItems]) => (
-                      <div key={group}>
-                        <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[color:var(--dp-text-55)]">
-                          {group}
-                        </h3>
-                        <div className="space-y-3">
-                          {groupItems.map((item) => {
-                            const visual = getProductVisual(item.product);
-                            const recurring = isRecurringPricing(item.product.pricingType);
-                            return (
+                                  {detailsOpen && item.product.shortDescription && (
+                                    <p className="mb-2 text-xs leading-relaxed text-[color:var(--dp-text-55)]">
+                                      {item.product.shortDescription}
+                                    </p>
+                                  )}
+
+                                  <div className="flex flex-wrap items-center justify-between gap-2">
+                                    <div className="flex items-center gap-1">
+                                      <Button
+                                        variant="outline"
+                                        size="icon"
+                                        onClick={() => updateQuantity(item.product.id, item.quantity - 1)}
+                                        disabled={item.quantity <= item.product.minimumQuantity}
+                                        className="h-11 w-11 border-de-accent/30 bg-de-accent/10 text-[color:var(--dp-text-primary)] hover:bg-de-accent/20"
+                                        data-testid={`button-decrease-${item.product.id}`}
+                                        aria-label={`Decrease ${item.product.name}`}
+                                      >
+                                        <Minus className="h-3 w-3" />
+                                      </Button>
+                                      <input
+                                        type="number"
+                                        min={item.product.minimumQuantity}
+                                        value={item.quantity}
+                                        onChange={(event) =>
+                                          updateQuantity(item.product.id, Number(event.target.value))
+                                        }
+                                        className="h-11 w-14 rounded-md border border-[color:var(--dp-border-10)] bg-transparent text-center text-sm text-[color:var(--dp-text-primary)]"
+                                        data-testid={`quantity-${item.product.id}`}
+                                        aria-label={`${item.product.name} quantity`}
+                                      />
+                                      <Button
+                                        variant="outline"
+                                        size="icon"
+                                        onClick={() => updateQuantity(item.product.id, item.quantity + 1)}
+                                        className="h-11 w-11 border-de-accent/30 bg-de-accent/10 text-[color:var(--dp-text-primary)] hover:bg-de-accent/20"
+                                        data-testid={`button-increase-${item.product.id}`}
+                                        aria-label={`Increase ${item.product.name}`}
+                                      >
+                                        <Plus className="h-3 w-3" />
+                                      </Button>
+                                    </div>
+                                    <span className="text-sm font-semibold text-de-accent-ink">
+                                      $
+                                      {(
+                                        (item.clientPrice ?? item.product.basePrice) * item.quantity
+                                      ).toFixed(2)}
+                                      {recurring
+                                        ? item.product.pricingType === "yearly"
+                                          ? "/yr"
+                                          : "/mo"
+                                        : ""}
+                                    </span>
+                                  </div>
+
+                                  <div className="mt-2 flex flex-wrap gap-2">
+                                    <Button
+                                      variant="ghost"
+                                      size="sm"
+                                      className="h-10 px-2 text-[color:var(--dp-text-60)] hover:text-[color:var(--dp-text-hover)]"
+                                      onClick={() => saveForLater(item.product.id)}
+                                      data-testid={`button-save-later-${item.product.id}`}
+                                    >
+                                      <BookmarkPlus className="mr-1 h-3.5 w-3.5" />
+                                      Save for later
+                                    </Button>
+                                    <Button
+                                      variant="ghost"
+                                      size="sm"
+                                      onClick={() => removeFromCart(item.product.id)}
+                                      className="h-10 px-2 text-[color:var(--dp-danger)] hover:bg-[color:var(--dp-danger-hover-bg)]"
+                                      data-testid={`button-remove-${item.product.id}`}
+                                    >
+                                      <Trash2 className="mr-1 h-3.5 w-3.5" />
+                                      Remove
+                                    </Button>
+                                  </div>
+                                </div>
+                              );
+                            })}
+                          </div>
+                        </div>
+                      ))}
+
+                      {canUndoRemove && (
+                        <Button
+                          variant="outline"
+                          className="h-11 w-full border-[color:var(--dp-border-15)] bg-transparent text-[color:var(--dp-text-primary)] hover:bg-[color:var(--dp-hover-bg)]"
+                          onClick={undoRemove}
+                          data-testid="button-undo-remove"
+                        >
+                          <RotateCcw className="mr-2 h-4 w-4" />
+                          Undo remove
+                        </Button>
+                      )}
+
+                      {savedForLater.length > 0 && (
+                        <div data-testid="saved-for-later">
+                          <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[color:var(--dp-text-55)]">
+                            Saved for later
+                          </h3>
+                          <div className="space-y-2">
+                            {savedForLater.map((item) => (
                               <div
                                 key={item.product.id}
-                                className="rounded-lg border border-[color:var(--dp-border-10)] bg-[color:var(--dp-card-bg)] p-4"
-                                data-testid={`cart-item-${item.product.id}`}
+                                className="flex items-center justify-between gap-2 rounded-lg border border-[color:var(--dp-border-10)] px-3 py-2"
                               >
-                                <div className="mb-3 flex items-start gap-3">
-                                  <img
-                                    src={visual.logoUrl || visual.cardUrl}
-                                    alt=""
-                                    className="h-12 w-12 shrink-0 rounded-md border border-[color:var(--dp-border-10)] bg-white object-contain p-1"
-                                  />
-                                  <div className="min-w-0 flex-1">
-                                    <h4 className="line-clamp-2 font-medium text-[color:var(--dp-text-primary)]">
-                                      {item.product.name}
-                                    </h4>
-                                    <p className="text-xs text-[color:var(--dp-text-50)]">
-                                      {categoryLabels[item.product.category]} ·{" "}
-                                      {billingLabel(item.product.pricingType, item.product.pricingUnit)}
-                                    </p>
-                                    <p className="text-sm text-[color:var(--dp-text-50)]">{formatPrice(item.product)}</p>
-                                  </div>
-                                </div>
-
-                                <div className="flex items-center justify-between gap-2">
-                                  <div className="flex items-center gap-1">
-                                    <Button
-                                      variant="outline"
-                                      size="icon"
-                                      onClick={() => updateQuantity(item.product.id, item.quantity - 1)}
-                                      disabled={item.quantity <= item.product.minimumQuantity}
-                                      className="h-11 w-11 border-de-accent/30 bg-de-accent/10 text-[color:var(--dp-text-primary)] hover:bg-de-accent/20"
-                                      data-testid={`button-decrease-${item.product.id}`}
-                                      aria-label={`Decrease ${item.product.name}`}
-                                    >
-                                      <Minus className="h-3 w-3" />
-                                    </Button>
-                                    <input
-                                      type="number"
-                                      min={item.product.minimumQuantity}
-                                      value={item.quantity}
-                                      onChange={(event) =>
-                                        updateQuantity(item.product.id, Number(event.target.value))
-                                      }
-                                      className="h-11 w-14 rounded-md border border-[color:var(--dp-border-10)] bg-transparent text-center text-sm text-[color:var(--dp-text-primary)]"
-                                      data-testid={`quantity-${item.product.id}`}
-                                      aria-label={`${item.product.name} quantity`}
-                                    />
-                                    <Button
-                                      variant="outline"
-                                      size="icon"
-                                      onClick={() => updateQuantity(item.product.id, item.quantity + 1)}
-                                      className="h-11 w-11 border-de-accent/30 bg-de-accent/10 text-[color:var(--dp-text-primary)] hover:bg-de-accent/20"
-                                      data-testid={`button-increase-${item.product.id}`}
-                                      aria-label={`Increase ${item.product.name}`}
-                                    >
-                                      <Plus className="h-3 w-3" />
-                                    </Button>
-                                  </div>
-                                  <span className="text-sm font-semibold text-de-accent-ink">
-                                    $
-                                    {(
-                                      (item.clientPrice ?? item.product.basePrice) * item.quantity
-                                    ).toFixed(2)}
-                                    {recurring
-                                      ? item.product.pricingType === "yearly"
-                                        ? "/yr"
-                                        : "/mo"
-                                      : ""}
-                                  </span>
-                                </div>
-
-                                <div className="mt-3 flex flex-wrap gap-2">
-                                  <Button
-                                    variant="ghost"
-                                    size="sm"
-                                    className="h-10 px-2 text-[color:var(--dp-text-60)] hover:text-[color:var(--dp-text-hover)]"
-                                    onClick={() => saveForLater(item.product.id)}
-                                    data-testid={`button-save-later-${item.product.id}`}
-                                  >
-                                    <BookmarkPlus className="mr-1 h-3.5 w-3.5" />
-                                    Save for later
-                                  </Button>
-                                  <Button
-                                    variant="ghost"
-                                    size="sm"
-                                    onClick={() => removeFromCart(item.product.id)}
-                                    className="h-10 px-2 text-[color:var(--dp-danger)] hover:bg-[color:var(--dp-danger-hover-bg)]"
-                                    data-testid={`button-remove-${item.product.id}`}
-                                  >
-                                    <Trash2 className="mr-1 h-3.5 w-3.5" />
-                                    Remove
-                                  </Button>
-                                </div>
-                              </div>
-                            );
-                          })}
-                        </div>
-                      </div>
-                    ))}
-
-                    {canUndoRemove && (
-                      <Button
-                        variant="outline"
-                        className="h-11 w-full border-[color:var(--dp-border-15)] bg-transparent text-[color:var(--dp-text-primary)] hover:bg-[color:var(--dp-hover-bg)]"
-                        onClick={undoRemove}
-                        data-testid="button-undo-remove"
-                      >
-                        <RotateCcw className="mr-2 h-4 w-4" />
-                        Undo remove
-                      </Button>
-                    )}
-
-                    {savedForLater.length > 0 && (
-                      <div data-testid="saved-for-later">
-                        <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[color:var(--dp-text-55)]">
-                          Saved for later
-                        </h3>
-                        <div className="space-y-2">
-                          {savedForLater.map((item) => (
-                            <div
-                              key={item.product.id}
-                              className="flex items-center justify-between gap-2 rounded-lg border border-[color:var(--dp-border-10)] px-3 py-2"
-                            >
-                              <p className="truncate text-sm text-[color:var(--dp-text-primary)]">{item.product.name}</p>
-                              <Button
-                                size="sm"
-                                variant="outline"
-                                className="h-10 border-[color:var(--dp-border-15)] bg-transparent text-[color:var(--dp-text-primary)] hover:bg-[color:var(--dp-hover-bg)]"
-                                onClick={() => moveToSolution(item.product.id)}
-                              >
-                                Move to solution
-                              </Button>
-                            </div>
-                          ))}
-                        </div>
-                      </div>
-                    )}
-
-                    {complements.length > 0 && (
-                      <div
-                        className="rounded-xl border border-[color:var(--dp-border-10)] bg-[color:var(--dp-card-bg)] p-4"
-                        data-testid="cart-complements"
-                      >
-                        <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-[color:var(--dp-text-55)]">
-                          Recommended because
-                        </p>
-                        <div className="space-y-3">
-                          {complements.map((product) => {
-                            const why = recommendationWhy(product, cartProducts);
-                            return (
-                              <div key={product.sku} className="flex items-start justify-between gap-2">
-                                <div className="min-w-0">
-                                  <p className="truncate text-sm text-[color:var(--dp-text-primary)]">{product.name}</p>
-                                  <p className="text-xs text-[color:var(--dp-text-55)]">{why}</p>
-                                  <p className="text-xs text-[color:var(--dp-text-45)]">{formatPrice(product)}</p>
-                                </div>
+                                <p className="truncate text-sm text-[color:var(--dp-text-primary)]">{item.product.name}</p>
                                 <Button
                                   size="sm"
                                   variant="outline"
-                                  className="h-10 shrink-0 border-[color:var(--dp-border-15)] bg-transparent text-xs text-[color:var(--dp-text-primary)] hover:bg-[color:var(--dp-hover-bg)]"
-                                  onClick={() => {
-                                    addToCart(
-                                      product,
-                                      Math.max(1, product.minimumQuantity),
-                                      product.basePrice,
-                                    );
-                                    analytics.storeAcceptRecommendation(product.name, why ?? "");
-                                    toast({ title: "Added to solution", description: product.name });
-                                  }}
-                                  data-testid={`button-complement-${product.id}`}
+                                  className="h-10 border-[color:var(--dp-border-15)] bg-transparent text-[color:var(--dp-text-primary)] hover:bg-[color:var(--dp-hover-bg)]"
+                                  onClick={() => moveToSolution(item.product.id)}
                                 >
-                                  Add
+                                  Move to solution
                                 </Button>
                               </div>
-                            );
-                          })}
+                            ))}
+                          </div>
                         </div>
-                      </div>
-                    )}
+                      )}
 
-                    <p className="text-xs text-[color:var(--dp-text-55)]">
-                      Estimated onboarding: typically 7–10 business days after kickoff (varies by
-                      stack). Questions?{" "}
-                      <a
-                        href={PRIMARY_PHONE.telHref}
-                        className="inline-flex items-center gap-1 text-de-accent-ink hover:text-de-accent-ink"
-                      >
-                        <Phone className="h-3 w-3" />
-                        {PRIMARY_PHONE.display}
-                      </a>
-                    </p>
+                      {missing.length > 0 && (
+                        <div
+                          className="rounded-xl border border-[color:var(--dp-warn-border)] bg-[color:var(--dp-warn-bg)] p-3"
+                          data-testid="solution-missing-requirements"
+                        >
+                          <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-[color:var(--dp-warn-text)]">
+                            Missing prerequisites
+                          </p>
+                          {missing.map((warning) => (
+                            <div key={`${warning.forSku}-${warning.sku}`} className="mb-2 last:mb-0">
+                              <p className="text-sm text-[color:var(--dp-text-80)]">{warning.message}</p>
+                              {warning.product && (
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  className="mt-2 h-10 border-[color:var(--dp-border-15)] bg-transparent text-[color:var(--dp-text-primary)] hover:bg-[color:var(--dp-hover-bg)]"
+                                  onClick={() =>
+                                    addToCart(
+                                      warning.product!,
+                                      Math.max(1, warning.product!.minimumQuantity),
+                                      warning.product!.basePrice,
+                                    )
+                                  }
+                                >
+                                  Add required item
+                                </Button>
+                              )}
+                            </div>
+                          ))}
+                        </div>
+                      )}
+
+                      {complements.length > 0 && (
+                        <div
+                          className="rounded-xl border border-[color:var(--dp-border-10)] bg-[color:var(--dp-card-bg)] p-3"
+                          data-testid="cart-complements"
+                        >
+                          <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-[color:var(--dp-text-55)]">
+                            Recommended because
+                          </p>
+                          <div className="space-y-3">
+                            {complements.map((product) => {
+                              const why = recommendationWhy(product, cartProducts);
+                              return (
+                                <div key={product.sku} className="flex items-start justify-between gap-2">
+                                  <div className="min-w-0">
+                                    <p className="truncate text-sm text-[color:var(--dp-text-primary)]">{product.name}</p>
+                                    <p className="text-xs text-[color:var(--dp-text-55)]">{why}</p>
+                                    <p className="text-xs text-[color:var(--dp-text-45)]">{formatPrice(product)}</p>
+                                  </div>
+                                  <Button
+                                    size="sm"
+                                    variant="outline"
+                                    className="h-10 shrink-0 border-[color:var(--dp-border-15)] bg-transparent text-xs text-[color:var(--dp-text-primary)] hover:bg-[color:var(--dp-hover-bg)]"
+                                    onClick={() => {
+                                      addToCart(
+                                        product,
+                                        Math.max(1, product.minimumQuantity),
+                                        product.basePrice,
+                                      );
+                                      analytics.storeAcceptRecommendation(product.name, why ?? "");
+                                      toast({ title: "Added to solution", description: product.name });
+                                    }}
+                                    data-testid={`button-complement-${product.id}`}
+                                  >
+                                    Add
+                                  </Button>
+                                </div>
+                              );
+                            })}
+                          </div>
+                        </div>
+                      )}
+
+                      <p className="text-xs text-[color:var(--dp-text-55)]">
+                        Estimated onboarding: typically 7–10 business days after kickoff (varies by
+                        stack). Questions?{" "}
+                        <a
+                          href={PRIMARY_PHONE.telHref}
+                          className="inline-flex items-center gap-1 text-de-accent-ink hover:text-de-accent-ink"
+                        >
+                          <Phone className="h-3 w-3" />
+                          {PRIMARY_PHONE.display}
+                        </a>
+                      </p>
+                    </div>
                   </>
                 )}
               </div>
             )}
 
             {items.length > 0 && (
-              <div className="border-t border-[color:var(--dp-border-10)] bg-[color:var(--dp-card-bg)] p-5 sm:p-6">
-                <div className="mb-4 space-y-2">
+              <div className="de-solution-drawer__footer border-t border-[color:var(--dp-border-10)] bg-[color:var(--dp-card-bg)] px-4 py-3 sm:px-5">
+                <div className="mb-3 space-y-1">
                   {totals.dueToday > 0 && (
                     <div className="flex items-center justify-between text-sm">
                       <span className="text-[color:var(--dp-text-60)]">Due today</span>
@@ -493,22 +528,36 @@ export function ShoppingCart() {
                       <span className="font-medium text-[color:var(--dp-success)]">-${savings.toFixed(2)}</span>
                     </div>
                   )}
-                  <div className="flex items-center justify-between border-t border-[color:var(--dp-border-10)] pt-2">
-                    <span className="font-medium text-[color:var(--dp-text-primary)]">Ongoing equivalent</span>
-                    <span className="text-lg font-bold text-de-accent-ink">
-                      ${totals.recurringMonthlyEquivalent.toFixed(2)}/mo
+                  {showOngoing && (
+                    <div className="flex items-center justify-between border-t border-[color:var(--dp-border-10)] pt-1.5">
+                      <span className="font-medium text-[color:var(--dp-text-primary)]">Ongoing equivalent</span>
+                      <span className="text-base font-bold text-de-accent-ink">
+                        ${totals.recurringMonthlyEquivalent.toFixed(2)}/mo
+                      </span>
+                    </div>
+                  )}
+                  <button
+                    type="button"
+                    className="flex min-h-10 w-full items-center gap-1.5 text-left text-xs text-[color:var(--dp-text-45)] hover:text-[color:var(--dp-text-60)]"
+                    onClick={() => setBillingOpen((open) => !open)}
+                    aria-expanded={billingOpen}
+                    data-testid="button-toggle-billing-notes"
+                  >
+                    <Clock className="h-3 w-3 shrink-0" />
+                    <span className="flex-1">
+                      {billingOpen
+                        ? "Recurring services bill on the start date after kickoff. One-time work is due when the order is placed. Tax is calculated at checkout when applicable."
+                        : "Billing cycle and tax notes"}
                     </span>
-                  </div>
-                  <p className="flex items-start gap-1.5 text-xs text-[color:var(--dp-text-45)]">
-                    <Clock className="mt-0.5 h-3 w-3 shrink-0" />
-                    Recurring services bill on the start date after kickoff. One-time work is due
-                    when the order is placed. Tax is calculated at checkout when applicable.
-                  </p>
+                    <ChevronDown
+                      className={`h-3.5 w-3.5 shrink-0 transition-transform ${billingOpen ? "rotate-180" : ""}`}
+                    />
+                  </button>
                 </div>
 
-                <div className="space-y-2.5">
+                <div className="space-y-2">
                   <Button
-                    className="h-12 w-full bg-de-accent text-white hover:bg-[#6548ff]"
+                    className="h-11 w-full bg-[#D3126A] text-white hover:bg-[#b80f5c]"
                     onClick={goCheckout}
                     data-testid="button-checkout"
                   >
@@ -524,10 +573,10 @@ export function ShoppingCart() {
                     <FileText className="mr-2 h-4 w-4" />
                     Request Formal Quote
                   </Button>
-                  <div className="grid grid-cols-2 gap-2">
+                  <div className="grid grid-cols-2 gap-1">
                     <Button
                       variant="ghost"
-                      className="h-auto min-h-11 whitespace-normal text-center leading-tight text-[color:var(--dp-text-70)] hover:bg-[color:var(--dp-hover-bg)] hover:text-[color:var(--dp-text-hover)]"
+                      className="h-auto min-h-11 whitespace-normal text-center text-sm leading-tight text-[color:var(--dp-text-70)] hover:bg-[color:var(--dp-hover-bg)] hover:text-[color:var(--dp-text-hover)]"
                       onClick={closeCart}
                       data-testid="button-continue-shopping"
                     >
@@ -536,7 +585,7 @@ export function ShoppingCart() {
                     <Button
                       asChild
                       variant="ghost"
-                      className="h-auto min-h-11 whitespace-normal text-center leading-tight text-[color:var(--dp-text-70)] hover:bg-de-accent/10 hover:text-[color:var(--dp-text-hover)]"
+                      className="h-auto min-h-11 whitespace-normal text-center text-sm leading-tight text-[color:var(--dp-text-70)] hover:bg-de-accent/10 hover:text-[color:var(--dp-text-hover)]"
                       onClick={closeCart}
                       data-testid="button-schedule-from-cart"
                     >

--- a/client/src/components/store/solutionCartUx.test.ts
+++ b/client/src/components/store/solutionCartUx.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  cartIdentityKeys,
+  shouldShowOngoingEquivalent,
+  suggestionAlreadyInSolution,
+} from "./solutionCartUx";
+
+describe("shouldShowOngoingEquivalent", () => {
+  it("hides when it only repeats Monthly", () => {
+    expect(
+      shouldShowOngoingEquivalent({
+        monthly: 315,
+        annual: 0,
+        recurringMonthlyEquivalent: 315,
+      }),
+    ).toBe(false);
+  });
+
+  it("shows when annual converts into a different equivalent", () => {
+    expect(
+      shouldShowOngoingEquivalent({
+        monthly: 315,
+        annual: 1200,
+        recurringMonthlyEquivalent: 415,
+      }),
+    ).toBe(true);
+  });
+
+  it("hides when there is no recurring total", () => {
+    expect(
+      shouldShowOngoingEquivalent({
+        monthly: 0,
+        annual: 0,
+        recurringMonthlyEquivalent: 0,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("suggestionAlreadyInSolution", () => {
+  const inSolution = cartIdentityKeys([
+    { id: "prod-bcdr", sku: "DE-SVC-MGD-BCDR-MO" },
+  ]);
+
+  it("treats an in-cart SKU as already in the solution", () => {
+    expect(
+      suggestionAlreadyInSolution(
+        { id: "other-id", sku: "DE-SVC-MGD-BCDR-MO" },
+        inSolution,
+      ),
+    ).toBe(true);
+  });
+
+  it("does not mark a missing coverage product as in-cart", () => {
+    expect(
+      suggestionAlreadyInSolution(
+        { id: "prod-net", sku: "DE-SVC-NET-MANAGED-CORE-MO" },
+        inSolution,
+      ),
+    ).toBe(false);
+  });
+});

--- a/client/src/components/store/solutionCartUx.ts
+++ b/client/src/components/store/solutionCartUx.ts
@@ -1,0 +1,34 @@
+import type { StoreProduct } from "@/data/storeProducts";
+
+/**
+ * Quote-builder totals for the Your Solution footer.
+ * Ongoing equivalent duplicates Monthly when there is no annual to convert.
+ */
+export function shouldShowOngoingEquivalent(totals: {
+  monthly: number;
+  annual: number;
+  recurringMonthlyEquivalent: number;
+}): boolean {
+  if (totals.recurringMonthlyEquivalent <= 0) return false;
+  if (totals.annual <= 0 && Math.abs(totals.recurringMonthlyEquivalent - totals.monthly) < 0.005) {
+    return false;
+  }
+  return true;
+}
+
+export function cartIdentityKeys(products: Pick<StoreProduct, "id" | "sku">[]): Set<string> {
+  const keys = new Set<string>();
+  for (const product of products) {
+    keys.add(product.id);
+    keys.add(product.sku);
+  }
+  return keys;
+}
+
+export function suggestionAlreadyInSolution(
+  product: Pick<StoreProduct, "id" | "sku"> | undefined,
+  inSolution: Set<string>,
+): boolean {
+  if (!product) return false;
+  return inSolution.has(product.id) || inSolution.has(product.sku);
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1940,3 +1940,41 @@ button, [role="button"], a {
 .de-panel-theme-toggle {
   transition: background-color 160ms ease, color 160ms ease, border-color 160ms ease;
 }
+
+/*
+ * Your Solution cart: overflow-y-auto on the list lets that flex child shrink
+ * to ~0 while the footer (overflow: visible) cannot shrink below its content.
+ * Pin the footer, give the line-item list remaining height, and keep a floor
+ * so 4–6 rows stay scannable on typical viewports.
+ */
+.de-solution-drawer {
+  min-height: 0;
+  overflow: hidden;
+}
+.de-solution-drawer__body {
+  display: flex;
+  min-height: 0;
+  flex: 1 1 auto;
+  flex-direction: column;
+  overflow: hidden;
+}
+.de-solution-drawer__list {
+  flex: 1 1 auto;
+  min-height: min(20rem, 42vh);
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+.de-solution-drawer__footer {
+  flex: 0 0 auto;
+}
+@media (max-height: 700px) {
+  .de-solution-drawer__list {
+    min-height: min(12.5rem, 34vh);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .de-solution-drawer__list {
+    scroll-behavior: auto;
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Buyers with 5 services in **Your Solution** could only see ~1–2 coverage-suggestion rows. The coverage panel sat above the cart, looked like line items with **Add**, and the fixed footer ate most of the drawer. This restores list-first quote-builder UX without a new cart system.

## What changed

- Line-item list is a flex-grow scroller with a min-height floor; footer is `flex: 0 0 auto` and compact.
- Coverage score is collapsed by default in the drawer. Gap suggestions are labeled as recommendations; in-cart products show **In solution**, not **Add**.
- Cart rows keep qty, **Remove**, Details (short description + Save for later). Checkout / quote / continue shopping / assessment / clear / theme / minimize stay.
- Hide **Ongoing equivalent** when it only repeats Monthly.
- Primary checkout CTA stays `#D3126A`. Store electric lock and category pills are untouched.

## Files

- `client/src/components/store/ShoppingCart.tsx`
- `client/src/components/store/CoverageScorePanel.tsx`
- `client/src/components/store/solutionCartUx.ts`
- `client/src/components/store/solutionCartUx.test.ts`
- `client/src/index.css` (append-only `.de-solution-drawer*`)

## Functionality preserved

Checkout, Request Formal Quote, continue shopping, Cyber Risk Assessment, clear, theme toggle, minimize, close, qty, undo remove, save for later, due-today vs monthly, coverage 50→67, `SolutionMobileBar`. Desk / ZohoASAPWidget / Visual System HUD were not touched.

## Tests

`solutionCartUx`, `categoryAccent`, `stickyCtaVisibility` — 16 passed.

## Visual QA

Store at `http://127.0.0.1:8080/store` with 5 services.

| Viewport | List / footer | Visible rows (top of list) |
|---|---|---|
| 1440×900 | 483px / 293px | 3 full + 4th partial |
| 768×900 | 483px / 293px | 3 full, no overflow |
| 390×844 | 402px / 293px | 3 full; checkout reachable |

Screenshots captured: YES

[Empty Your Solution drawer at 1440](https://cursor.com/agents/bc-41048611-79fd-4e04-98ed-bb429bbcc9ac/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fyour_solution_empty_1440.png)
[Your Solution with five services visible at 1440](https://cursor.com/agents/bc-41048611-79fd-4e04-98ed-bb429bbcc9ac/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fyour_solution_5_items_1440_list.png)
[Your Solution five-item cart at 768](https://cursor.com/agents/bc-41048611-79fd-4e04-98ed-bb429bbcc9ac/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fyour_solution_5_items_768.png)
[Your Solution five-item cart at 390](https://cursor.com/agents/bc-41048611-79fd-4e04-98ed-bb429bbcc9ac/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fyour_solution_5_items_390.png)

## CONCURRENCY AUDIT

Branch base: `c218ad6`
Current origin/main: `595c820` (`Port campaign landing pages and resource assets onto current main (#82)`)
Commits landed on main since branch creation:
- `595c820` #82 campaign landing pages / resource assets

Overlapping files:
- none vs `595c820`. This PR touches `ShoppingCart.tsx`, `CoverageScorePanel.tsx`, `solutionCartUx.ts`, `solutionCartUx.test.ts`, and an append-only `index.css` hunk. #82 did not change those paths.

Reconciliation performed:
- Fetched `origin/main` before opening this PR. File overlap with #82 is empty. No whole-file ours/theirs.

Newer-main work preserved: YES (no overlapping files; PR can merge after a fast-forward)
Whole-file replacements reviewed: YES — none used

Tests: `solutionCartUx`, `categoryAccent`, `stickyCtaVisibility` — 16 passed
Visual QA:
390: yes
768: yes
1440: yes
Screenshots captured: YES

## Remaining

- Items 4–5 still need a short scroll; 44px CTAs keep the footer from shrinking further.
- If #59-style `index.css` work appears again, keep this PR’s `.de-solution-drawer*` hunk and the other hunks.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41048611-79fd-4e04-98ed-bb429bbcc9ac?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41048611-79fd-4e04-98ed-bb429bbcc9ac&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

