### PR TITLE
Harden DE runner fleet and pin website production runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,14 +86,14 @@ jobs:
           BASE_URL=http://127.0.0.1:3300 npm run smoke:public
 
   # Production is a CyberPanel/OpenLiteSpeed VPS, not a Replit deployment.
-  # A self-hosted runner is allowed to deploy only when it proves it is on the
-  # canonical DE production host. This permanently replaces the broken
-  # cron/webhook assumption with an explicit, fail-closed release path.
+  # This job is pinned to a repo-scoped production runner. Generic Linux
+  # self-hosted runners (RackNerd security runner, Zorin laptop, etc.) are not
+  # eligible, preventing accidental cross-project execution.
   deploy-production:
     name: Deploy and verify production VPS
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: check-test-build
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, Linux, X64, de-production, website-prod]
     timeout-minutes: 30
 
     steps:
@@ -129,7 +129,7 @@ jobs:
           elif sudo -n -u diger7051 true 2>/dev/null; then
             echo "DE_DEPLOY_AS=sudo-site-user" >> "$GITHUB_ENV"
           else
-            echo "::error::Runner is on the production VPS but cannot execute as diger7051. Grant only this runner user passwordless sudo-as-diger7051 for the canonical deploy command; do not grant NOPASSWD: ALL."
+            echo "::error::Runner is on the production VPS but cannot execute as diger7051. Use scripts/setup-github-runner.sh with RUNNER_USER=diger7051, or grant only the required sudo-as-diger7051 deployment command."
             exit 1
           fi
 

--- a/docs/GITHUB-RUNNERS.md
+++ b/docs/GITHUB-RUNNERS.md
@@ -1,0 +1,88 @@
+# Digerati Experts GitHub Runner Fleet
+
+## Why runners are repo-scoped
+
+The DE repositories are currently owned by the `digeratiexperts` GitHub **user account**. A self-hosted runner registered to one repository is not automatically available to the other repositories. The RackNerd runner originally registered for `vulnerability-management` therefore cannot satisfy a `digeratiexperts-site` job.
+
+One physical Linux host may run multiple isolated runner services. Each service gets its own install directory, repository registration, name, labels, work directory, and systemd service.
+
+## Canonical roles
+
+| Repository | Role label | Intended host | Purpose |
+| --- | --- | --- | --- |
+| `digeratiexperts/digeratiexperts-site` | `website-prod` + `de-production` | canonical website VPS | production website deploy only |
+| `digeratiexperts/Intelligence-Hub` | `hub-prod` + `de-production` | Intelligence Hub VPS | future explicit Hub deployment/ops jobs |
+| `digeratiexperts/vulnerability-management` | `security-runner` | RackNerd/Wazuh security VPS | Wazuh/security/local diagnostics |
+| development repos | `de-dev` | Zorin laptop or other workstation | optional development/heavy test jobs |
+
+Do not use only `[self-hosted, Linux, X64]` for privileged production jobs. Role labels prevent a laptop or unrelated VPS from accepting a production deployment.
+
+## Website production runner
+
+Run on the canonical website VPS. The recommended runner account is `diger7051`, because the production release script is already designed to run as that site user.
+
+```bash
+cd /home/digeratiexperts.com/current
+chmod +x scripts/setup-github-runner.sh
+
+# Option A: gh is authenticated with repository-admin permission
+sudo -E RUNNER_USER=diger7051 ./scripts/setup-github-runner.sh
+
+# Option B: use the short-lived token from:
+# GitHub > digeratiexperts-site > Settings > Actions > Runners > New self-hosted runner
+sudo -E RUNNER_TOKEN='SHORT_LIVED_TOKEN' RUNNER_USER=diger7051 ./scripts/setup-github-runner.sh
+```
+
+Expected labels:
+
+```text
+self-hosted
+Linux
+X64
+de-production
+website-prod
+```
+
+The bootstrap installs the runner as a systemd service so it returns after reboot without an open terminal.
+
+## Multiple runners on one host
+
+Use a different `RUNNER_ROLE`, labels, and directory for each repo registration. Never reuse one runner directory for multiple repositories.
+
+Example pattern:
+
+```bash
+REPO=digeratiexperts/example \
+RUNNER_ROLE=de-dev \
+RUNNER_LABELS=de-dev,zorin \
+RUNNER_USER="$USER" \
+RUNNER_ROOT="$HOME/.local/github-runners" \
+RUNNER_TOKEN='SHORT_LIVED_TOKEN' \
+./scripts/setup-github-runner.sh
+```
+
+## Security rules
+
+1. Production deployment runners are not general-purpose development runners.
+2. Public pull-request validation stays on GitHub-hosted runners.
+3. Self-hosted production jobs must be restricted to trusted push/dispatch events and exact role labels.
+4. Runner registration tokens are short-lived and must never be committed.
+5. Do not grant a runner `NOPASSWD: ALL`.
+6. Do not place production secrets in repository files or runner workspaces.
+7. Each production job must still verify the expected host filesystem/service before making changes.
+
+## Recovery checklist
+
+If a job remains `queued`:
+
+1. Confirm its requested labels match a registered runner for **that repository**.
+2. On the runner host, check the runner service:
+
+```bash
+systemctl list-units 'actions.runner.*' --all
+systemctl status 'actions.runner.*' --no-pager
+```
+
+3. In GitHub: **Settings > Actions > Runners** and confirm the runner is `Idle` or `Active`, not `Offline`.
+4. If absent/offline, rerun `scripts/setup-github-runner.sh` with a fresh registration token.
+5. Do not weaken `runs-on` labels just to make a queued production deployment execute on an unrelated machine.

