### PR TITLE
Lighten homepage FAQ cards and threat tiles for readable titles

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -605,6 +605,57 @@ html[data-dock-hidden="true"] .de-bottom-bar {
   box-shadow: 0 8px 32px rgba(26, 18, 16, 0.1);
 }
 
+/* FAQ rows on paper: same white lift as the assessment card, magenta left rail. */
+.de-paper-faq-item {
+  background-color: var(--de-paper-raised);
+  border: 1px solid var(--de-paper-hairline);
+  box-shadow:
+    inset 3px 0 0 #d3126a,
+    -6px 0 18px -8px rgba(211, 18, 106, 0.28),
+    0 8px 32px rgba(26, 18, 16, 0.08);
+  transition:
+    box-shadow 0.55s cubic-bezier(0.22, 1, 0.36, 1),
+    transform 0.55s cubic-bezier(0.22, 1, 0.36, 1);
+}
+@media (hover: hover) and (pointer: fine) {
+  .de-paper-faq-item:hover {
+    transform: translateY(-1px);
+    box-shadow:
+      inset 3px 0 0 #d3126a,
+      -8px 0 22px -6px rgba(211, 18, 106, 0.36),
+      0 12px 36px rgba(26, 18, 16, 0.1);
+  }
+}
+.de-paper-faq-item.is-open {
+  box-shadow:
+    inset 3px 0 0 #d3126a,
+    -8px 0 22px -6px rgba(211, 18, 106, 0.36),
+    0 12px 36px rgba(26, 18, 16, 0.1);
+}
+.de-paper-faq-item:has(:focus-visible) {
+  outline: 2px solid #d3126a;
+  outline-offset: 2px;
+}
+.de-paper-faq-chevron {
+  transition:
+    transform 0.3s cubic-bezier(0.22, 1, 0.36, 1),
+    background-color 0.3s ease;
+}
+.de-paper-faq-chevron.is-open {
+  transform: rotate(180deg);
+}
+@media (prefers-reduced-motion: reduce) {
+  .de-paper-faq-item {
+    transition: box-shadow 0.2s ease;
+  }
+  .de-paper-faq-item:hover {
+    transform: none;
+  }
+  .de-paper-faq-chevron {
+    transition: none;
+  }
+}
+
 /* Elevated, floating paper showcase island over dark cyber canvas */
 .de-paper-island {
   position: relative;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -605,6 +605,15 @@ html[data-dock-hidden="true"] .de-bottom-bar {
   box-shadow: 0 8px 32px rgba(26, 18, 16, 0.1);
 }
 
+/* White cards on a dark well — threat tiles and similar homepage boxes. */
+.de-paper-on-well {
+  background-color: var(--de-paper-raised);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  box-shadow:
+    0 12px 36px rgba(0, 0, 0, 0.42),
+    0 0 0 1px rgba(211, 18, 106, 0.1);
+}
+
 /* FAQ rows on paper: same white lift as the assessment card, magenta left rail. */
 .de-paper-faq-item {
   background-color: var(--de-paper-raised);

--- a/client/src/lib/homepageFields.test.ts
+++ b/client/src/lib/homepageFields.test.ts
@@ -36,4 +36,19 @@ describe("homepage chapter fields", () => {
     expect(homepage).toContain("DigeratiThreatsInsightsSection");
     expect(homepage).toContain("DigeratiPricingSection");
   });
+
+  it("FAQ matches the paper island recipe with white magenta-rail rows", () => {
+    const faq = readFileSync(
+      path.resolve(__dirname, "../pages/sections/DigeratiFAQSection.tsx"),
+      "utf8",
+    );
+    expect(faq).toContain("de-dark-well");
+    expect(faq).toContain("de-paper-island");
+    expect(faq).toContain("de-paper-faq-item");
+    expect(faq).toContain('text-[#1A1228]');
+    expect(faq).not.toContain("de-hud-card");
+    expect(css).toContain(".de-paper-faq-item {");
+    expect(css).toContain("inset 3px 0 0 #d3126a");
+    expect(css).toContain("background-color: var(--de-paper-raised)");
+  });
 });

--- a/client/src/lib/homepageFields.test.ts
+++ b/client/src/lib/homepageFields.test.ts
@@ -51,4 +51,18 @@ describe("homepage chapter fields", () => {
     expect(css).toContain("inset 3px 0 0 #d3126a");
     expect(css).toContain("background-color: var(--de-paper-raised)");
   });
