### PR TITLE
Pin production deploys to the canonical website repository

### DIFF
--- a/deploy/vps/deploy.sh
+++ b/deploy/vps/deploy.sh
@@ -18,6 +18,7 @@
 #   User:        diger7051
 #   Code:        /home/digeratiexperts.com/current
 #   Service:     digeratiexperts-site (systemd — NOT PM2)
+#   Repository:  https://github.com/digeratiexperts/digeratiexperts-site.git
 #   Do NOT deploy from /root/Replit-Site
 #
 # Usage:
@@ -59,7 +60,7 @@ case "$TARGET" in
     ;;
 esac
 
-REPO_URL="${REPO_URL:-https://github.com/digeratiexperts/Replit-Site.git}"
+REPO_URL="${REPO_URL:-https://github.com/digeratiexperts/digeratiexperts-site.git}"
 DEPLOY_BRANCH="${DEPLOY_BRANCH:-main}"
 KEEP_RELEASES="${KEEP_RELEASES:-3}"
 NO_SYSTEMD="${NO_SYSTEMD:-0}"
@@ -76,6 +77,7 @@ log() { printf '[deploy %s] %s\n' "$(date +%H:%M:%S)" "$*"; }
 fail() { log "ERROR: $*"; exit 1; }
 
 # ---------------------------------------------------------------- preflight
+command -v git  >/dev/null || fail "git not found on PATH"
 command -v node >/dev/null || fail "node not found on PATH"
 command -v npm  >/dev/null || fail "npm not found on PATH"
 NODE_MAJOR="$(node -p 'process.versions.node.split(".")[0]')"
@@ -106,10 +108,27 @@ if [ ! -d "$MIRROR_DIR" ]; then
   log "Cloning $REPO_URL (bare mirror) into $MIRROR_DIR"
   git clone --mirror "$REPO_URL" "$MIRROR_DIR"
 else
-  log "Fetching latest $DEPLOY_BRANCH"
-  git --git-dir="$MIRROR_DIR" fetch --prune origin
+  git --git-dir="$MIRROR_DIR" rev-parse --is-bare-repository 2>/dev/null | grep -qx true \
+    || fail "$MIRROR_DIR exists but is not a valid bare Git repository"
+
+  CURRENT_ORIGIN="$(git --git-dir="$MIRROR_DIR" remote get-url origin 2>/dev/null || true)"
+  if [ "$CURRENT_ORIGIN" != "$REPO_URL" ]; then
+    log "Repairing mirror origin: ${CURRENT_ORIGIN:-<missing>} -> $REPO_URL"
+    if [ -n "$CURRENT_ORIGIN" ]; then
+      git --git-dir="$MIRROR_DIR" remote set-url origin "$REPO_URL"
+    else
+      git --git-dir="$MIRROR_DIR" remote add origin "$REPO_URL"
+    fi
+  fi
 fi
-COMMIT="$(git --git-dir="$MIRROR_DIR" rev-parse "$DEPLOY_BRANCH")"
+
+VERIFIED_ORIGIN="$(git --git-dir="$MIRROR_DIR" remote get-url origin 2>/dev/null || true)"
+[ "$VERIFIED_ORIGIN" = "$REPO_URL" ] \
+  || fail "mirror origin verification failed: expected $REPO_URL, got ${VERIFIED_ORIGIN:-<missing>}"
+
+log "Fetching latest $DEPLOY_BRANCH from $VERIFIED_ORIGIN"
+git --git-dir="$MIRROR_DIR" fetch --prune origin
+COMMIT="$(git --git-dir="$MIRROR_DIR" rev-parse "refs/heads/$DEPLOY_BRANCH")"
 log "Deploying $DEPLOY_BRANCH @ $COMMIT"
 
 # ---------------------------------------------------------------- build

--- a/scripts/deployScripts.test.ts
+++ b/scripts/deployScripts.test.ts
@@ -1,0 +1,31 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const deployScript = resolve(root, "deploy/vps/deploy.sh");
+const runnerScript = resolve(root, "scripts/setup-github-runner.sh");
+
+describe("production deployment scripts", () => {
+  it("remain valid bash", () => {
+    expect(() => execFileSync("bash", ["-n", deployScript], { stdio: "pipe" })).not.toThrow();
+    expect(() => execFileSync("bash", ["-n", runnerScript], { stdio: "pipe" })).not.toThrow();
+  });
+
+  it("pins production to the canonical digeratiexperts-site repository", () => {
+    const deploy = readFileSync(deployScript, "utf8");
+    const runner = readFileSync(runnerScript, "utf8");
+
+    expect(deploy).toContain(
+      'REPO_URL="${REPO_URL:-https://github.com/digeratiexperts/digeratiexperts-site.git}"',
+    );
+    expect(deploy).toContain('remote set-url origin "$REPO_URL"');
+    expect(deploy).not.toContain(
+      'REPO_URL="${REPO_URL:-https://github.com/digeratiexperts/Replit-Site.git}"',
+    );
+
+    expect(runner).toContain('CANONICAL_GIT_URL="${CANONICAL_GIT_URL:-${REPO_URL}.git}"');
+    expect(runner).toContain('production mirror verified: $VERIFIED_ORIGIN');
+  });
+});

