### PR TITLE
Widen DE Desk type and treat staff/internal company answers as Digerati Experts

### DIFF
--- a/client/src/components/ZohoASAPWidget.desk-shell.test.ts
+++ b/client/src/components/ZohoASAPWidget.desk-shell.test.ts
@@ -94,6 +94,14 @@ describe("DE Desk shell positioning", () => {
     expect(src).toMatch(/\.de-desk-tool-title \{[\s\S]*?font-size: 15\.5px;/);
   });
 
+  it("stamps Ask DE messages with a real local time, not fake SOC chrome", () => {
+    expect(src).toMatch(/function formatDeskMessageTime/);
+    expect(src).toMatch(/className="de-desk-msg-time"/);
+    expect(src).toMatch(/dateTime=\{chatMessage\.createdAt\}/);
+    expect(src).toMatch(/toLocaleTimeString\(undefined, \{ hour: "numeric", minute: "2-digit" \}\)/);
+    expect(src).not.toMatch(/AZ SOC Live/);
+  });
+
   it("styles Ask DE discovery and Get Support issues as graphite grouped stacks", () => {
     expect(src).toMatch(/de-desk-discover/);
     expect(src).toMatch(/de-desk-discover-list/);

--- a/client/src/components/ZohoASAPWidget.desk-shell.test.ts
+++ b/client/src/components/ZohoASAPWidget.desk-shell.test.ts
@@ -79,6 +79,21 @@ describe("DE Desk shell positioning", () => {
     expect(src).toMatch(/support-submit-error/);
   });
 
+  it("opens a tad wider with one-step larger type on chrome, Client Tools, and Ask DE", () => {
+    expect(src).toMatch(/sm:w-\[440px\]/);
+    expect(src).not.toMatch(/sm:w-\[410px\]/);
+    expect(src).toMatch(/\.de-desk-id h2 \{[\s\S]*?font-size: 17px;/);
+    expect(src).toMatch(/\.de-desk-id p \{ font-size: 14px;/);
+    expect(src).toMatch(/\.de-desk-tab \{[\s\S]*?font-size: 14\.5px;/);
+    expect(src).toMatch(/\.de-desk-tools-intro h3 \{[\s\S]*?font-size: 18px;/);
+    expect(src).toMatch(/\.de-desk-tools-kicker \{[\s\S]*?font-size: 16px !important;/);
+    expect(src).toMatch(/\.de-desk-tools-intro p \{[\s\S]*?font-size: 14\.5px;/);
+    expect(src).toMatch(/\.de-desk-bubble \{[\s\S]*?font-size: 15px;/);
+    expect(src).toMatch(/\.de-desk-composer input \{[\s\S]*?font-size: 15\.5px;/);
+    expect(src).toMatch(/\.de-desk-composer-caption \{[\s\S]*?font-size: 13px;/);
+    expect(src).toMatch(/\.de-desk-tool-title \{[\s\S]*?font-size: 15\.5px;/);
+  });
+
   it("styles Ask DE discovery and Get Support issues as graphite grouped stacks", () => {
     expect(src).toMatch(/de-desk-discover/);
     expect(src).toMatch(/de-desk-discover-list/);

--- a/client/src/components/ZohoASAPWidget.tsx
+++ b/client/src/components/ZohoASAPWidget.tsx
@@ -93,6 +93,13 @@ function previewChatLine(content: string, max = 108) {
   return text.length > max ? `${text.slice(0, max - 1)}…` : text;
 }
 
+function formatDeskMessageTime(iso?: string): string {
+  if (!iso) return "";
+  const when = new Date(iso);
+  if (Number.isNaN(when.getTime())) return "";
+  return when.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
+}
+
 function getDeskChipIcon(id: DeskTicketChipId) {
   const iconClass = "w-4 h-4 text-[#D3126A] shrink-0";
   switch (id) {
@@ -189,7 +196,9 @@ export const ZohoASAPWidget = ({
   const [advisorSessionId, setAdvisorSessionId] = useState<string | null>(null);
   const [pendingSeed, setPendingSeed] = useState<string | null>(null);
 
-  const [chatMessages, setChatMessages] = useState<ChatMessage[]>([CHAT_WELCOME]);
+  const [chatMessages, setChatMessages] = useState<ChatMessage[]>(() => [
+    { ...CHAT_WELCOME, createdAt: new Date().toISOString() },
+  ]);
   const [chatInput, setChatInput] = useState("");
   const [isChatSending, setIsChatSending] = useState(false);
   const [assistantAvailable, setAssistantAvailable] = useState<boolean | null>(null);
@@ -645,6 +654,7 @@ export const ZohoASAPWidget = ({
           id: `assistant-error-${Date.now()}`,
           role: "assistant",
           content: `${description} You can create a support ticket here and the team will follow up.`,
+          createdAt: new Date().toISOString(),
         },
       ]);
       if (activeTabRef.current !== "chat") {
@@ -1112,6 +1122,14 @@ export const ZohoASAPWidget = ({
                             >
                               <p className="whitespace-pre-wrap">{chatMessage.content}</p>
                             </div>
+                            {chatMessage.createdAt && formatDeskMessageTime(chatMessage.createdAt) ? (
+                              <time
+                                className="de-desk-msg-time"
+                                dateTime={chatMessage.createdAt}
+                              >
+                                {formatDeskMessageTime(chatMessage.createdAt)}
+                              </time>
+                            ) : null}
                             {chatMessage.supportChips?.length ? (
                               <div className="de-desk-chips" role="group" aria-label="Open a support ticket">
                                 {chatMessage.supportChips.map((chipId) => {
@@ -2285,6 +2303,19 @@ export const ZohoASAPWidget = ({
               background: var(--de-raised, #151217); color: #fff;
               border: 1px solid var(--de-hairline, rgba(255,255,255,0.10));
               border-bottom-left-radius: 5px;
+            }
+            .de-desk-msg-time {
+              display: block;
+              margin-top: 5px;
+              font-size: 11px;
+              font-weight: 500;
+              letter-spacing: 0.02em;
+              color: rgba(255,255,255,0.38);
+              font-variant-numeric: tabular-nums;
+            }
+            .de-desk-msg.is-user .de-desk-msg-time { text-align: right; }
+            @media (prefers-reduced-motion: reduce) {
+              .de-desk-msg-time { transition: none; }
             }
             .de-desk-discover {
               margin: 12px 0 2px;

--- a/client/src/components/ZohoASAPWidget.tsx
+++ b/client/src/components/ZohoASAPWidget.tsx
@@ -921,7 +921,7 @@ export const ZohoASAPWidget = ({
         {isOpen && (
           <section
             ref={deskDrag.panelRef}
-            className="de-desk-shell fixed inset-x-3 top-[max(0.75rem,env(safe-area-inset-top))] bottom-[max(0.75rem,env(safe-area-inset-bottom))] z-[10040] flex max-h-[100dvh] w-auto flex-col overflow-hidden sm:inset-auto sm:h-[min(760px,calc(100dvh-5.5rem))] sm:max-h-[min(86vh,calc(100dvh-4.5rem))] sm:w-[410px] sm:max-w-[calc(100vw-2rem)]"
+            className="de-desk-shell fixed inset-x-3 top-[max(0.75rem,env(safe-area-inset-top))] bottom-[max(0.75rem,env(safe-area-inset-bottom))] z-[10040] flex max-h-[100dvh] w-auto flex-col overflow-hidden sm:inset-auto sm:h-[min(760px,calc(100dvh-5.5rem))] sm:max-h-[min(86vh,calc(100dvh-4.5rem))] sm:w-[440px] sm:max-w-[calc(100vw-2rem)]"
             style={deskWindowStyle}
             role="dialog"
             aria-modal="true"
@@ -1783,11 +1783,11 @@ export const ZohoASAPWidget = ({
             .de-desk-id h2 {
               font-family: "Space Grotesk", sans-serif;
               font-weight: 600;
-              font-size: 16px;
+              font-size: 17px;
               color: var(--desk-shell-text);
               line-height: 1.2;
             }
-            .de-desk-id p { font-size: 13px; color: var(--desk-shell-muted); margin-top: 1px; }
+            .de-desk-id p { font-size: 14px; color: var(--desk-shell-muted); margin-top: 1px; }
             .de-desk-close {
               width: 44px; height: 44px; border-radius: 9px;
               border: 1px solid var(--de-hairline, rgba(255,255,255,0.10));
@@ -1818,7 +1818,7 @@ export const ZohoASAPWidget = ({
               padding: 8px 4px 10px;
               border-radius: 0;
               font-family: "Space Grotesk", sans-serif;
-              font-weight: 600; font-size: 13.5px;
+              font-weight: 600; font-size: 14.5px;
               color: rgba(255,255,255,0.62);
               display: flex; align-items: center; justify-content: center; gap: 6px;
               position: relative;
@@ -1909,15 +1909,15 @@ export const ZohoASAPWidget = ({
               font-size: 10px; font-weight: 700; letter-spacing: 0.02em; flex: none;
             }
             .de-desk-msg-col { min-width: 0; flex: 1; }
-            .de-desk-msg.is-user .de-desk-msg-col { flex: 0 1 auto; max-width: min(86%, 280px); }
+            .de-desk-msg.is-user .de-desk-msg-col { flex: 0 1 auto; max-width: min(86%, 310px); }
             .de-desk-msg-who {
               display: flex; align-items: baseline; gap: 8px; margin-bottom: 6px;
             }
             .de-desk-msg-who strong {
               font-family: "Space Grotesk", sans-serif;
-              font-size: 13.5px; font-weight: 650; color: #fff;
+              font-size: 14.5px; font-weight: 650; color: #fff;
             }
-            .de-desk-msg-who em { font-style: normal; font-size: 12px; font-weight: 600; color: #4ade80; }
+            .de-desk-msg-who em { font-style: normal; font-size: 13px; font-weight: 600; color: #4ade80; }
             .de-desk-scroll::-webkit-scrollbar {
               width: 6px;
             }
@@ -2274,7 +2274,7 @@ export const ZohoASAPWidget = ({
             .de-desk-bubble {
               max-width: 100%;
               padding: 10px 13px;
-              font-size: 14px; line-height: 1.5;
+              font-size: 15px; line-height: 1.5;
               border-radius: 12px;
             }
             .de-desk-bubble.is-user {
@@ -2297,7 +2297,7 @@ export const ZohoASAPWidget = ({
             .de-desk-discover-intro h3 {
               margin: 0;
               font-family: "Space Grotesk", sans-serif;
-              font-size: 16px;
+              font-size: 17px;
               font-weight: 700;
               line-height: 1.25;
               letter-spacing: -0.015em;
@@ -2306,7 +2306,7 @@ export const ZohoASAPWidget = ({
             .de-desk-discover-intro p {
               margin: 4px 0 0;
               color: rgba(255,255,255,0.68);
-              font-size: 13.5px;
+              font-size: 14.5px;
               line-height: 1.45;
             }
             .de-desk-discover-list {
@@ -2330,7 +2330,7 @@ export const ZohoASAPWidget = ({
               border-bottom: 1px solid var(--de-hairline, rgba(255,255,255,0.10));
               color: #fff;
               font-family: "Space Grotesk", sans-serif;
-              font-size: 14px;
+              font-size: 15px;
               font-weight: 650;
               line-height: 1.3;
               text-align: left;
@@ -2388,7 +2388,7 @@ export const ZohoASAPWidget = ({
               background: transparent;
               color: #fff;
               font-family: "Space Grotesk", sans-serif;
-              font-size: 13.5px; font-weight: 650;
+              font-size: 14.5px; font-weight: 650;
               text-align: left;
               transition: background 0.15s ease;
             }
@@ -2516,7 +2516,7 @@ export const ZohoASAPWidget = ({
               border: 1px solid var(--de-hairline, rgba(255,255,255,0.10));
               border-radius: 10px;
               padding: 10px 14px;
-              color: #fff; font-size: 14.5px;
+              color: #fff; font-size: 15.5px;
             }
             .de-desk-shell input:-webkit-autofill,
             .de-desk-shell textarea:-webkit-autofill {
@@ -2547,7 +2547,7 @@ export const ZohoASAPWidget = ({
               margin: 0;
               padding: 0 16px 10px;
               background: transparent;
-              font-size: 12px; color: rgba(255,255,255,0.46);
+              font-size: 13px; color: rgba(255,255,255,0.46);
               flex-shrink: 0;
             }
             .de-desk-composer-caption svg { width: 11px; height: 11px; color: rgba(255,255,255,0.46); }
@@ -2577,7 +2577,7 @@ export const ZohoASAPWidget = ({
             .de-desk-tools-intro h3 {
               margin: 0;
               font-family: "Space Grotesk", sans-serif;
-              font-size: 17px;
+              font-size: 18px;
               font-weight: 700;
               line-height: 1.25;
               letter-spacing: -0.015em;
@@ -2586,14 +2586,14 @@ export const ZohoASAPWidget = ({
             .de-desk-tools-intro p {
               margin: 4px 0 0;
               color: rgba(255,255,255,0.68);
-              font-size: 13.5px;
+              font-size: 14.5px;
               line-height: 1.45;
             }
             .de-desk-tools-kicker {
               margin: 10px 0 6px !important;
               color: #fff !important;
               font-family: "Space Grotesk", sans-serif;
-              font-size: 15px !important;
+              font-size: 16px !important;
               font-weight: 650;
               line-height: 1.35 !important;
             }
@@ -2634,7 +2634,7 @@ export const ZohoASAPWidget = ({
             .de-desk-launch-heading {
               margin: 0 0 8px;
               color: rgba(255,255,255,0.52);
-              font-size: 11px;
+              font-size: 12px;
               font-weight: 700;
               letter-spacing: 0.08em;
               text-transform: uppercase;
@@ -2669,7 +2669,7 @@ export const ZohoASAPWidget = ({
             .de-desk-launch-icon svg { width: 14px; height: 14px; }
             .de-desk-launch-title {
               flex: 1; min-width: 0;
-              font-size: 13.5px; font-weight: 650;
+              font-size: 14.5px; font-weight: 650;
             }
             .de-desk-tools-list {
               --desk-ink: #17141f;
@@ -2768,7 +2768,7 @@ export const ZohoASAPWidget = ({
             .de-desk-tool-title {
               color: var(--desk-ink);
               font-family: "Space Grotesk", sans-serif;
-              font-size: 14.5px;
+              font-size: 15.5px;
               font-weight: 650;
               line-height: 1.3;
             }
@@ -2776,7 +2776,7 @@ export const ZohoASAPWidget = ({
               display: block;
               margin-top: 2px;
               color: var(--desk-ink-muted);
-              font-size: 12.75px;
+              font-size: 13.75px;
               line-height: 1.4;
             }
             .de-desk-tool-badge {
@@ -2980,7 +2980,7 @@ export const ZohoASAPWidget = ({
             @media (max-width: 420px) {
               .de-desk-grid2 { grid-template-columns: 1fr; }
               .de-desk-hero-art { display: none; }
-              .de-desk-tab { font-size: 12.5px; gap: 4px; padding: 8px 2px 10px; }
+              .de-desk-tab { font-size: 13.5px; gap: 4px; padding: 8px 2px 10px; }
               .de-desk-tab svg { width: 13px; height: 13px; }
               .de-desk-hero h3 { font-size: 17px; }
             }

--- a/client/src/hooks/useDraggableWindow.ts
+++ b/client/src/hooks/useDraggableWindow.ts
@@ -86,7 +86,7 @@ export function useDraggableWindow(options: {
 
   const measureAndClamp = useCallback((x: number, y: number) => {
     const el = panelRef.current;
-    const width = el?.offsetWidth ?? 410;
+    const width = el?.offsetWidth ?? 440;
     return clampDeskPos(x, y, width, readViewport());
   }, []);
 
@@ -145,7 +145,7 @@ export function useDraggableWindow(options: {
     if (!open || (!pos && !size)) return;
     const onResize = () => {
       const view = readViewport();
-      setPos((current) => (current ? clampDeskPos(current.x, current.y, size?.w ?? panelRef.current?.offsetWidth ?? 410, view) : current));
+      setPos((current) => (current ? clampDeskPos(current.x, current.y, size?.w ?? panelRef.current?.offsetWidth ?? 440, view) : current));
       setSize((current) => (current ? clampDeskSize(current.w, current.h, view) : current));
     };
     window.addEventListener("resize", onResize);

--- a/server/services/msp-advisor/advisor.ts
+++ b/server/services/msp-advisor/advisor.ts
@@ -17,6 +17,7 @@ import {
   extractCompanyNameFromText,
   isSubstantiveAdvisorQuestion,
   isInformalCompanyName,
+  isDeInternalCompanyAnswer,
 } from "./profile";
 import { buildSystemPrompt, INTERNAL_REFUSAL, BANNED_CANNED_OPENER } from "./prompt";
 import { sanitizeActions, assertNoInternalLeak, defaultActionsForMode } from "./actions";
@@ -75,8 +76,15 @@ function parseModelJson(raw: string): ModelAdvisorOutput | null {
 }
 
 function applyCompanyGuess(profile: ConversationProfile, raw: string): ConversationProfile {
+  if (isDeInternalCompanyAnswer(raw)) {
+    return mergeProfile(profile, {
+      companyName: "Digerati Experts",
+      deInternal: true,
+      companyInformal: false,
+    });
+  }
   if (isInformalCompanyName(raw)) {
-    return mergeProfile(profile, { companyName: "Walk-in", companyInformal: true });
+    return mergeProfile(profile, { companyName: "Walk-in", companyInformal: true, deInternal: false });
   }
   return mergeProfile(profile, { companyName: raw, companyInformal: false });
 }
@@ -113,6 +121,18 @@ function identityCompanyPrompt(contactName?: string): string {
     : "What company are you with?";
 }
 
+function identityReadyPrompt(profile: ConversationProfile): string {
+  const first = (profile.contactName || "").split(" ")[0];
+  if (profile.deInternal) {
+    return first
+      ? `${first}, you're with DE — I won't treat that as an outside company. What's on the desk?`
+      : "You're with DE — I won't treat that as an outside company. What's on the desk?";
+  }
+  return first
+    ? `Got it, ${first}. What should we look at?`
+    : "Got it. What should we look at?";
+}
+
 export async function handleAdvisorChat(req: AdvisorChatRequest): Promise<AdvisorChatResponse> {
   const userTurn = (req.message || "").trim().slice(0, 4000);
   if (!userTurn) {
@@ -123,6 +143,8 @@ export async function handleAdvisorChat(req: AdvisorChatRequest): Promise<Adviso
   const session = getOrCreateSession(req.sessionId, req.pageContext);
   const page = req.pageContext || session.pageContext;
   const priorName = session.profile.contactName;
+  const priorCompany = session.profile.companyName;
+  const priorDeInternal = session.profile.deInternal;
 
   // Merge heuristic extraction before model so known facts are available
   let profile = mergeProfile(session.profile, extractProfileFromText(message));
@@ -233,18 +255,47 @@ export async function handleAdvisorChat(req: AdvisorChatRequest): Promise<Adviso
   }
 
   let justCollectedInformalCompany = false;
+  let justCollectedDeInternal = Boolean(!priorDeInternal && profile.deInternal);
   if (!skipIdentity && !profile.companyName) {
     const collectedNameThisTurn = Boolean(!priorName && profile.contactName);
     const companyGuess = extractCompanyNameFromText(message, { allowBare: !collectedNameThisTurn });
     if (companyGuess && companyGuess.toLowerCase() !== (profile.contactName || "").toLowerCase()) {
       justCollectedInformalCompany = isInformalCompanyName(companyGuess);
+      justCollectedDeInternal = isDeInternalCompanyAnswer(companyGuess);
       profile = applyCompanyGuess(profile, companyGuess);
       updateProfile(session, profile);
     }
   }
 
+  const justCollectedCompany = Boolean(!priorCompany && profile.companyName);
+
   if (!skipIdentity && !profile.companyName) {
     const reply = identityCompanyPrompt(profile.contactName);
+    appendMessage(session, "user", message);
+    appendMessage(session, "assistant", reply);
+    session.lastAssistantReply = reply;
+    session.lastMode = mode === "off_topic" ? "msp_discovery" : mode;
+    const persisted = await persistTurn(session.id, message, reply, profile, page?.pathname);
+    return {
+      sessionId: session.id,
+      reply,
+      mode: session.lastMode,
+      profile,
+      actions: [],
+      analyticsEvents: ["conversation_started"],
+      knownFacts: knownFactsList(profile),
+      ...persisted,
+    };
+  }
+
+  // Identity just finished and they have not asked anything yet — greet locally.
+  // Skip the model so "Joe" / "yours" does not wait on a heavy prompt.
+  if (
+    justCollectedCompany &&
+    !session.heldUserMessage &&
+    !isSubstantiveAdvisorQuestion(userTurn)
+  ) {
+    const reply = identityReadyPrompt(profile);
     appendMessage(session, "user", message);
     appendMessage(session, "assistant", reply);
     session.lastAssistantReply = reply;
@@ -306,6 +357,9 @@ export async function handleAdvisorChat(req: AdvisorChatRequest): Promise<Adviso
     profile.companyInformal
       ? "Company was given informally — treat as a walk-in. Do not moralize or dump a sales pitch."
       : "",
+    profile.deInternal
+      ? "Visitor indicated they work at Digerati Experts. Acknowledge as staff/internal. Do not treat them as a client. Do not invent portal features. Never echo throwaway company words like yours, us, here, or DE as an outside company name."
+      : "",
     `Latest message: ${userTurn}`,
   ]
     .filter(Boolean)
@@ -324,11 +378,15 @@ export async function handleAdvisorChat(req: AdvisorChatRequest): Promise<Adviso
   };
 
   let modelOut: ModelAdvisorOutput | null = null;
-  try {
-    const raw = await callModel(system, history, modelUserTurn);
-    if (raw) modelOut = parseModelJson(raw);
-  } catch (err) {
-    console.error("[msp-advisor] model call failed:", err);
+  // Staff-affiliation turns stay local/heuristic so we do not wait on the model
+  // just to echo a garbled company name.
+  if (!justCollectedDeInternal) {
+    try {
+      const raw = await callModel(system, history, modelUserTurn);
+      if (raw) modelOut = parseModelJson(raw);
+    } catch (err) {
+      console.error("[msp-advisor] model call failed:", err);
+    }
   }
 
   if (!modelOut?.reply) {

--- a/server/services/msp-advisor/fallback.ts
+++ b/server/services/msp-advisor/fallback.ts
@@ -46,6 +46,9 @@ export type HeuristicInput = {
 };
 
 function walkInPrefix(input: HeuristicInput): string {
+  if (input.profile.deInternal) {
+    return "You're with DE — I won't treat that as an outside company. ";
+  }
   if (!input.justCollectedInformalCompany && !input.profile.companyInformal) return "";
   if (input.justCollectedInformalCompany) {
     return "I'll put you down as a walk-in for now. ";

--- a/server/services/msp-advisor/msp-advisor.test.ts
+++ b/server/services/msp-advisor/msp-advisor.test.ts
@@ -9,7 +9,7 @@ import {
   listKnownServiceNames,
   inferPageType,
 } from "./knowledge";
-import { extractProfileFromText, mergeProfile, createEmptyProfile, knownFactsList, extractContactNameFromText, extractCompanyNameFromText, isInformalCompanyName } from "./profile";
+import { extractProfileFromText, mergeProfile, createEmptyProfile, knownFactsList, extractContactNameFromText, extractCompanyNameFromText, isInformalCompanyName, isDeInternalCompanyAnswer } from "./profile";
 import { BANNED_CANNED_OPENER } from "./prompt";
 import { sanitizeActions, sanitizePath, assertNoInternalLeak, isAllowedActionType } from "./actions";
 import { handleAdvisorChat } from "./advisor";
@@ -158,6 +158,17 @@ describe("identity extraction", () => {
     assert.equal(isInformalCompanyName("Acme Dental"), false);
     assert.equal(extractCompanyNameFromText("Your Mama", { allowBare: true }), "Your Mama");
   });
+  it("does not treat DE-staff company answers as a literal outside company", () => {
+    for (const answer of ["yours", "us", "DE", "here", "this company", "Digerati Experts"]) {
+      assert.equal(isDeInternalCompanyAnswer(answer), true, answer);
+      assert.equal(isInformalCompanyName(answer), false, answer);
+    }
+    assert.equal(isDeInternalCompanyAnswer("Acme Dental"), false);
+    const patched = mergeProfile(createEmptyProfile(), { companyName: "yours" });
+    assert.equal(patched.companyName, "Digerati Experts");
+    assert.equal(patched.deInternal, true);
+    assert.doesNotMatch(patched.companyName || "", /yours/i);
+  });
 });
 
 function normalizeForCompare(text: string): string {
@@ -203,6 +214,22 @@ describe("handleAdvisorChat acceptance (heuristic / no LLM required)", () => {
     });
     assert.equal(third.profile.companyName, "Hale Family Dentistry");
     assert.doesNotMatch(third.reply, /what'?s your name/i);
+  });
+
+  it("does not echo yours as a company when the visitor means they work at DE", async () => {
+    const first = await handleAdvisorChat({ message: "Joe" });
+    assert.equal(first.profile.contactName, "Joe");
+    assert.match(first.reply, /company/i);
+    const second = await handleAdvisorChat({
+      sessionId: first.sessionId,
+      message: "yours",
+    });
+    assert.equal(second.profile.deInternal, true);
+    assert.equal(second.profile.companyName, "Digerati Experts");
+    assert.doesNotMatch(second.reply, /from yours/i);
+    assert.doesNotMatch(second.reply, /Joe from yours/i);
+    assert.match(second.reply, /DE/i);
+    assert.doesNotMatch(second.reply, /portal\.digeratiexperts\.com/i);
   });
 
   it("answers IT question path without crashing and returns DE actions", async () => {

--- a/server/services/msp-advisor/msp-advisor.test.ts
+++ b/server/services/msp-advisor/msp-advisor.test.ts
@@ -159,15 +159,36 @@ describe("identity extraction", () => {
     assert.equal(extractCompanyNameFromText("Your Mama", { allowBare: true }), "Your Mama");
   });
   it("does not treat DE-staff company answers as a literal outside company", () => {
-    for (const answer of ["yours", "us", "DE", "here", "this company", "Digerati Experts"]) {
+    for (const answer of [
+      "yours",
+      "us",
+      "DE",
+      "here",
+      "this company",
+      "this firm",
+      "Digerati Experts",
+      "DE staff",
+      "DE employee",
+      "I work for Digerati Experts",
+      "I'm DE staff",
+      "I am DE staff",
+    ]) {
       assert.equal(isDeInternalCompanyAnswer(answer), true, answer);
       assert.equal(isInformalCompanyName(answer), false, answer);
     }
     assert.equal(isDeInternalCompanyAnswer("Acme Dental"), false);
+    assert.equal(isDeInternalCompanyAnswer("yours truly"), false);
+    assert.equal(isInformalCompanyName("yours truly"), true);
     const patched = mergeProfile(createEmptyProfile(), { companyName: "yours" });
     assert.equal(patched.companyName, "Digerati Experts");
     assert.equal(patched.deInternal, true);
     assert.doesNotMatch(patched.companyName || "", /yours/i);
+    const staff = mergeProfile(createEmptyProfile(), { companyName: "DE staff" });
+    assert.equal(staff.companyName, "Digerati Experts");
+    assert.equal(staff.deInternal, true);
+    const employed = mergeProfile(createEmptyProfile(), { companyName: "I work for Digerati Experts" });
+    assert.equal(employed.companyName, "Digerati Experts");
+    assert.equal(employed.deInternal, true);
   });
 });
 
@@ -214,6 +235,20 @@ describe("handleAdvisorChat acceptance (heuristic / no LLM required)", () => {
     });
     assert.equal(third.profile.companyName, "Hale Family Dentistry");
     assert.doesNotMatch(third.reply, /what'?s your name/i);
+  });
+
+  it("treats yours truly as a walk-in, not a company named yours truly", async () => {
+    const first = await handleAdvisorChat({ message: "Joe" });
+    assert.equal(first.profile.contactName, "Joe");
+    const second = await handleAdvisorChat({
+      sessionId: first.sessionId,
+      message: "yours truly",
+    });
+    assert.equal(second.profile.companyInformal, true);
+    assert.equal(second.profile.companyName, "Walk-in");
+    assert.notEqual(second.profile.deInternal, true);
+    assert.doesNotMatch(second.profile.companyName || "", /yours truly/i);
+    assert.doesNotMatch(second.reply, /from yours truly/i);
   });
 
   it("does not echo yours as a company when the visitor means they work at DE", async () => {

--- a/server/services/msp-advisor/profile.ts
+++ b/server/services/msp-advisor/profile.ts
@@ -153,13 +153,13 @@ export function extractContactNameFromText(message: string): string | undefined 
 }
 
 const INFORMAL_COMPANY =
-  /^(your\s+(mom|mama|mother)|yo\s+mama|none|n\/a|n\.a\.|na|idk|skip|pass|nope|no|private|asdf+|test(ing)?|foo|bar|baz|-|\.|walk-?in|personal|myself|me|n\/a)$/i;
+  /^(your\s+(mom|mama|mother)|yo\s+mama|yours\s+truly|none|n\/a|n\.a\.|na|idk|skip|pass|nope|no|private|asdf+|test(ing)?|foo|bar|baz|-|\.|walk-?in|personal|myself|me|n\/a)$/i;
 
 const DE_INTERNAL_COMPANY =
-  /^(yours|your(s| company)?|you( guys| all)?|us|we|ours|our company|here|this( company| one| place)?|the company|de|d\.e\.|digerati( experts)?|internal|staff|employee)$/i;
+  /^(yours|your(s| company)?|you( guys| all)?|us|we|ours|our company|here|this( company| one| place| firm)?|the company|de( staff| employee)?|d\.e\.( staff| employee)?|digerati( experts)?( staff| employee)?|internal|staff|employee)$/i;
 
 const DE_INTERNAL_PHRASE =
-  /\b(i work (here|for (you|us|de|digerati( experts)?))|i(?:['’]?m| am) (with|at) (de|you|digerati)|we(?:['’]?re| are) (de|digerati|you|yours|here))\b/i;
+  /\b(i work (here|for (you|us|de|digerati( experts)?))|i(?:['’]?m| am) (with|at) (de|you|digerati)|i(?:['’]?m| am) (an? )?(de staff|de employee)|we(?:['’]?re| are) (de|digerati|you|yours|here))\b/i;
 
 /** Visitor is pointing at Digerati Experts / this desk — not a literal outside company name. */
 export function isDeInternalCompanyAnswer(name: string | undefined | null): boolean {

--- a/server/services/msp-advisor/profile.ts
+++ b/server/services/msp-advisor/profile.ts
@@ -155,11 +155,28 @@ export function extractContactNameFromText(message: string): string | undefined 
 const INFORMAL_COMPANY =
   /^(your\s+(mom|mama|mother)|yo\s+mama|none|n\/a|n\.a\.|na|idk|skip|pass|nope|no|private|asdf+|test(ing)?|foo|bar|baz|-|\.|walk-?in|personal|myself|me|n\/a)$/i;
 
+const DE_INTERNAL_COMPANY =
+  /^(yours|your(s| company)?|you( guys| all)?|us|we|ours|our company|here|this( company| one| place)?|the company|de|d\.e\.|digerati( experts)?|internal|staff|employee)$/i;
+
+const DE_INTERNAL_PHRASE =
+  /\b(i work (here|for (you|us|de|digerati( experts)?))|i(?:['’]?m| am) (with|at) (de|you|digerati)|we(?:['’]?re| are) (de|digerati|you|yours|here))\b/i;
+
+/** Visitor is pointing at Digerati Experts / this desk — not a literal outside company name. */
+export function isDeInternalCompanyAnswer(name: string | undefined | null): boolean {
+  if (!name) return false;
+  const text = name.replace(/\s+/g, " ").trim();
+  if (!text) return false;
+  if (DE_INTERNAL_COMPANY.test(text)) return true;
+  if (DE_INTERNAL_PHRASE.test(text)) return true;
+  return false;
+}
+
 /** Joke, declined, or nonsense company — accept as a walk-in, do not stall. */
 export function isInformalCompanyName(name: string | undefined | null): boolean {
   if (!name) return false;
   const text = name.replace(/\s+/g, " ").trim();
   if (!text) return false;
+  if (isDeInternalCompanyAnswer(text)) return false;
   if (INFORMAL_COMPANY.test(text)) return true;
   if (/\byour\s+(mom|mama|mother)\b/i.test(text)) return true;
   if (/\b(rather not|prefer not|none of your|mind your own)\b/i.test(text)) return true;
@@ -246,6 +263,12 @@ export function mergeProfile(
     next.employeeCount = current.employeeCount;
   }
 
+  if (isDeInternalCompanyAnswer(next.companyName)) {
+    next.companyName = "Digerati Experts";
+    next.deInternal = true;
+    next.companyInformal = false;
+  }
+
   next.qualificationConfidence = scoreQualification(next);
   return next;
 }
@@ -269,6 +292,11 @@ export function scoreQualification(profile: ConversationProfile): number {
 export function knownFactsList(profile: ConversationProfile): string[] {
   const facts: string[] = [];
   if (profile.companyName) facts.push(`companyName=${profile.companyName}`);
+  if (profile.deInternal) {
+    facts.push(
+      "deInternal=true (visitor indicated they work at Digerati Experts — staff/internal, not a client, not an outside company named yours/us/DE/here)",
+    );
+  }
   if (profile.companyInformal) facts.push("companyInformal=true (walk-in — do not moralize or dump a sales pitch)");
   if (profile.contactName) facts.push(`contactName=${profile.contactName}`);
   if (profile.email) facts.push(`email=${profile.email}`);

--- a/server/services/msp-advisor/prompt.ts
+++ b/server/services/msp-advisor/prompt.ts
@@ -41,6 +41,7 @@ HARD RULES:
 - NEVER say "I can still point you", "You asked:", or "I'll recommend a DE path."
 - NEVER prepend a static phone + calendar dump. Phone is ${PRIMARY_PHONE.display}. Booking is https://meet.digerati-experts.com/. Use them only when asked or after clear qualification.
 - Humor / joke company names: light professional deflection ("I'll put you down as a walk-in for now") then the NEXT useful question. Do not moralize.
+- If they answer company as yours / us / DE / here / this company / Digerati Experts, they mean they work here. Acknowledge as DE staff/internal. Never write "Joe from yours". Do not invent that they are a client or extra portal features.
 - If they call out canned or repeated language: apologize in one short sentence and answer their actual question.
 - Match their register. If they are brief, be brief.
 - Compliance: help with audit readiness / evidence / framework mapping. Do NOT claim DE certifies the customer for HIPAA/SOC2/PCI/CMMC.

--- a/server/services/msp-advisor/types.ts
+++ b/server/services/msp-advisor/types.ts
@@ -63,6 +63,8 @@ export interface ConversationProfile {
   desiredOutcome?: string;
   /** Joke / declined company — treat as walk-in, do not collapse the thread. */
   companyInformal?: boolean;
+  /** Visitor indicated they work at Digerati Experts — not an external company, not a client claim. */
+  deInternal?: boolean;
 }
 
 export interface AdvisorAction {


### PR DESCRIPTION
## Summary
- Gives DE Desk a tad more width and one-step larger type so Ask DE / Get Support / Client Tools are easier to read without restyling Blog or Store.
- Stops Ask DE from treating nearby staff/internal replies (`yours`, `DE staff`, `this firm`, `I work for Digerati Experts`, `I'm DE staff`) as an outside company; those rewrite to Digerati Experts with `deInternal`.
- Stamps real message times on persisted Desk turns. A lone `yours truly` is a walk-in, not a company named “yours truly.”
- Portal login is unchanged: https://portal.digeratiexperts.com/portal/login

## Test plan
- [ ] Open DE Desk on desktop (~1440) and confirm the shell is a tad wider with slightly larger type; tabs, composer, and Get Support still fit.
- [ ] Check 390 and 768: no overflow, one `.de-desk-shell`, graphite field, magenta actions only.
- [ ] Ask DE identity: after a name, answer `yours` or `DE staff` — company becomes Digerati Experts, reply does not say “from yours,” no invented portal features.
- [ ] Answer `I work for Digerati Experts` or `I'm DE staff` — treated as DE staff, not a literal company string.
- [ ] Answer `yours truly` — walk-in, not stored as company “yours truly.”
- [ ] Answer a real company (e.g. Acme Dental) — still stored literally.
- [ ] Confirm persisted assistant messages show a real timestamp (not a blank/epoch time).
- [ ] Existing client path still uses https://portal.digeratiexperts.com/portal/login
- [ ] `npm run test:advisor` passes


Made with [Cursor](https://cursor.com)