--- a/scripts/setup-github-runner.sh
+++ b/scripts/setup-github-runner.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# Persistent, repo-scoped GitHub Actions runner bootstrap for Digerati Experts.
+# Safe defaults target the production website VPS. The registration token is
+# never stored by this script; pass RUNNER_TOKEN or authenticate `gh` with repo
+# admin permission so a short-lived token can be requested at runtime.
+
+REPO="${REPO:-digeratiexperts/digeratiexperts-site}"
+REPO_URL="https://github.com/${REPO}"
+RUNNER_ROLE="${RUNNER_ROLE:-website-prod}"
+RUNNER_LABELS="${RUNNER_LABELS:-de-production,website-prod}"
+RUNNER_NAME="${RUNNER_NAME:-$(hostname -s)-${RUNNER_ROLE}}"
+RUNNER_USER="${RUNNER_USER:-diger7051}"
+RUNNER_ROOT="${RUNNER_ROOT:-/opt/github-runners}"
+RUNNER_DIR="${RUNNER_DIR:-${RUNNER_ROOT}/${REPO##*/}-${RUNNER_ROLE}}"
+WORK_DIR="${WORK_DIR:-_work}"
+
+log() { printf '[de-runner] %s\n' "$*"; }
+die() { printf '[de-runner] ERROR: %s\n' "$*" >&2; exit 1; }
+
+[[ "$(uname -s)" == "Linux" ]] || die "This bootstrap currently supports Linux only."
+[[ "$(uname -m)" =~ ^(x86_64|amd64)$ ]] || die "Expected x86_64/amd64 host."
+
+if [[ "$RUNNER_ROLE" == "website-prod" ]]; then
+  [[ -d /home/digeratiexperts.com ]] || die "website-prod must run on the canonical website VPS (/home/digeratiexperts.com missing)."
+  systemctl show -p LoadState --value digeratiexperts-site 2>/dev/null | grep -qx loaded \
+    || die "website-prod requires the digeratiexperts-site systemd unit on this host."
+fi
+
+if [[ $EUID -ne 0 ]]; then
+  command -v sudo >/dev/null 2>&1 || die "Run as root or install sudo."
+  SUDO=sudo
+else
+  SUDO=""
+fi
+
+id "$RUNNER_USER" >/dev/null 2>&1 || die "Runner user '$RUNNER_USER' does not exist."
+
+get_token() {
+  if [[ -n "${RUNNER_TOKEN:-}" ]]; then
+    printf '%s' "$RUNNER_TOKEN"
+    return 0
+  fi
+  if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+    gh api --method POST "repos/${REPO}/actions/runners/registration-token" --jq .token
+    return 0
+  fi
+  return 1
+}
+
+TOKEN="$(get_token || true)"
+[[ -n "$TOKEN" ]] || die "No registration token. Set RUNNER_TOKEN to the short-lived token from GitHub > Settings > Actions > Runners > New self-hosted runner, or authenticate gh with repo admin access."
+
+command -v curl >/dev/null 2>&1 || die "curl is required."
+command -v tar >/dev/null 2>&1 || die "tar is required."
+
+VERSION="${RUNNER_VERSION:-}"
+if [[ -z "$VERSION" ]]; then
+  VERSION="$(curl -fsSL https://api.github.com/repos/actions/runner/releases/latest | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p' | head -n1)"
+fi
+[[ -n "$VERSION" ]] || die "Could not determine actions/runner version."
+
+ARCHIVE="actions-runner-linux-x64-${VERSION}.tar.gz"
+URL="https://github.com/actions/runner/releases/download/v${VERSION}/${ARCHIVE}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+log "repo=$REPO role=$RUNNER_ROLE name=$RUNNER_NAME labels=$RUNNER_LABELS"
+log "installing actions/runner v$VERSION in $RUNNER_DIR"
+
+$SUDO mkdir -p "$RUNNER_DIR"
+$SUDO chown -R "$RUNNER_USER":"$(id -gn "$RUNNER_USER")" "$RUNNER_DIR"
+
+curl -fL --retry 3 --retry-delay 2 "$URL" -o "$TMP/$ARCHIVE"
+$SUDO -u "$RUNNER_USER" tar -xzf "$TMP/$ARCHIVE" -C "$RUNNER_DIR"
+
+cd "$RUNNER_DIR"
+
+# Dependencies are additive and distribution-aware in the upstream helper.
+$SUDO ./bin/installdependencies.sh >/dev/null 2>&1 || true
+
+# Stop an existing service before reconfiguration. svc.sh may not yet be installed.
+$SUDO ./svc.sh stop >/dev/null 2>&1 || true
+
+# --replace makes repeated runs idempotent for the same runner name.
+$SUDO -u "$RUNNER_USER" ./config.sh \
+  --unattended \
+  --replace \
+  --url "$REPO_URL" \
+  --token "$TOKEN" \
+  --name "$RUNNER_NAME" \
+  --labels "$RUNNER_LABELS" \
+  --work "$WORK_DIR"
+
+$SUDO ./svc.sh install "$RUNNER_USER" >/dev/null 2>&1 || true
+$SUDO ./svc.sh start
+
+SERVICE_NAME="$(basename "$(ls -1 /etc/systemd/system/actions.runner.*.service 2>/dev/null | grep -F "${REPO##*/}" | tail -n1)" 2>/dev/null || true)"
+
+log "runner configured and service started"
+[[ -n "$SERVICE_NAME" ]] && log "service=$SERVICE_NAME"
+$SUDO ./svc.sh status || true
+
+cat <<EOF
+
+Runner fleet result
+  Repository : $REPO
+  Name       : $RUNNER_NAME
+  Labels     : self-hosted, Linux, X64, $RUNNER_LABELS
+  User       : $RUNNER_USER
+  Directory  : $RUNNER_DIR
+
+This runner is intentionally repo-scoped. Because these DE repositories are
+owned by the digeratiexperts user account, repeat the bootstrap separately for
+each repository that needs a self-hosted runner.
+EOF


### PR DESCRIPTION
Fixes the runner architecture that caused production deploys to queue indefinitely.

- Pins website production deployment to `de-production` + `website-prod`, so generic self-hosted runners/laptops/security hosts cannot receive it.
- Adds an idempotent Linux runner bootstrap that installs a repo-scoped runner as a persistent systemd service.
- Supports either a short-lived registration token or authenticated `gh` token retrieval.
- Fails closed unless `website-prod` is installed on the canonical site VPS.
- Documents the DE runner fleet, per-repo registration requirement, recovery process, and separation of production/dev/security roles.

This does not weaken the existing production-host filesystem/systemd assertions.