--- a/scripts/setup-github-runner.sh
+++ b/scripts/setup-github-runner.sh
@@ -8,6 +8,7 @@ set -Eeuo pipefail
 
 REPO="${REPO:-digeratiexperts/digeratiexperts-site}"
 REPO_URL="https://github.com/${REPO}"
+CANONICAL_GIT_URL="${CANONICAL_GIT_URL:-${REPO_URL}.git}"
 RUNNER_ROLE="${RUNNER_ROLE:-website-prod}"
 RUNNER_LABELS="${RUNNER_LABELS:-de-production,website-prod}"
 RUNNER_NAME="${RUNNER_NAME:-$(hostname -s)-${RUNNER_ROLE}}"
@@ -36,6 +37,40 @@ else
 fi
 
 id "$RUNNER_USER" >/dev/null 2>&1 || die "Runner user '$RUNNER_USER' does not exist."
+
+# The website deployer uses /home/digeratiexperts.com/app as a persistent bare
+# mirror. Repair it here before the first queued deployment is allowed to run.
+# This also migrates hosts that were still pointed at the retired Replit-Site
+# repository. The production deploy must always source the canonical site repo.
+if [[ "$RUNNER_ROLE" == "website-prod" ]]; then
+  command -v git >/dev/null 2>&1 || die "git is required on the website production VPS."
+  SITE_HOME=/home/digeratiexperts.com
+  MIRROR_DIR="$SITE_HOME/app"
+  SITE_USER="${SITE_USER:-diger7051}"
+  id "$SITE_USER" >/dev/null 2>&1 || die "Site user '$SITE_USER' does not exist."
+
+  if [[ ! -d "$MIRROR_DIR" ]]; then
+    log "creating canonical production mirror: $CANONICAL_GIT_URL -> $MIRROR_DIR"
+    $SUDO -u "$SITE_USER" git clone --mirror "$CANONICAL_GIT_URL" "$MIRROR_DIR"
+  else
+    git --git-dir="$MIRROR_DIR" rev-parse --is-bare-repository 2>/dev/null | grep -qx true \
+      || die "$MIRROR_DIR exists but is not a valid bare Git repository."
+    CURRENT_ORIGIN="$(git --git-dir="$MIRROR_DIR" remote get-url origin 2>/dev/null || true)"
+    if [[ "$CURRENT_ORIGIN" != "$CANONICAL_GIT_URL" ]]; then
+      log "repairing production mirror origin: ${CURRENT_ORIGIN:-<missing>} -> $CANONICAL_GIT_URL"
+      if [[ -n "$CURRENT_ORIGIN" ]]; then
+        $SUDO -u "$SITE_USER" git --git-dir="$MIRROR_DIR" remote set-url origin "$CANONICAL_GIT_URL"
+      else
+        $SUDO -u "$SITE_USER" git --git-dir="$MIRROR_DIR" remote add origin "$CANONICAL_GIT_URL"
+      fi
+    fi
+  fi
+
+  VERIFIED_ORIGIN="$(git --git-dir="$MIRROR_DIR" remote get-url origin 2>/dev/null || true)"
+  [[ "$VERIFIED_ORIGIN" == "$CANONICAL_GIT_URL" ]] \
+    || die "Production mirror origin verification failed: '$VERIFIED_ORIGIN'"
+  log "production mirror verified: $VERIFIED_ORIGIN"
+fi
 
 get_token() {
   if [[ -n "${RUNNER_TOKEN:-}" ]]; then


### PR DESCRIPTION
Closes a production deployment correctness hole: deploy/vps/deploy.sh still defaulted to the retired digeratiexperts/Replit-Site.git remote, and an existing bare mirror could silently keep fetching that old origin. This change defaults to digeratiexperts/digeratiexperts-site.git, repairs/verifies the persistent production mirror origin before every fetch, has the runner bootstrap repair/create the canonical mirror before accepting deploy work, and adds regression tests for Bash syntax + canonical repo pinning.