+
+  it("homepage threat tiles are white on the dark well, not graphite fills", () => {
+    expect(insights).toContain("de-paper-on-well");
+    expect(insights).toContain("bg-white");
+    expect(insights).toContain('text-[#1A1228]');
+    expect(insights).not.toContain("from-[#18141f]");
+    expect(css).toContain(".de-paper-on-well {");
+    const ai = readFileSync(
+      path.resolve(__dirname, "../pages/sections/DigeratiAIAssistanceSection.tsx"),
+      "utf8",
+    );
+    expect(ai).toContain("de-paper-on-well");
+    expect(ai).toContain("Coverage with Context");
+  });
 });

--- a/client/src/pages/sections/DigeratiAIAssistanceSection.tsx
+++ b/client/src/pages/sections/DigeratiAIAssistanceSection.tsx
@@ -86,22 +86,24 @@ export const DigeratiAIAssistanceSection = (): JSX.Element => {
                 ))}
               </ul>
 
-              <div className="grid sm:grid-cols-2 gap-4 mb-8">
-                <div className="group rounded-xl border border-white/10 bg-gradient-to-b from-[#18141f] to-[#0e0c13] p-5 shadow-lg transition-all duration-300 hover:border-[#D3126A]/50">
-                  <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-white/10 bg-[#D3126A]/10 text-[#D3126A] mb-3 transition-colors group-hover:bg-[#D3126A] group-hover:text-white">
+              <div className="mb-8 grid gap-4 sm:grid-cols-2">
+                <div className="de-paper-on-well group relative overflow-hidden rounded-xl bg-white p-5">
+                  <div className="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-[#D3126A] via-[#E61E76] to-transparent opacity-80" />
+                  <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-lg border border-[var(--de-paper-hairline)] bg-[#D3126A]/10 text-[#D3126A] transition-colors group-hover:bg-[#D3126A] group-hover:text-white">
                     <Shield className="h-5 w-5" aria-hidden />
                   </div>
-                  <p className="text-white font-bold text-base mb-1">Coverage with Context</p>
-                  <p className="text-white/65 text-xs md:text-sm leading-relaxed">
+                  <p className="mb-1 text-base font-bold text-[#1A1228]">Coverage with Context</p>
+                  <p className="text-xs leading-relaxed text-black/60 md:text-sm">
                     Alerts are interpreted against your specific environment — never dumped into an unmonitored ticket queue.
                   </p>
                 </div>
-                <div className="group rounded-xl border border-white/10 bg-gradient-to-b from-[#18141f] to-[#0e0c13] p-5 shadow-lg transition-all duration-300 hover:border-[#D3126A]/50">
-                  <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-white/10 bg-[#D3126A]/10 text-[#D3126A] mb-3 transition-colors group-hover:bg-[#D3126A] group-hover:text-white">
+                <div className="de-paper-on-well group relative overflow-hidden rounded-xl bg-white p-5">
+                  <div className="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-[#D3126A] via-[#E61E76] to-transparent opacity-80" />
+                  <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-lg border border-[var(--de-paper-hairline)] bg-[#D3126A]/10 text-[#D3126A] transition-colors group-hover:bg-[#D3126A] group-hover:text-white">
                     <Layers className="h-5 w-5" aria-hidden />
                   </div>
-                  <p className="text-white font-bold text-base mb-1">Documented Next Steps</p>
-                  <p className="text-white/65 text-xs md:text-sm leading-relaxed">
+                  <p className="mb-1 text-base font-bold text-[#1A1228]">Documented Next Steps</p>
+                  <p className="text-xs leading-relaxed text-black/60 md:text-sm">
                     Findings translate into actionable steps your executive and IT teams can execute without decoding cryptic jargon.
                   </p>
                 </div>

--- a/client/src/pages/sections/DigeratiFAQSection.tsx
+++ b/client/src/pages/sections/DigeratiFAQSection.tsx
@@ -41,31 +41,29 @@ export const DigeratiFAQSection = (): JSX.Element => {
       <FAQJsonLd faqs={faqs} />
       <div className="mx-auto max-w-[var(--de-canvas)] px-3 sm:px-4 lg:px-6">
         <div className="de-paper-island relative px-6 py-10 sm:px-10 sm:py-14 md:px-12 md:py-16">
-          <div className="max-w-4xl mx-auto relative z-10">
-            {/* Header */}
+          <div className="relative z-10 mx-auto max-w-4xl">
             <motion.div
               initial={prefersReducedMotion ? false : revealInitial}
               whileInView={revealInView}
               viewport={revealViewport}
               transition={revealTransition}
-              className="text-center mb-10 md:mb-12"
+              className="mb-10 text-center md:mb-12"
             >
-              <p className="mb-3 text-sm font-semibold uppercase tracking-[0.16em] text-[#D3126A] md:text-base">
+              <p className="mb-3 text-base font-semibold uppercase tracking-[0.2em] text-[#D3126A]">
                 Common questions
               </p>
-              <h2 className="mb-4 px-2 font-heading text-3xl font-semibold tracking-[-0.02em] text-[#1A1228] sm:text-4xl md:mb-5 md:text-5xl">
+              <h2 className="mb-4 font-heading text-3xl font-semibold leading-tight tracking-[-0.02em] text-[#1A1228] md:text-4xl lg:text-5xl">
                 Frequently Asked Questions
               </h2>
-              <p className="px-4 text-lg text-[#5A5368] md:text-xl">
+              <p className="mx-auto max-w-2xl text-lg leading-relaxed text-black/60 md:text-xl">
                 Straight answers on how we work, what we recommend, and why.
               </p>
             </motion.div>
 
-            {/* FAQ Items */}
-            <div className="space-y-4">
+            <div className="space-y-3 md:space-y-4">
               {faqs.map((faq, index) => {
                 const isOpen = openIndex === index;
-                
+
                 return (
                   <motion.div
                     key={index}
@@ -75,51 +73,46 @@ export const DigeratiFAQSection = (): JSX.Element => {
                     transition={{ ...revealTransition, delay: index * 0.04 }}
                     data-testid={`faq-${index}`}
                   >
-                    <div 
-                      className={`de-paper-lift rounded-xl border-l-4 transition-all duration-300 ${
-                        isOpen 
-                          ? 'border-l-[#D3126A] shadow-[0_6px_28px_-8px_rgba(211,18,106,0.22)]'
-                          : 'border-l-[#D3126A]/30 hover:border-l-[#D3126A] hover:shadow-[0_4px_20px_-8px_rgba(211,18,106,0.18)]'
-                      }`}
+                    <div
+                      className={`de-paper-faq-item rounded-2xl ${isOpen ? "is-open" : ""}`}
                     >
                       <button
-                        className="w-full px-6 py-6 md:px-8 md:py-7 flex items-center justify-between text-left group"
+                        className="group flex w-full min-h-11 items-center justify-between gap-4 px-5 py-5 text-left focus-visible:outline-none md:px-7 md:py-6"
                         onClick={() => toggleAccordion(index)}
                         aria-expanded={isOpen}
                         aria-controls={`faq-answer-${index}`}
                         id={`faq-question-${index}`}
                         data-testid={`faq-trigger-${index}`}
                       >
-                        <span className={`pr-4 text-base font-semibold transition-colors duration-200 md:text-lg ${
-                          isOpen ? 'text-[#D3126A]' : 'text-[#1A1228] group-hover:text-[#D3126A]'
-                        }`}>
+                        <span className="pr-2 text-base font-semibold text-[#1A1228] md:text-lg">
                           {faq.question}
                         </span>
-                        <div className={`w-8 h-8 flex-shrink-0 rounded-full flex items-center justify-center transition-all duration-300 ${
-                          isOpen 
-                            ? 'bg-[#D3126A] rotate-180 shadow-[0_0_14px_-2px_rgba(211,18,106,0.55)]' 
-                            : 'bg-[#D3126A]/10 group-hover:bg-[#D3126A]/20'
-                        }`}>
-                          <ChevronDown 
-                            className={`h-5 w-5 transition-colors duration-200 flex-shrink-0 ${
-                              isOpen ? 'text-white' : 'text-[#D3126A]'
-                            }`}
-                          />
-                        </div>
+                        <span
+                          className={`de-paper-faq-chevron flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-[#D3126A]/10 group-hover:bg-[#D3126A]/15 ${
+                            isOpen ? "is-open bg-[#D3126A]/15" : ""
+                          }`}
+                          aria-hidden="true"
+                        >
+                          <ChevronDown className="h-5 w-5 text-[#D3126A]" />
+                        </span>
                       </button>
 
                       <AnimatePresence initial={false}>
                         {isOpen && (
                           <motion.div
-                            initial={{ height: 0, opacity: 0 }}
+                            initial={prefersReducedMotion ? false : { height: 0, opacity: 0 }}
                             animate={{ height: "auto", opacity: 1 }}
                             exit={{ height: 0, opacity: 0 }}
-                            transition={{ duration: 0.25, ease: "easeOut" }}
+                            transition={prefersReducedMotion ? { duration: 0 } : { duration: 0.25, ease: "easeOut" }}
                             className="overflow-hidden"
                           >
-                            <div className="px-5 pb-6 md:px-8 md:pb-7 pt-0">
+                            <div className="px-5 pb-6 pt-0 md:px-7 md:pb-7">
                               <div className="border-t border-[var(--de-paper-hairline)] pt-4">
-                                <p className="text-base leading-relaxed text-[#3A3448] md:text-lg" id={`faq-answer-${index}`} data-testid={`faq-answer-${index}`}>
+                                <p
+                                  className="text-base leading-relaxed text-black/60 md:text-lg"
+                                  id={`faq-answer-${index}`}
+                                  data-testid={`faq-answer-${index}`}
+                                >
                                   {faq.answer}
                                 </p>
                               </div>

--- a/client/src/pages/sections/DigeratiThreatsInsightsSection.tsx
+++ b/client/src/pages/sections/DigeratiThreatsInsightsSection.tsx
@@ -24,15 +24,15 @@ const categoryIcon: Record<ThreatCategory, JSX.Element> = {
 };
 
 function categoryBadgeClass(item: ThreatItem): string {
-  if (item.severity === "critical") return "bg-red-500/20 text-red-400 border-red-500/30";
-  if (item.severity === "high") return "border-[#D3126A] bg-transparent text-white";
-  return "border-de-hairline bg-transparent text-white/70";
+  if (item.severity === "critical") return "bg-red-50 text-red-700 border-red-200";
+  if (item.severity === "high") return "border-[#D3126A] bg-transparent text-[#A30E52]";
+  return "border-[var(--de-paper-hairline)] bg-transparent text-[#5A5368]";
 }
 
 function InsightCard({ insight, index }: { insight: ThreatItem; index: number }) {
   return (
     <Card
-      className="de-interactive-tile group relative h-full overflow-hidden rounded-xl border border-white/10 bg-gradient-to-b from-[#18141f] to-[#0e0c13] shadow-lg transition-all duration-300 hover:border-[#D3126A]/50 hover:-translate-y-1"
+      className="de-paper-on-well de-interactive-tile group relative h-full overflow-hidden rounded-xl bg-white shadow-none hover:border-[#D3126A]/50"
       data-testid={`insight-card-${index}`}
     >
       <div className="h-1 bg-gradient-to-r from-[#D3126A] via-[#E61E76] to-transparent opacity-80 group-hover:opacity-100" />
@@ -45,7 +45,7 @@ function InsightCard({ insight, index }: { insight: ThreatItem; index: number })
               <span className="sm:hidden">{insight.category.split(" ")[0]}</span>
             </span>
           </Badge>
-          <span className="text-xs text-white/50 flex items-center gap-1.5 whitespace-nowrap font-mono">
+          <span className="flex items-center gap-1.5 whitespace-nowrap font-mono text-xs text-[#5A5368]">
             <Calendar className="h-3.5 w-3.5 text-[#D3126A]" />
             <span className="hidden sm:inline">{formatThreatDate(insight.publishedAt)}</span>
             <span className="sm:hidden">{formatThreatDate(insight.publishedAt, "short")}</span>
@@ -54,16 +54,16 @@ function InsightCard({ insight, index }: { insight: ThreatItem; index: number })
         <p className="mb-1.5 text-xs font-bold uppercase tracking-[0.14em] text-[#D3126A]">
           {insight.kicker}
         </p>
-        <CardTitle className="text-base sm:text-lg font-bold text-white line-clamp-2 leading-snug group-hover:text-white">
+        <CardTitle className="line-clamp-2 text-base font-bold leading-snug text-[#1A1228] sm:text-lg">
           {insight.title}
         </CardTitle>
       </CardHeader>
       <CardContent className="p-5 sm:p-6 pt-0">
-        <CardDescription className="text-white/70 mb-4 line-clamp-3 text-xs sm:text-sm leading-relaxed">
+        <CardDescription className="mb-4 line-clamp-3 text-xs leading-relaxed text-black/60 sm:text-sm">
           {insight.excerpt}
         </CardDescription>
-        <div className="flex items-center justify-between pt-4 border-t border-white/10 gap-3 text-xs">
-          <span className="text-white/50 truncate font-mono">
+        <div className="flex items-center justify-between gap-3 border-t border-[var(--de-paper-hairline)] pt-4 text-xs">
+          <span className="truncate font-mono text-[#5A5368]">
             {insight.sourceName}
             {insight.vendor ? ` · ${insight.vendor}` : ""}
             {insight.cve ? ` · ${insight.cve}` : ""}
@@ -72,7 +72,7 @@ function InsightCard({ insight, index }: { insight: ThreatItem; index: number })
             href={insight.sourceUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="flex items-center gap-1 font-semibold text-[#D3126A] hover:text-[#f0187a] shrink-0"
+            className="flex shrink-0 items-center gap-1 font-semibold text-[#D3126A] hover:text-[#f0187a]"
           >
             Read source
             <ExternalLink className="h-3 w-3" />
@@ -198,21 +198,21 @@ export const DigeratiThreatsInsightsSection = (): JSX.Element => {
 
         {loading ? (
           <div
-            className="mx-auto mb-12 max-w-2xl rounded-2xl border border-de-hairline bg-de-raised p-6 text-center md:p-8"
+            className="de-paper-on-well mx-auto mb-12 max-w-2xl rounded-2xl bg-white p-6 text-center md:p-8"
             data-testid="insights-loading"
           >
-            <p className="text-lg font-semibold text-white">Loading current threats…</p>
-            <p className="mt-2 text-base leading-relaxed text-white/55">
+            <p className="text-lg font-semibold text-[#1A1228]">Loading current threats…</p>
+            <p className="mt-2 text-base leading-relaxed text-black/60">
               Checking CISA, FIRST, NVD, and Microsoft MSRC. Nothing is invented while this loads.
             </p>
           </div>
         ) : displayed.length === 0 ? (
           <div
-            className="mx-auto mb-12 max-w-2xl rounded-2xl border border-de-hairline bg-de-raised p-6 text-center md:p-8"
+            className="de-paper-on-well mx-auto mb-12 max-w-2xl rounded-2xl bg-white p-6 text-center md:p-8"
             data-testid="insights-empty"
           >
-            <p className="text-lg font-semibold text-white">No current items meet the homepage threshold.</p>
-            <p className="mt-2 text-base leading-relaxed text-white/55">
+            <p className="text-lg font-semibold text-[#1A1228]">No current items meet the homepage threshold.</p>
+            <p className="mt-2 text-base leading-relaxed text-black/60">
               We only promote threats with confirmed exploitation, high exploit probability, or clear
               SMB relevance — and only within the last 45 days. The full stream stays on Security
               Updates with dates and sources.


### PR DESCRIPTION
## Summary
- Matches homepage FAQ cards to the paper assessment recipe so the FAQ chapter reads as a light, scannable field instead of dark unreadable cards.
- Paints homepage threat tiles white so titles stay readable against the insight cards.
- Does not change DE Desk, Blog, Store, or portal routing. Portal login remains https://portal.digeratiexperts.com/portal/login

## Test plan
- [ ] Open `/` at 1440 and confirm FAQ cards follow the paper assessment look (light field, readable questions).
- [ ] Confirm threat/insight tiles are white enough that titles remain readable (not dark-on-dark).
- [ ] Check 390 and 768: no overflow, FAQ accordion still usable, threat tiles stack cleanly.
- [ ] Confirm Blog/Journal stays amber and Store stays electric; this PR only touches homepage FAQ + threat tiles.
- [ ] Spot-check that no Desk widget or portal login URL changed.


Made with [Cursor](https://cursor.com)