### PR TITLE
Keep the production Actions runner online and stop canceling main deploys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,16 @@ on:
     branches: [main]
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read
 
+# Cancel overlapping pull_request runs only. A newer push to main must not
+# cancel a queued or in-flight production deploy waiting on the VPS runner.
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   check-test-build:
@@ -91,7 +94,7 @@ jobs:
   # cron/webhook assumption with an explicit, fail-closed release path.
   deploy-production:
     name: Deploy and verify production VPS
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     needs: check-test-build
     runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 30

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -18,7 +18,22 @@
 | Service | `digeratiexperts-site` (systemd) |
 | Private port | `127.0.0.1:3300` (OLS proxies HTTPS here) |
 
-### Deploy an update
+### Automatic deploy (required)
+
+GitHub Actions deploys `main` through a **self-hosted runner on de-vps**.
+If that runner is offline, Phase 2 and every later `main` commit stay off
+production even when hosted CI is green.
+
+```bash
+# On 192.227.158.46 as root, once (token from GitHub → Settings → Runners)
+RUNNER_TOKEN=... bash deploy/vps/install-actions-runner.sh
+systemctl enable --now actions-runner-digeratiexperts-site.service
+```
+
+Do not cancel in-flight `main` deploys by stacking more pushes. Hosted CI
+cancels overlapping pull requests only.
+
+### Manual deploy (same script the runner runs)
 
 ```bash
 sudo -u diger7051 bash -lc \

--- a/deploy/vps/README.md
+++ b/deploy/vps/README.md
@@ -85,9 +85,18 @@ The script:
 8. On any restart/inactive/health failure: rolls back the symlink, restarts,
    and **exits non-zero** (failed deployment — never treated as optional)
 
-Automatic deploys: either a cron entry polling `main`, or CyberPanel's Git
-Manager webhook calling the script. Choose ONE mechanism — if this script
-is the deployer, disable any competing timer/webhook.
+Automatic deploys: GitHub Actions job **Deploy and verify production VPS**
+on `main`, using a self-hosted runner **on this VPS**. Labels required:
+`self-hosted`, `Linux`, `X64`. Install or repair it with
+`deploy/vps/install-actions-runner.sh` and keep
+`actions-runner-digeratiexperts-site.service` enabled.
+
+Do **not** rely on cron or CyberPanel Git Manager for production rollout.
+If the runner is offline, `main` CI stays green and production stays stale.
+
+If a deploy job is already queued, starting the runner is enough — do not
+push another commit just to retry. `workflow_dispatch` on the CI workflow
+can also re-run check + deploy after the runner is online.
 
 ## One-time setup (staging)
 

--- a/deploy/vps/actions-runner.service
+++ b/deploy/vps/actions-runner.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=GitHub Actions runner for digeratiexperts-site production deploys
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=de-cursor
+Group=de-cursor
+WorkingDirectory=/home/de-cursor/actions-runner
+ExecStart=/home/de-cursor/actions-runner/run.sh
+Restart=always
+RestartSec=10
+KillSignal=SIGINT
+TimeoutStopSec=5min
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/vps/install-actions-runner.sh
+++ b/deploy/vps/install-actions-runner.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Install or repair the GitHub Actions runner that deploys digeratiexperts-site.
+# Run on de-vps (192.227.158.46) only. Do not install a runner on any other host.
+# Do not touch Intelligence Hub (:3100).
+#
+# Usage (as root or a user that can write the runner dir and systemd):
+#   RUNNER_TOKEN=... bash deploy/vps/install-actions-runner.sh
+#
+# Get RUNNER_TOKEN from the repo: Settings → Actions → Runners → New self-hosted runner.
+# The token is short-lived. Do not commit it.
+#
+set -euo pipefail
+
+REPO_URL="${REPO_URL:-https://github.com/digeratiexperts/digeratiexperts-site}"
+RUNNER_USER="${RUNNER_USER:-de-cursor}"
+RUNNER_DIR="${RUNNER_DIR:-/home/${RUNNER_USER}/actions-runner}"
+RUNNER_VERSION="${RUNNER_VERSION:-2.328.0}"
+SITE_HOME="${SITE_HOME:-/home/digeratiexperts.com}"
+UNIT_SRC="$(cd "$(dirname "$0")" && pwd)/actions-runner.service"
+
+fail() { echo "ERROR: $*" >&2; exit 1; }
+
+test -n "${RUNNER_TOKEN:-}" || fail "Set RUNNER_TOKEN from GitHub runner registration."
+test -d "$SITE_HOME" || fail "This host is not the DE production VPS: $SITE_HOME missing."
+id "$RUNNER_USER" >/dev/null 2>&1 || fail "Runner user $RUNNER_USER does not exist. Create it before installing."
+
+if [ "$(id -u)" -ne 0 ]; then
+  fail "Run this installer as root so it can write systemd and $RUNNER_DIR."
+fi
+
+install -d -o "$RUNNER_USER" -g "$RUNNER_USER" -m 0750 "$RUNNER_DIR"
+cd "$RUNNER_DIR"
+
+TGZ="actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz"
+if [ ! -x ./config.sh ]; then
+  curl -fsSL -o "$TGZ" \
+    "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/${TGZ}"
+  tar xzf "$TGZ"
+  chown -R "$RUNNER_USER:$RUNNER_USER" "$RUNNER_DIR"
+fi
+
+if [ ! -f .runner ]; then
+  sudo -u "$RUNNER_USER" ./config.sh --unattended \
+    --url "$REPO_URL" \
+    --token "$RUNNER_TOKEN" \
+    --name de-vps-production \
+    --labels "self-hosted,Linux,X64,de-vps,production" \
+    --work _work \
+    --replace
+fi
+
+install -m 0644 "$UNIT_SRC" /etc/systemd/system/actions-runner-digeratiexperts-site.service
+systemctl daemon-reload
+systemctl enable --now actions-runner-digeratiexperts-site.service
+systemctl --no-pager --full status actions-runner-digeratiexperts-site.service
+
+echo "Runner should now accept jobs labeled [self-hosted, Linux, X64]."
+echo "If a deploy job is already queued, it should start without another commit."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

The blocker in the screenshot is real: **PR #87 is on `main` and hosted CI is green, but production never rolled.**

- Deploy job on run `33171865342` has been **queued** since 12:39 UTC on `[self-hosted, Linux, X64]` with no runner name.
- The earlier #86 production run was **cancelled** because `cancel-in-progress: true` fired when #87 merged.
- Live `https://digeratiexperts.com/api/portal/zoho/chat/status` still returns the old payload (no `de-intelligence-v1`).

This PR does not invent a second host. It:

1. Cancels overlapping **pull_request** CI only, so a newer `main` push cannot abort a queued VPS deploy.
2. Allows **workflow_dispatch** to re-run check + deploy after the runner is online (no extra commit required).
3. Adds `deploy/vps/install-actions-runner.sh` and `actions-runner-digeratiexperts-site.service` so the runner stays up across reboots.

## Why

Committed ≠ deployed. Green GitHub-hosted CI is not a production release.

## What this environment cannot do

No VPS SSH key is present (`~/.ssh/de_cursor_ed25519` missing). Runner list/register APIs return 403. Starting the runner on `192.227.158.46` still needs DE: either provide `DE_CURSOR_SSH_KEY`, or run the install script on the VPS. Once the runner is online, the **already-queued** #87 deploy should start without another merge.

## Tests

Documentation + workflow YAML only. Did not SSH. Did not deploy. Did not archive anything.

## Human input

- Start or install the self-hosted runner on de-vps (labels `self-hosted`, `Linux`, `X64`)
- Do not rotate app secrets
- Leave Intelligence Hub `:3100` alone
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b286a545-0bfc-4e43-a400-f13e828623d4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b286a545-0bfc-4e43-a400-f13e828623d4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

