### PR TITLE
Restore real production deployment through self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,27 +85,87 @@ jobs:
 
           BASE_URL=http://127.0.0.1:3300 npm run smoke:public
 
-      # The VPS deployer may be a CyberPanel Git webhook or a cron poll of main.
-      # On a main push, prove the actual public runtime picked up this release.
-      - name: Verify DE Intelligence production rollout
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+  # Production is a CyberPanel/OpenLiteSpeed VPS, not a Replit deployment.
+  # A self-hosted runner is allowed to deploy only when it proves it is on the
+  # canonical DE production host. This permanently replaces the broken
+  # cron/webhook assumption with an explicit, fail-closed release path.
+  deploy-production:
+    name: Deploy and verify production VPS
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: check-test-build
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 30
+
+    steps:
+      - name: Assert runner is the DE production host
         shell: bash
         run: |
           set -euo pipefail
-          URL="https://digeratiexperts.com/api/portal/zoho/chat/status"
-          BODY=""
-          for _ in $(seq 1 30); do
-            BODY="$(curl -fsS --max-time 10 "$URL" || true)"
-            if printf '%s' "$BODY" | grep -q '"version":"de-intelligence-v1"' \
-              && printf '%s' "$BODY" | grep -q '"enabled":true' \
-              && printf '%s' "$BODY" | grep -Eq '"publicGovernedRecords":[1-9][0-9]*'; then
-              echo "Production is serving DE Intelligence v1"
-              printf '%s\n' "$BODY"
-              exit 0
-            fi
-            sleep 20
-          done
+          echo "Runner host: $(hostname)"
+          echo "Runner user: $(id -un)"
 
-          echo "Production did not report DE Intelligence v1 after polling $URL"
+          SITE=/home/digeratiexperts.com
+          DEPLOY="$SITE/current/deploy/vps/deploy.sh"
+
+          test -d "$SITE" || {
+            echo "::error::This runner is not on the DE production VPS: $SITE is missing."
+            exit 1
+          }
+          test -f "$DEPLOY" || {
+            echo "::error::Canonical production deploy script is missing: $DEPLOY"
+            exit 1
+          }
+
+          LOAD_STATE="$(systemctl show -p LoadState --value digeratiexperts-site 2>/dev/null || true)"
+          test "$LOAD_STATE" = "loaded" || {
+            echo "::error::digeratiexperts-site systemd unit is not loaded on this runner host."
+            exit 1
+          }
+
+          if [ "$(id -un)" = "diger7051" ]; then
+            echo "DE_DEPLOY_AS=site-user" >> "$GITHUB_ENV"
+          elif [ "$(id -u)" = "0" ]; then
+            echo "DE_DEPLOY_AS=root" >> "$GITHUB_ENV"
+          elif sudo -n -u diger7051 true 2>/dev/null; then
+            echo "DE_DEPLOY_AS=sudo-site-user" >> "$GITHUB_ENV"
+          else
+            echo "::error::Runner is on the production VPS but cannot execute as diger7051. Grant only this runner user passwordless sudo-as-diger7051 for the canonical deploy command; do not grant NOPASSWD: ALL."
+            exit 1
+          fi
+
+      - name: Deploy current main with canonical release script
+        shell: bash
+        run: |
+          set -euo pipefail
+          CMD='DEPLOY_BRANCH=main bash /home/digeratiexperts.com/current/deploy/vps/deploy.sh production'
+          case "$DE_DEPLOY_AS" in
+            site-user)
+              bash -lc "$CMD"
+              ;;
+            root)
+              sudo -u diger7051 bash -lc "$CMD"
+              ;;
+            sudo-site-user)
+              sudo -n -u diger7051 bash -lc "$CMD"
+              ;;
+            *)
+              echo "::error::Unknown deployment execution mode"
+              exit 1
+              ;;
+          esac
+
+      - name: Verify production runtime
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsS http://127.0.0.1:3300/healthz
+          curl -fsS https://digeratiexperts.com/healthz
+
+          URL="https://digeratiexperts.com/api/portal/zoho/chat/status"
+          BODY="$(curl -fsS --max-time 15 "$URL")"
           printf '%s\n' "$BODY"
-          exit 1
+
+          printf '%s' "$BODY" | grep -q '"version":"de-intelligence-v1"'
+          printf '%s' "$BODY" | grep -q '"enabled":true'
+          printf '%s' "$BODY" | grep -Eq '"publicGovernedRecords":[1-9][0-9]*'
+          echo "Production is serving DE Intelligence v1"


### PR DESCRIPTION
The hosted CI proved production stayed on the old runtime for 10 minutes after #85, so the documented cron/CyberPanel auto-deployer is not functioning.

This change moves production rollout out of the hosted test job and adds an explicit post-CI deployment job on the registered self-hosted Linux/X64 runner. The job fails closed unless the runner proves it is on the canonical DE production VPS (`/home/digeratiexperts.com`, canonical deploy script, and loaded `digeratiexperts-site` systemd unit). It then executes the existing production release script as `diger7051` and verifies both health endpoints and the `de-intelligence-v1` runtime marker.

No alternate hosting path is introduced; this uses the existing CyberPanel/OpenLiteSpeed/systemd release architecture.