### PR TITLE
Expose DE Intelligence runtime status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,3 +84,28 @@ jobs:
           fi
 
           BASE_URL=http://127.0.0.1:3300 npm run smoke:public
+
+      # The VPS deployer may be a CyberPanel Git webhook or a cron poll of main.
+      # On a main push, prove the actual public runtime picked up this release.
+      - name: Verify DE Intelligence production rollout
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        shell: bash
+        run: |
+          set -euo pipefail
+          URL="https://digeratiexperts.com/api/portal/zoho/chat/status"
+          BODY=""
+          for _ in $(seq 1 30); do
+            BODY="$(curl -fsS --max-time 10 "$URL" || true)"
+            if printf '%s' "$BODY" | grep -q '"version":"de-intelligence-v1"' \
+              && printf '%s' "$BODY" | grep -q '"enabled":true' \
+              && printf '%s' "$BODY" | grep -Eq '"publicGovernedRecords":[1-9][0-9]*'; then
+              echo "Production is serving DE Intelligence v1"
+              printf '%s\n' "$BODY"
+              exit 0
+            fi
+            sleep 20
+          done
+
+          echo "Production did not report DE Intelligence v1 after polling $URL"
+          printf '%s\n' "$BODY"
+          exit 1

--- a/server/publicSupportChat.ts
+++ b/server/publicSupportChat.ts
@@ -2,6 +2,7 @@ import { randomBytes } from "crypto";
 import type { Express } from "express";
 import rateLimit from "express-rate-limit";
 import { generateChatResponse } from "./openaiService";
+import { DE_KNOWLEDGE_CATALOG } from "./services/de-intelligence/catalog";
 
 export type PublicChatHistoryEntry = {
   role: "user" | "assistant";
@@ -50,11 +51,20 @@ const publicSupportChatRateLimiter = rateLimit({
 
 export function registerPublicSupportChat(app: Express): void {
   app.get("/api/portal/zoho/chat/status", (_req, res) => {
+    const publicKnowledgeRecords = DE_KNOWLEDGE_CATALOG.filter(
+      (record) => record.scope === "public" && record.status === "active",
+    ).length;
+
     res.json({
       success: true,
       assistantAvailable: assistantConfigured(),
       mode: "ai-assistant",
       ticketFallback: "/api/portal/zoho/ticket",
+      intelligence: {
+        enabled: true,
+        version: "de-intelligence-v1",
+        publicGovernedRecords: publicKnowledgeRecords,
+      },
     });
   });
 


### PR DESCRIPTION
Adds a non-sensitive runtime marker to the existing public assistant status endpoint so production can be verified as serving the governed DE Intelligence release. Reports only enabled/version and the count of active public governed records; no internal/client knowledge or source contents are exposed.