### PR TITLE
Fix CI/deploy concurrency without blocking main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ on:
 permissions:
   contents: read
 
-# Cancel overlapping PR validation only. A newer push to main must not cancel a
-# queued or in-flight production deployment waiting on the production runner.
+# PR validation can cancel stale runs. Push/dispatch runs use their run ID so
+# an offline production runner never blocks newer main CI from starting.
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
@@ -98,9 +98,30 @@ jobs:
     needs: check-test-build
     runs-on: [self-hosted, Linux, X64, de-production, website-prod]
     timeout-minutes: 30
+    concurrency:
+      group: de-production-website
+      cancel-in-progress: false
 
     steps:
+      # If the production runner was offline for several merges, old deploy jobs
+      # may be waiting. They should not redeploy repeatedly when the runner returns.
+      - name: Coalesce stale deployment runs
+        shell: bash
+        run: |
+          set -euo pipefail
+          LATEST_SHA="$(git ls-remote https://github.com/digeratiexperts/digeratiexperts-site.git refs/heads/main | awk '{print $1}')"
+          test -n "$LATEST_SHA"
+          echo "Workflow SHA: $GITHUB_SHA"
+          echo "Latest main:  $LATEST_SHA"
+          if [ "$GITHUB_SHA" != "$LATEST_SHA" ]; then
+            echo "DE_DEPLOY_STALE=true" >> "$GITHUB_ENV"
+            echo "This is a stale deployment run; a newer main run will deploy instead."
+          else
+            echo "DE_DEPLOY_STALE=false" >> "$GITHUB_ENV"
+          fi
+
       - name: Assert runner is the DE production host
+        if: env.DE_DEPLOY_STALE != 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -137,6 +158,7 @@ jobs:
           fi
 
       - name: Deploy current main with canonical release script
+        if: env.DE_DEPLOY_STALE != 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -158,6 +180,7 @@ jobs:
           esac
 
       - name: Verify production runtime
+        if: env.DE_DEPLOY_STALE != 'true'
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
Fixes the remaining concurrency edge case after #90. PR validation remains cancellable, main push/dispatch CI no longer waits behind an offline production runner, production deploys are serialized in their own concurrency lane, and stale queued deploy runs self-coalesce so an offline-runner backlog does not repeatedly redeploy old commits. Preserves [self-hosted, Linux, X64, de-production, website-prod].