### PR TITLE
Store: Your Solution panes and white checkout popups

### DIFF
--- a/client/src/components/CookieConsentBanner.tsx
+++ b/client/src/components/CookieConsentBanner.tsx
@@ -1,7 +1,9 @@
 import { useState, useEffect, useRef } from "react";
-import { Link } from "wouter";
+import { Link, useLocation } from "wouter";
 import { AnimatePresence, motion } from "framer-motion";
 import { saveConsent } from "@/lib/analytics";
+import { isStorePath } from "@/lib/storeChromeGestures";
+import { cn } from "@/lib/utils";
 
 const LEGACY_KEY = "de_cookie_consent";
 const CONSENT_KEY = "de_cookie_consent_v2";
@@ -15,6 +17,8 @@ function hasStoredConsent(): boolean {
 }
 
 export function CookieConsentBanner() {
+  const [location] = useLocation();
+  const light = isStorePath(location);
   const [visible, setVisible] = useState(false);
   const [showPreferences, setShowPreferences] = useState(false);
   const [analyticsEnabled, setAnalyticsEnabled] = useState(true);
@@ -101,68 +105,124 @@ export function CookieConsentBanner() {
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: 40 }}
               transition={{ duration: 0.3 }}
-              className="fixed bottom-[88px] left-4 right-4 md:left-auto z-[9995] rounded-2xl border border-de-hairline bg-de-raised shadow-2xl shadow-black/50 p-6 md:w-[420px]"
+              className={cn(
+                "fixed bottom-[88px] left-4 right-4 z-[9995] rounded-2xl border p-6 shadow-2xl md:left-auto md:w-[420px]",
+                light
+                  ? "border-black/10 bg-white shadow-black/20"
+                  : "border-de-hairline bg-de-raised shadow-black/50",
+              )}
               style={{ right: "calc(var(--de-canvas-gutter) + 1.5rem)" }}
               data-testid="cookie-preferences-panel"
+              data-surface={light ? "light" : "dark"}
             >
-              <h3 className="text-white font-semibold text-lg mb-1 font-['Space_Grotesk']">Cookie Preferences</h3>
-              <p className="text-gray-300 text-base mb-5 leading-relaxed">
+              <h3
+                className={cn(
+                  "mb-1 font-['Space_Grotesk'] text-lg font-semibold",
+                  light ? "text-slate-900" : "text-white",
+                )}
+              >
+                Cookie Preferences
+              </h3>
+              <p className={cn("mb-5 text-base leading-relaxed", light ? "text-slate-600" : "text-gray-300")}>
                 Choose which cookies you allow. Strictly necessary cookies are always enabled.
               </p>
 
               <div className="space-y-4">
-                <div className="flex items-start justify-between gap-4 p-3 rounded-xl bg-white/5 border border-white/10">
+                <div
+                  className={cn(
+                    "flex items-start justify-between gap-4 rounded-xl border p-3",
+                    light ? "border-black/10 bg-slate-50" : "border-white/10 bg-white/5",
+                  )}
+                >
                   <div>
-                    <p className="text-white text-base font-medium">Strictly Necessary</p>
-                    <p className="text-gray-400 text-base mt-0.5">Required for the site to function.</p>
+                    <p className={cn("text-base font-medium", light ? "text-slate-900" : "text-white")}>
+                      Strictly Necessary
+                    </p>
+                    <p className={cn("mt-0.5 text-base", light ? "text-slate-500" : "text-gray-400")}>
+                      Required for the site to function.
+                    </p>
                   </div>
-                  <span className="text-emerald-400 text-base font-semibold mt-1 whitespace-nowrap">Always On</span>
+                  <span
+                    className={cn(
+                      "mt-1 whitespace-nowrap text-base font-semibold",
+                      light ? "text-emerald-700" : "text-emerald-400",
+                    )}
+                  >
+                    Always On
+                  </span>
                 </div>
 
-                <label className="flex items-start justify-between gap-4 p-3 rounded-xl bg-white/5 border border-white/10 cursor-pointer">
+                <label
+                  className={cn(
+                    "flex cursor-pointer items-start justify-between gap-4 rounded-xl border p-3",
+                    light ? "border-black/10 bg-slate-50" : "border-white/10 bg-white/5",
+                  )}
+                >
                   <div>
-                    <p className="text-white text-base font-medium">Analytics Cookies</p>
-                    <p className="text-gray-400 text-base mt-0.5">Help us understand how visitors interact with the site.</p>
+                    <p className={cn("text-base font-medium", light ? "text-slate-900" : "text-white")}>
+                      Analytics Cookies
+                    </p>
+                    <p className={cn("mt-0.5 text-base", light ? "text-slate-500" : "text-gray-400")}>
+                      Help us understand how visitors interact with the site.
+                    </p>
                   </div>
                   <div
                     role="switch"
                     aria-checked={analyticsEnabled}
                     onClick={() => setAnalyticsEnabled(v => !v)}
-                    className={`relative mt-1 w-10 h-5 rounded-full flex-shrink-0 cursor-pointer transition-colors ${analyticsEnabled ? "bg-[#D3126A]" : "bg-white/20"}`}
+                    className={`relative mt-1 h-5 w-10 flex-shrink-0 cursor-pointer rounded-full transition-colors ${
+                      analyticsEnabled ? "bg-[#D3126A]" : light ? "bg-slate-300" : "bg-white/20"
+                    }`}
                     data-testid="toggle-analytics"
                   >
-                    <span className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white transition-transform ${analyticsEnabled ? "translate-x-5" : "translate-x-0"}`} />
+                    <span className={`absolute left-0.5 top-0.5 h-4 w-4 rounded-full bg-white transition-transform ${analyticsEnabled ? "translate-x-5" : "translate-x-0"}`} />
                   </div>
                 </label>
 
-                <label className="flex items-start justify-between gap-4 p-3 rounded-xl bg-white/5 border border-white/10 cursor-pointer">
+                <label
+                  className={cn(
+                    "flex cursor-pointer items-start justify-between gap-4 rounded-xl border p-3",
+                    light ? "border-black/10 bg-slate-50" : "border-white/10 bg-white/5",
+                  )}
+                >
                   <div>
-                    <p className="text-white text-base font-medium">Marketing Cookies</p>
-                    <p className="text-gray-400 text-base mt-0.5">Used to deliver relevant ads and track campaign effectiveness.</p>
+                    <p className={cn("text-base font-medium", light ? "text-slate-900" : "text-white")}>
+                      Marketing Cookies
+                    </p>
+                    <p className={cn("mt-0.5 text-base", light ? "text-slate-500" : "text-gray-400")}>
+                      Used to deliver relevant ads and track campaign effectiveness.
+                    </p>
                   </div>
                   <div
                     role="switch"
                     aria-checked={marketingEnabled}
                     onClick={() => setMarketingEnabled(v => !v)}
-                    className={`relative mt-1 w-10 h-5 rounded-full flex-shrink-0 cursor-pointer transition-colors ${marketingEnabled ? "bg-[#D3126A]" : "bg-white/20"}`}
+                    className={`relative mt-1 h-5 w-10 flex-shrink-0 cursor-pointer rounded-full transition-colors ${
+                      marketingEnabled ? "bg-[#D3126A]" : light ? "bg-slate-300" : "bg-white/20"
+                    }`}
                     data-testid="toggle-marketing"
                   >
-                    <span className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white transition-transform ${marketingEnabled ? "translate-x-5" : "translate-x-0"}`} />
+                    <span className={`absolute left-0.5 top-0.5 h-4 w-4 rounded-full bg-white transition-transform ${marketingEnabled ? "translate-x-5" : "translate-x-0"}`} />
                   </div>
                 </label>
               </div>
 
-              <div className="flex gap-3 mt-5">
+              <div className="mt-5 flex gap-3">
                 <button
                   onClick={savePreferences}
-                  className="flex-1 min-h-11 bg-[#D3126A] hover:bg-[#e01874] text-white text-base font-semibold py-2.5 rounded-xl transition-colors"
+                  className="min-h-11 flex-1 rounded-xl bg-[#D3126A] py-2.5 text-base font-semibold text-white transition-colors hover:bg-[#e01874]"
                   data-testid="button-save-preferences"
                 >
                   Save Preferences
                 </button>
                 <button
                   onClick={() => setShowPreferences(false)}
-                  className="min-h-11 px-4 bg-white/10 hover:bg-white/20 text-white text-base font-semibold py-2.5 rounded-xl transition-colors"
+                  className={cn(
+                    "min-h-11 rounded-xl px-4 py-2.5 text-base font-semibold transition-colors",
+                    light
+                      ? "bg-slate-100 text-slate-800 hover:bg-slate-200"
+                      : "bg-white/10 text-white hover:bg-white/20",
+                  )}
                   data-testid="button-cancel-preferences"
                 >
                   Cancel
@@ -181,41 +241,61 @@ export function CookieConsentBanner() {
               deskOpen ? " invisible pointer-events-none" : ""
             }`}
             data-testid="cookie-consent-banner"
+            data-surface={light ? "light" : "dark"}
             aria-hidden={deskOpen || undefined}
           >
             <div
               ref={bannerRef}
               className="relative overflow-hidden"
-              style={{
-                background: "#0a0a0a",
-                borderTop: "1px solid rgba(255,255,255,0.1)",
-              }}
+              style={
+                light
+                  ? { background: "#ffffff", borderTop: "1px solid rgba(15, 23, 42, 0.12)" }
+                  : { background: "#0a0a0a", borderTop: "1px solid rgba(255,255,255,0.1)" }
+              }
             >
-              <div
-                className="absolute inset-0 pointer-events-none opacity-[0.04]"
-                style={{
-                  backgroundImage: `linear-gradient(rgba(255,255,255,0.15) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,0.15) 1px, transparent 1px)`,
-                  backgroundSize: "32px 32px",
-                }}
-              />
+              {!light && (
+                <div
+                  className="pointer-events-none absolute inset-0 opacity-[0.04]"
+                  style={{
+                    backgroundImage: `linear-gradient(rgba(255,255,255,0.15) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,0.15) 1px, transparent 1px)`,
+                    backgroundSize: "32px 32px",
+                  }}
+                />
+              )}
 
-              <div className="relative z-10 max-w-screen-2xl mx-auto px-4 md:px-8 py-2.5 md:py-4 flex flex-col md:flex-row items-stretch md:items-center gap-2 md:gap-8">
-                <p className="hidden md:block text-gray-200 text-base leading-relaxed flex-1 min-w-0">
+              <div className="relative z-10 mx-auto flex max-w-screen-2xl flex-col items-stretch gap-2 px-4 py-2.5 md:flex-row md:items-center md:gap-8 md:px-8 md:py-4">
+                <p
+                  className={cn(
+                    "hidden min-w-0 flex-1 text-base leading-relaxed md:block",
+                    light ? "text-slate-700" : "text-gray-200",
+                  )}
+                >
                   Digerati Experts uses cookies and similar tracking technologies to collect information you provide and to capture your interaction with our site. We use this information to enhance site navigation, personalize content, analyze your use of our website, and assist in our marketing efforts and customer service. To deliver the best experience, analytics and hosting service providers may have access to this information. By clicking "Accept All," you consent to our collection, use, and disclosure of such information. For more information about our data processing practices, please see our{" "}
                   <Link
                     href="/legal/privacy-policy"
-                    className="underline underline-offset-2 text-[#D3126A] hover:text-white transition-colors font-medium"
+                    className={cn(
+                      "font-medium underline underline-offset-2 transition-colors",
+                      light ? "text-[#D3126A] hover:text-slate-900" : "text-[#D3126A] hover:text-white",
+                    )}
                     data-testid="link-privacy-policy-cookie"
                   >
                     Privacy Policy
                   </Link>
                   .
                 </p>
-                <p className="md:hidden text-sm font-medium leading-snug text-gray-200 flex-1 min-w-0">
+                <p
+                  className={cn(
+                    "min-w-0 flex-1 text-sm font-medium leading-snug md:hidden",
+                    light ? "text-slate-800" : "text-gray-200",
+                  )}
+                >
                   We use cookies.{" "}
                   <Link
                     href="/legal/privacy-policy"
-                    className="underline underline-offset-2 text-[#D3126A] hover:text-white transition-colors font-semibold"
+                    className={cn(
+                      "font-semibold underline underline-offset-2 transition-colors",
+                      light ? "text-[#D3126A] hover:text-slate-900" : "text-[#D3126A] hover:text-white",
+                    )}
                     data-testid="link-privacy-policy-cookie-mobile"
                   >
                     Privacy
@@ -224,26 +304,37 @@ export function CookieConsentBanner() {
                   <button
                     type="button"
                     onClick={() => setShowPreferences(v => !v)}
-                    className="underline underline-offset-2 text-[#D3126A] hover:text-white font-semibold"
+                    className={cn(
+                      "font-semibold underline underline-offset-2",
+                      light ? "text-[#D3126A] hover:text-slate-900" : "text-[#D3126A] hover:text-white",
+                    )}
                     data-testid="button-manage-cookie-preferences-mobile"
                   >
                     Preferences
                   </button>
                 </p>
 
-                <div className="flex items-center gap-2 flex-shrink-0 flex-wrap w-full md:w-auto justify-between md:justify-end">
+                <div className="flex w-full flex-shrink-0 flex-wrap items-center justify-between gap-2 md:w-auto md:justify-end">
                   <button
                     onClick={() => setShowPreferences(v => !v)}
-                    className="hidden md:inline-flex text-[#D3126A] hover:text-white text-base font-semibold underline underline-offset-2 transition-colors whitespace-nowrap px-1 min-h-11"
+                    className={cn(
+                      "hidden min-h-11 whitespace-nowrap px-1 text-base font-semibold underline underline-offset-2 transition-colors md:inline-flex",
+                      light ? "text-[#D3126A] hover:text-slate-900" : "text-[#D3126A] hover:text-white",
+                    )}
                     data-testid="button-manage-cookie-preferences"
                   >
                     Manage Cookie Preferences
                   </button>
 
-                  <div className="flex items-center gap-2 ml-auto md:ml-0">
+                  <div className="ml-auto flex items-center gap-2 md:ml-0">
                     <button
                       onClick={reject}
-                      className="min-h-11 px-5 py-2 rounded text-base font-semibold bg-[#0a0a1a] border border-white/20 text-white hover:bg-white/10 transition-colors whitespace-nowrap"
+                      className={cn(
+                        "min-h-11 whitespace-nowrap rounded border px-5 py-2 text-base font-semibold transition-colors",
+                        light
+                          ? "border-slate-300 bg-white text-slate-800 hover:bg-slate-50"
+                          : "border-white/20 bg-[#0a0a1a] text-white hover:bg-white/10",
+                      )}
                       data-testid="button-reject-all-cookies"
                     >
                       Reject All
@@ -251,7 +342,12 @@ export function CookieConsentBanner() {
 
                     <button
                       onClick={accept}
-                      className="min-h-11 px-5 py-2 rounded text-base font-semibold bg-[#0a0a1a] border border-white/20 text-white hover:bg-white/10 transition-colors whitespace-nowrap"
+                      className={cn(
+                        "min-h-11 whitespace-nowrap rounded px-5 py-2 text-base font-semibold transition-colors",
+                        light
+                          ? "bg-[#D3126A] text-white hover:bg-[#e01874]"
+                          : "border border-white/20 bg-[#0a0a1a] text-white hover:bg-white/10",
+                      )}
                       data-testid="button-accept-all-cookies"
                     >
                       Accept All

--- a/client/src/components/CookieConsentBanner.tsx
+++ b/client/src/components/CookieConsentBanner.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { Link, useLocation } from "wouter";
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { saveConsent } from "@/lib/analytics";
 import { isStorePath } from "@/lib/storeChromeGestures";
 import { cn } from "@/lib/utils";
@@ -19,6 +19,7 @@ function hasStoredConsent(): boolean {
 export function CookieConsentBanner() {
   const [location] = useLocation();
   const light = isStorePath(location);
+  const reduceMotion = useReducedMotion() ?? false;
   const [visible, setVisible] = useState(false);
   const [showPreferences, setShowPreferences] = useState(false);
   const [analyticsEnabled, setAnalyticsEnabled] = useState(true);
@@ -90,9 +91,10 @@ export function CookieConsentBanner() {
           {showPreferences && !deskOpen && (
             <motion.div
               key="prefs-overlay"
-              initial={{ opacity: 0 }}
+              initial={reduceMotion ? false : { opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
+              transition={{ duration: reduceMotion ? 0 : 0.2 }}
               className="fixed inset-0 z-[9990] bg-black/60 backdrop-blur-sm"
               onClick={() => setShowPreferences(false)}
             />
@@ -101,10 +103,10 @@ export function CookieConsentBanner() {
           {showPreferences && !deskOpen && (
             <motion.div
               key="prefs-panel"
-              initial={{ opacity: 0, y: 40 }}
+              initial={reduceMotion ? false : { opacity: 0, y: 40 }}
               animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: 40 }}
-              transition={{ duration: 0.3 }}
+              exit={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 40 }}
+              transition={{ duration: reduceMotion ? 0 : 0.3 }}
               className={cn(
                 "fixed bottom-[88px] left-4 right-4 z-[9995] rounded-2xl border p-6 shadow-2xl md:left-auto md:w-[420px]",
                 light
@@ -233,10 +235,10 @@ export function CookieConsentBanner() {
 
           <motion.div
             key="cookie-banner"
-            initial={{ y: "100%" }}
+            initial={reduceMotion ? false : { y: "100%" }}
             animate={{ y: 0 }}
-            exit={{ y: "100%" }}
-            transition={{ duration: 0.4, ease: "easeOut" }}
+            exit={reduceMotion ? { opacity: 0 } : { y: "100%" }}
+            transition={{ duration: reduceMotion ? 0 : 0.4, ease: "easeOut" }}
             className={`fixed z-[9991] de-fixed-in-canvas bottom-0${
               deskOpen ? " invisible pointer-events-none" : ""
             }`}
@@ -263,10 +265,11 @@ export function CookieConsentBanner() {
                 />
               )}
 
-              <div className="relative z-10 mx-auto flex max-w-screen-2xl flex-col items-stretch gap-2 px-4 py-2.5 md:flex-row md:items-center md:gap-8 md:px-8 md:py-4">
+              <div className="relative z-10 mx-auto flex max-w-screen-2xl flex-col items-stretch gap-2 px-4 py-2.5 lg:flex-row lg:items-center lg:gap-8 lg:px-8 lg:py-4">
                 <p
                   className={cn(
-                    "hidden min-w-0 flex-1 text-base leading-relaxed md:block",
+                    "min-w-0 flex-1 text-base leading-relaxed",
+                    light ? "hidden" : "hidden lg:block",
                     light ? "text-slate-700" : "text-gray-200",
                   )}
                 >
@@ -285,7 +288,8 @@ export function CookieConsentBanner() {
                 </p>
                 <p
                   className={cn(
-                    "min-w-0 flex-1 text-sm font-medium leading-snug md:hidden",
+                    "min-w-0 flex-1 text-sm font-medium leading-snug",
+                    light ? "" : "lg:hidden",
                     light ? "text-slate-800" : "text-gray-200",
                   )}
                 >
@@ -318,8 +322,10 @@ export function CookieConsentBanner() {
                   <button
                     onClick={() => setShowPreferences(v => !v)}
                     className={cn(
-                      "hidden min-h-11 whitespace-nowrap px-1 text-base font-semibold underline underline-offset-2 transition-colors md:inline-flex",
-                      light ? "text-[#D3126A] hover:text-slate-900" : "text-[#D3126A] hover:text-white",
+                      "hidden min-h-11 whitespace-nowrap px-1 text-base font-semibold underline underline-offset-2 transition-colors md:inline-flex focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A] focus-visible:ring-offset-2 rounded-sm",
+                      light
+                        ? "text-[#D3126A] hover:text-slate-900 focus-visible:ring-offset-white"
+                        : "text-[#D3126A] hover:text-white focus-visible:ring-offset-[#0a0a0a]",
                     )}
                     data-testid="button-manage-cookie-preferences"
                   >
@@ -330,10 +336,10 @@ export function CookieConsentBanner() {
                     <button
                       onClick={reject}
                       className={cn(
-                        "min-h-11 whitespace-nowrap rounded border px-5 py-2 text-base font-semibold transition-colors",
+                        "min-h-11 whitespace-nowrap rounded border px-5 py-2 text-base font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A] focus-visible:ring-offset-2",
                         light
-                          ? "border-slate-300 bg-white text-slate-800 hover:bg-slate-50"
-                          : "border-white/20 bg-[#0a0a1a] text-white hover:bg-white/10",
+                          ? "border-slate-300 bg-white text-slate-800 hover:bg-slate-50 focus-visible:ring-offset-white"
+                          : "border-white/20 bg-[#0a0a1a] text-white hover:bg-white/10 focus-visible:ring-offset-[#0a0a0a]",
                       )}
                       data-testid="button-reject-all-cookies"
                     >
@@ -343,10 +349,10 @@ export function CookieConsentBanner() {
                     <button
                       onClick={accept}
                       className={cn(
-                        "min-h-11 whitespace-nowrap rounded px-5 py-2 text-base font-semibold transition-colors",
+                        "min-h-11 whitespace-nowrap rounded px-5 py-2 text-base font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A] focus-visible:ring-offset-2",
                         light
-                          ? "bg-[#D3126A] text-white hover:bg-[#e01874]"
-                          : "border border-white/20 bg-[#0a0a1a] text-white hover:bg-white/10",
+                          ? "bg-[#D3126A] text-white hover:bg-[#e01874] focus-visible:ring-offset-white"
+                          : "border border-white/20 bg-[#0a0a1a] text-white hover:bg-white/10 focus-visible:ring-offset-[#0a0a0a]",
                       )}
                       data-testid="button-accept-all-cookies"
                     >

--- a/client/src/components/StickyCTABar.tsx
+++ b/client/src/components/StickyCTABar.tsx
@@ -6,6 +6,8 @@ import { Button } from "@/components/ui/button";
 import { useBooking } from "@/contexts/BookingContext";
 import { CTA } from "@/lib/ctaCopy";
 import { PRIMARY_PHONE } from "@/data/companyContact";
+import { isStorePath } from "@/lib/storeChromeGestures";
+import { cn } from "@/lib/utils";
 import {
   STICKY_CTA_AUTO_HIDE_MS,
   STICKY_CTA_RESHOW_DELTA_PX,
@@ -24,6 +26,7 @@ function publishStickyCtaHeight(px: number) {
 
 export function StickyCTABar() {
   const [location] = useLocation();
+  const light = isStorePath(location);
   const [dismissed, setDismissed] = useState(false);
   const [pastThreshold, setPastThreshold] = useState(false);
   const [scrolling, setScrolling] = useState(false);
@@ -188,50 +191,84 @@ export function StickyCTABar() {
           className="de-bottom-bar"
           data-testid="sticky-cta-bar"
           data-sticky-cta-chrome="true"
+          data-surface={light ? "light" : "dark"}
         >
-          <div className="relative overflow-hidden rounded-2xl border border-de-hairline bg-de-raised">
+          <div
+            className={cn(
+              "relative overflow-hidden rounded-2xl border",
+              light
+                ? "border-black/10 bg-white shadow-[0_12px_40px_rgba(0,0,0,0.16)]"
+                : "border-de-hairline bg-de-raised",
+            )}
+          >
             <button
               onClick={handleDismiss}
-              className="absolute top-2 right-2 z-10 p-1.5 rounded-full hover:bg-white/10 transition-colors"
+              className={cn(
+                "absolute right-2 top-2 z-10 rounded-full p-1.5 transition-colors",
+                light ? "hover:bg-black/5" : "hover:bg-white/10",
+              )}
               aria-label="Close banner"
               data-testid="button-dismiss-sticky-cta"
             >
-              <X className="w-4 h-4 text-white/70" />
+              <X className={cn("h-4 w-4", light ? "text-slate-600" : "text-white/70")} />
             </button>
 
             <div className="px-4 py-3 pr-11">
-              <div className="flex flex-col lg:flex-row items-center justify-between gap-3 lg:gap-5">
-                <div className="flex items-center gap-3 min-w-0">
-                  <div className="hidden sm:flex w-10 h-10 rounded-full bg-white/10 items-center justify-center shrink-0">
-                    <Shield className="w-5 h-5 text-de-accent-ink" />
+              <div className="flex flex-col items-center justify-between gap-3 lg:flex-row lg:gap-5">
+                <div className="flex min-w-0 items-center gap-3">
+                  <div
+                    className={cn(
+                      "hidden h-10 w-10 shrink-0 items-center justify-center rounded-full sm:flex",
+                      light ? "bg-black/[0.04]" : "bg-white/10",
+                    )}
+                  >
+                    <Shield className="h-5 w-5 text-de-accent-ink" />
                   </div>
-                  <div className="text-center lg:text-left min-w-0">
-                    <p className="text-white font-semibold text-base md:text-lg">
+                  <div className="min-w-0 text-center lg:text-left">
+                    <p
+                      className={cn(
+                        "text-base font-semibold md:text-lg",
+                        light ? "text-slate-900" : "text-white",
+                      )}
+                    >
                       Independent Risk Assessment
                     </p>
-                    <p className="text-white/70 text-sm md:text-base leading-snug max-w-xl">
+                    <p
+                      className={cn(
+                        "max-w-xl text-sm leading-snug md:text-base",
+                        light ? "text-slate-600" : "text-white/70",
+                      )}
+                    >
                       Your current provider has a conflict grading their own work.
                       {" "}
-                      <span className="text-white/90">
+                      <span className={light ? "text-slate-800" : "text-white/90"}>
                         We map the gaps, build a plan, and can collaborate with them — switching is optional.
                       </span>
                     </p>
                   </div>
                 </div>
 
-                <div className="hidden xl:flex items-center">
+                <div className="hidden items-center xl:flex">
                   <span
-                    className="rounded-full border border-white/20 bg-white/5 px-3.5 py-1.5 text-xs font-medium tracking-wide text-white/80 whitespace-nowrap"
+                    className={cn(
+                      "whitespace-nowrap rounded-full border px-3.5 py-1.5 text-xs font-medium tracking-wide",
+                      light
+                        ? "border-black/10 bg-black/[0.03] text-slate-700"
+                        : "border-white/20 bg-white/5 text-white/80",
+                    )}
                     data-testid="sticky-cta-reassurance"
                   >
                     No switch required
                   </span>
                 </div>
 
-                <div className="flex items-center gap-2 md:gap-4 flex-shrink-0">
+                <div className="flex shrink-0 items-center gap-2 md:gap-4">
                   <a
                     href={PRIMARY_PHONE.telHref}
-                    className="hidden md:flex items-center gap-2 text-white/75 hover:text-white transition-colors text-base"
+                    className={cn(
+                      "hidden items-center gap-2 text-base transition-colors md:flex",
+                      light ? "text-slate-600 hover:text-slate-900" : "text-white/75 hover:text-white",
+                    )}
                     data-testid="link-phone-sticky"
                   >
                     <Phone className="w-4 h-4" />

--- a/client/src/components/StickyCTABar.tsx
+++ b/client/src/components/StickyCTABar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { ArrowRight, Phone, Shield, X } from "lucide-react";
 import { useLocation } from "wouter";
 import { Button } from "@/components/ui/button";
@@ -15,7 +15,9 @@ import {
   isNearDocumentEnd,
   isPageFooterOnScreen,
   isPastStickyCtaThreshold,
+  isStickyCtaPinnedRoute,
   isStickyCtaRouteAllowed,
+  isTooShortToReachStickyThreshold,
   rectOverlapsPageContent,
   shouldShowStickyCta,
 } from "@/lib/stickyCtaVisibility";
@@ -27,6 +29,7 @@ function publishStickyCtaHeight(px: number) {
 export function StickyCTABar() {
   const [location] = useLocation();
   const light = isStorePath(location);
+  const reduceMotion = useReducedMotion() ?? false;
   const [dismissed, setDismissed] = useState(false);
   const [pastThreshold, setPastThreshold] = useState(false);
   const [scrolling, setScrolling] = useState(false);
@@ -40,6 +43,7 @@ export function StickyCTABar() {
   const lastHeight = useRef(0);
 
   const routeAllowed = isStickyCtaRouteAllowed(location);
+  const pinned = isStickyCtaPinnedRoute(location);
   const visible = shouldShowStickyCta({
     dismissed,
     routeAllowed,
@@ -47,6 +51,7 @@ export function StickyCTABar() {
     scrolling,
     overlapping,
     autoHidden,
+    pinned,
   });
 
   useEffect(() => {
@@ -91,16 +96,27 @@ export function StickyCTABar() {
       const overlayHits = rectOverlapsPageContent(rect, (x) =>
         document.elementsFromPoint(x, top + Math.min(20, height / 2)),
       );
-      const footerHits = Array.from(document.querySelectorAll("footer")).some((el) => {
-        if (el.closest("[role='dialog']") || el.closest(".de-desk-shell")) return false;
-        return isPageFooterOnScreen(el.getBoundingClientRect().top, window.innerHeight);
-      });
-      const endHits = isNearDocumentEnd(
-        window.scrollY,
+      const shortPage = isTooShortToReachStickyThreshold(
         window.innerHeight,
         document.documentElement.scrollHeight,
       );
-      setOverlapping(overlayHits || footerHits || endHits);
+      // Pinned checkout (and other short pages) always have the footer in view.
+      // Parking for that would make the Risk Assessment bar never appear.
+      const parkForFooter = !pinned && !shortPage;
+      const footerHits =
+        parkForFooter &&
+        Array.from(document.querySelectorAll("footer")).some((el) => {
+          if (el.closest("[role='dialog']") || el.closest(".de-desk-shell")) return false;
+          return isPageFooterOnScreen(el.getBoundingClientRect().top, window.innerHeight);
+        });
+      const endHits =
+        parkForFooter &&
+        isNearDocumentEnd(
+          window.scrollY,
+          window.innerHeight,
+          document.documentElement.scrollHeight,
+        );
+      setOverlapping(Boolean(overlayHits || footerHits || endHits));
     };
 
     const markScrolling = (on: boolean) => {
@@ -110,8 +126,16 @@ export function StickyCTABar() {
 
     const onScroll = () => {
       const scrollY = window.scrollY;
-      setPastThreshold(isPastStickyCtaThreshold(scrollY, window.innerHeight));
-      markScrolling(true);
+      const shortPage = isTooShortToReachStickyThreshold(
+        window.innerHeight,
+        document.documentElement.scrollHeight,
+      );
+      setPastThreshold(
+        pinned || shortPage || isPastStickyCtaThreshold(scrollY, window.innerHeight),
+      );
+      if (!pinned) {
+        markScrolling(true);
+      }
       if (Math.abs(scrollY - lastShowScroll.current) >= STICKY_CTA_RESHOW_DELTA_PX) {
         setAutoHidden(false);
       }
@@ -119,7 +143,7 @@ export function StickyCTABar() {
       idleTimer = window.setTimeout(() => {
         markScrolling(false);
         measureOverlap();
-      }, STICKY_CTA_SCROLL_IDLE_MS);
+      }, pinned ? 0 : STICKY_CTA_SCROLL_IDLE_MS);
     };
 
     const onScrollRaf = () => {
@@ -142,7 +166,7 @@ export function StickyCTABar() {
       window.removeEventListener("resize", measureOverlap);
       document.documentElement.dataset.stickyCtaScrolling = "false";
     };
-  }, [dismissed, routeAllowed]);
+  }, [dismissed, routeAllowed, pinned]);
 
   useEffect(() => {
     if (dismissed || !routeAllowed) {
@@ -164,12 +188,14 @@ export function StickyCTABar() {
     publish();
     const ro = new ResizeObserver(publish);
     ro.observe(el);
-    const hideTimer = window.setTimeout(() => setAutoHidden(true), STICKY_CTA_AUTO_HIDE_MS);
+    const hideTimer = pinned
+      ? undefined
+      : window.setTimeout(() => setAutoHidden(true), STICKY_CTA_AUTO_HIDE_MS);
     return () => {
       ro.disconnect();
-      window.clearTimeout(hideTimer);
+      if (hideTimer) window.clearTimeout(hideTimer);
     };
-  }, [visible, dismissed, routeAllowed]);
+  }, [visible, dismissed, routeAllowed, pinned]);
 
   const handleDismiss = () => {
     setDismissed(true);
@@ -184,10 +210,10 @@ export function StickyCTABar() {
       {visible && (
         <motion.div
           ref={barRef}
-          initial={{ y: 24, opacity: 0 }}
+          initial={reduceMotion ? false : { y: 24, opacity: 0 }}
           animate={{ y: 0, opacity: 1 }}
-          exit={{ y: 16, opacity: 0 }}
-          transition={{ duration: 0.16, ease: "easeOut" }}
+          exit={reduceMotion ? { opacity: 0 } : { y: 16, opacity: 0 }}
+          transition={{ duration: reduceMotion ? 0 : 0.16, ease: "easeOut" }}
           className="de-bottom-bar"
           data-testid="sticky-cta-bar"
           data-sticky-cta-chrome="true"
@@ -204,8 +230,10 @@ export function StickyCTABar() {
             <button
               onClick={handleDismiss}
               className={cn(
-                "absolute right-2 top-2 z-10 rounded-full p-1.5 transition-colors",
-                light ? "hover:bg-black/5" : "hover:bg-white/10",
+                "absolute right-2 top-2 z-10 flex min-h-11 min-w-11 items-center justify-center rounded-full p-1.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A] focus-visible:ring-offset-2",
+                light
+                  ? "hover:bg-black/5 focus-visible:ring-offset-white"
+                  : "hover:bg-white/10 focus-visible:ring-offset-de-raised",
               )}
               aria-label="Close banner"
               data-testid="button-dismiss-sticky-cta"
@@ -214,7 +242,7 @@ export function StickyCTABar() {
             </button>
 
             <div className="px-4 py-3 pr-11">
-              <div className="flex flex-col items-center justify-between gap-3 lg:flex-row lg:gap-5">
+              <div className="flex flex-col items-center justify-between gap-3 sm:flex-row lg:gap-5">
                 <div className="flex min-w-0 items-center gap-3">
                   <div
                     className={cn(
@@ -235,7 +263,7 @@ export function StickyCTABar() {
                     </p>
                     <p
                       className={cn(
-                        "max-w-xl text-sm leading-snug md:text-base",
+                        "hidden max-w-xl text-sm leading-snug lg:block md:text-base",
                         light ? "text-slate-600" : "text-white/70",
                       )}
                     >
@@ -266,8 +294,10 @@ export function StickyCTABar() {
                   <a
                     href={PRIMARY_PHONE.telHref}
                     className={cn(
-                      "hidden items-center gap-2 text-base transition-colors md:flex",
-                      light ? "text-slate-600 hover:text-slate-900" : "text-white/75 hover:text-white",
+                      "hidden items-center gap-2 text-base transition-colors md:flex focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A] focus-visible:ring-offset-2 rounded-sm",
+                      light
+                        ? "text-slate-600 hover:text-slate-900 focus-visible:ring-offset-white"
+                        : "text-white/75 hover:text-white focus-visible:ring-offset-de-raised",
                     )}
                     data-testid="link-phone-sticky"
                   >

--- a/client/src/components/store/CoverageScorePanel.tsx
+++ b/client/src/components/store/CoverageScorePanel.tsx
@@ -9,6 +9,8 @@ interface CoverageScorePanelProps {
   products: StoreProduct[];
   onAddSuggestion?: (product: StoreProduct) => void;
   compact?: boolean;
+  /** Skip the outer card + heading when the parent pane already provides them. */
+  embedded?: boolean;
 }
 
 /**
@@ -17,6 +19,7 @@ interface CoverageScorePanelProps {
 export function CoverageScorePanel({
   products,
   onAddSuggestion,
+  embedded = false,
 }: CoverageScorePanelProps) {
   const score = computeCoverageScore(products);
 
@@ -24,13 +27,21 @@ export function CoverageScorePanel({
 
   return (
     <div
-      className="rounded-xl border border-[color:var(--dp-border-10,#ffffff1a)] bg-[color:var(--dp-card-bg,#141414)] p-4"
+      className={
+        embedded
+          ? ""
+          : "rounded-xl border border-[color:var(--dp-border-10,#ffffff1a)] bg-[color:var(--dp-card-bg,#141414)] p-4"
+      }
       data-testid="coverage-score-panel"
     >
       <div className="mb-3 flex items-center justify-between gap-2">
         <div className="flex items-center gap-2">
           <Shield className="h-4 w-4 text-de-accent-ink" />
-          <h3 className="text-sm font-semibold text-[color:var(--dp-text-primary,#ffffff)]">Solution coverage</h3>
+          {embedded ? (
+            <p className="text-sm font-medium text-[color:var(--dp-text-55,#ffffff8c)]">Heuristic score</p>
+          ) : (
+            <h3 className="text-sm font-semibold text-[color:var(--dp-text-primary,#ffffff)]">Solution coverage</h3>
+          )}
         </div>
         <div className="text-right">
           <span className="text-lg font-bold text-[color:var(--dp-text-primary,#ffffff)]" data-testid="text-coverage-score">

--- a/client/src/components/store/ShoppingCart.tsx
+++ b/client/src/components/store/ShoppingCart.tsx
@@ -20,7 +20,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { getPanelThemeStyle, isRecurringPricing, useCart } from "@/contexts/CartContext";
 import { categoryLabels, formatPrice } from "@/data/storeProducts";
-import { solutionGroupFor, getCartComplements } from "@/data/storeMerchandising";
+import { computeCoverageScore, solutionGroupFor, getCartComplements } from "@/data/storeMerchandising";
 import { getProductVisual } from "@/data/productImages";
 import { billingLabel } from "@shared/storeCommerce";
 import {
@@ -34,6 +34,19 @@ import { analytics } from "@/lib/analytics";
 import { CTA } from "@/lib/ctaCopy";
 import { PRIMARY_PHONE } from "@/data/companyContact";
 import { useDockHiddenWhileOpen } from "@/hooks/useDockHiddenWhileOpen";
+import { formatSnapshotMoney } from "@/lib/solutionSnapshotView";
+import { SolutionDrawerPane } from "@/components/store/SolutionDrawerPane";
+import {
+  checkoutPaneSummary,
+  coveragePaneSummary,
+  defaultSolutionDrawerPanes,
+  itemsPaneSummary,
+  openItemsPane,
+  readSolutionDrawerViewport,
+  toggleSolutionPane,
+  type SolutionDrawerPaneId,
+  type SolutionDrawerPaneState,
+} from "@/components/store/solutionDrawerPanes";
 
 export function ShoppingCart() {
   const {
@@ -57,6 +70,10 @@ export function ShoppingCart() {
     togglePanelTheme,
   } = useCart();
   const [isMinimized, setIsMinimized] = useState(false);
+  const [panes, setPanes] = useState<SolutionDrawerPaneState>(() =>
+    defaultSolutionDrawerPanes("desktop"),
+  );
+  const paneTouchedRef = useRef(false);
   const prefersReducedMotion = useReducedMotion();
   const { toast } = useToast();
   const [, setLocation] = useLocation();
@@ -68,6 +85,7 @@ export function ShoppingCart() {
   const cartProducts = useMemo(() => items.map((item) => item.product), [items]);
   const complements = useMemo(() => getCartComplements(cartProducts, { limit: 3 }), [cartProducts]);
   const missing = useMemo(() => getMissingRequirements(cartProducts), [cartProducts]);
+  const coverage = useMemo(() => computeCoverageScore(cartProducts), [cartProducts]);
 
   const grouped = useMemo(() => {
     const map = new Map<string, typeof items>();
@@ -79,6 +97,21 @@ export function ShoppingCart() {
     }
     return Array.from(map.entries());
   }, [items]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      paneTouchedRef.current = false;
+      return;
+    }
+    if (!paneTouchedRef.current) {
+      setPanes(defaultSolutionDrawerPanes(readSolutionDrawerViewport(window.innerWidth)));
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setPanes((prev) => openItemsPane(prev));
+  }, [isOpen, lastUpdated]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -110,6 +143,17 @@ export function ShoppingCart() {
     ? new Date(lastUpdated).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })
     : null;
 
+  const onTogglePane = (id: SolutionDrawerPaneId) => {
+    paneTouchedRef.current = true;
+    setPanes((prev) => toggleSolutionPane(prev, id));
+  };
+
+  const drawerWidthClass = isMinimized
+    ? "bottom-0 top-auto rounded-tl-2xl sm:max-w-xl"
+    : items.length === 0
+      ? "inset-y-0 max-sm:inset-0 sm:max-w-xl"
+      : "inset-y-0 max-sm:inset-0 sm:max-w-4xl lg:max-w-6xl";
+
   return (
     <AnimatePresence>
       {isOpen && (
@@ -134,9 +178,7 @@ export function ShoppingCart() {
             transition={
               prefersReducedMotion ? { duration: 0 } : { type: "spring", damping: 26, stiffness: 320 }
             }
-            className={`de-panel fixed right-0 z-[61] flex w-full flex-col border-l border-[color:var(--dp-border-10)] bg-[color:var(--dp-panel-bg)] sm:max-w-xl ${
-              isMinimized ? "bottom-0 top-auto rounded-tl-2xl" : "inset-y-0 max-sm:inset-0"
-            }`}
+            className={`de-panel fixed right-0 z-[61] flex w-full flex-col border-l border-[color:var(--dp-border-10)] bg-[color:var(--dp-panel-bg)] ${drawerWidthClass}`}
             data-theme={panelTheme}
             style={getPanelThemeStyle(panelTheme)}
             data-testid="shopping-cart-panel"
@@ -195,366 +237,401 @@ export function ShoppingCart() {
               {announcement}
             </div>
 
-            {!isMinimized && (
-              <div className="flex-1 space-y-5 overflow-y-auto p-5 sm:p-6">
-                {items.length === 0 ? (
-                  <div className="flex h-full flex-col items-center justify-center text-center">
-                    <div className="mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-[color:var(--dp-card-bg)]">
-                      <Layers className="h-10 w-10 text-[color:var(--dp-text-55)]" />
-                    </div>
-                    <h3 className="mb-2 text-lg font-medium text-[color:var(--dp-text-primary)]">No services yet</h3>
-                    <p className="mb-6 text-[color:var(--dp-text-50)]">
-                      Build a solution from outcomes, rails, or the catalog.
-                    </p>
-                    <Button
-                      asChild
-                      className="bg-de-accent text-white hover:bg-[#6548ff]"
-                      onClick={closeCart}
-                      data-testid="button-browse-products"
-                    >
-                      <Link href="/store/co-managed">
-                        Browse Products
-                        <ArrowRight className="ml-2 h-4 w-4" />
-                      </Link>
-                    </Button>
-                  </div>
-                ) : (
-                  <>
-                    <CoverageScorePanel
-                      products={cartProducts}
-                      onAddSuggestion={(product) => {
-                        addToCart(product, Math.max(1, product.minimumQuantity), product.basePrice);
-                        toast({ title: "Added to solution", description: product.name });
-                      }}
-                    />
-
-                    {missing.length > 0 && (
-                      <div
-                        className="rounded-xl border border-[color:var(--dp-warn-border)] bg-[color:var(--dp-warn-bg)] p-4"
-                        data-testid="solution-missing-requirements"
-                      >
-                        <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-[color:var(--dp-warn-text)]">
-                          Missing prerequisites
-                        </p>
-                        {missing.map((warning) => (
-                          <div key={`${warning.forSku}-${warning.sku}`} className="mb-2 last:mb-0">
-                            <p className="text-sm text-[color:var(--dp-text-80)]">{warning.message}</p>
-                            {warning.product && (
-                              <Button
-                                size="sm"
-                                variant="outline"
-                                className="mt-2 h-10 border-[color:var(--dp-border-15)] bg-transparent text-[color:var(--dp-text-primary)] hover:bg-[color:var(--dp-hover-bg)]"
-                                onClick={() =>
-                                  addToCart(
-                                    warning.product!,
-                                    Math.max(1, warning.product!.minimumQuantity),
-                                    warning.product!.basePrice,
-                                  )
-                                }
-                              >
-                                Add required item
-                              </Button>
-                            )}
-                          </div>
-                        ))}
-                      </div>
-                    )}
-
-                    {grouped.map(([group, groupItems]) => (
-                      <div key={group}>
-                        <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[color:var(--dp-text-55)]">
-                          {group}
-                        </h3>
-                        <div className="space-y-3">
-                          {groupItems.map((item) => {
-                            const visual = getProductVisual(item.product);
-                            const recurring = isRecurringPricing(item.product.pricingType);
-                            return (
-                              <div
-                                key={item.product.id}
-                                className="rounded-lg border border-[color:var(--dp-border-10)] bg-[color:var(--dp-card-bg)] p-4"
-                                data-testid={`cart-item-${item.product.id}`}
-                              >
-                                <div className="mb-3 flex items-start gap-3">
-                                  <img
-                                    src={visual.logoUrl || visual.cardUrl}
-                                    alt=""
-                                    className="h-12 w-12 shrink-0 rounded-md border border-[color:var(--dp-border-10)] bg-white object-contain p-1"
-                                  />
-                                  <div className="min-w-0 flex-1">
-                                    <h4 className="line-clamp-2 font-medium text-[color:var(--dp-text-primary)]">
-                                      {item.product.name}
-                                    </h4>
-                                    <p className="text-xs text-[color:var(--dp-text-50)]">
-                                      {categoryLabels[item.product.category]} ·{" "}
-                                      {billingLabel(item.product.pricingType, item.product.pricingUnit)}
-                                    </p>
-                                    <p className="text-sm text-[color:var(--dp-text-50)]">{formatPrice(item.product)}</p>
-                                  </div>
-                                </div>
-
-                                <div className="flex items-center justify-between gap-2">
-                                  <div className="flex items-center gap-1">
-                                    <Button
-                                      variant="outline"
-                                      size="icon"
-                                      onClick={() => updateQuantity(item.product.id, item.quantity - 1)}
-                                      disabled={item.quantity <= item.product.minimumQuantity}
-                                      className="h-11 w-11 border-de-accent/30 bg-de-accent/10 text-[color:var(--dp-text-primary)] hover:bg-de-accent/20"
-                                      data-testid={`button-decrease-${item.product.id}`}
-                                      aria-label={`Decrease ${item.product.name}`}
-                                    >
-                                      <Minus className="h-3 w-3" />
-                                    </Button>
-                                    <input
-                                      type="number"
-                                      min={item.product.minimumQuantity}
-                                      value={item.quantity}
-                                      onChange={(event) =>
-                                        updateQuantity(item.product.id, Number(event.target.value))
-                                      }
-                                      className="h-11 w-14 rounded-md border border-[color:var(--dp-border-10)] bg-transparent text-center text-sm text-[color:var(--dp-text-primary)]"
-                                      data-testid={`quantity-${item.product.id}`}
-                                      aria-label={`${item.product.name} quantity`}
-                                    />
-                                    <Button
-                                      variant="outline"
-                                      size="icon"
-                                      onClick={() => updateQuantity(item.product.id, item.quantity + 1)}
-                                      className="h-11 w-11 border-de-accent/30 bg-de-accent/10 text-[color:var(--dp-text-primary)] hover:bg-de-accent/20"
-                                      data-testid={`button-increase-${item.product.id}`}
-                                      aria-label={`Increase ${item.product.name}`}
-                                    >
-                                      <Plus className="h-3 w-3" />
-                                    </Button>
-                                  </div>
-                                  <span className="text-sm font-semibold text-de-accent-ink">
-                                    $
-                                    {(
-                                      (item.clientPrice ?? item.product.basePrice) * item.quantity
-                                    ).toFixed(2)}
-                                    {recurring
-                                      ? item.product.pricingType === "yearly"
-                                        ? "/yr"
-                                        : "/mo"
-                                      : ""}
-                                  </span>
-                                </div>
-
-                                <div className="mt-3 flex flex-wrap gap-2">
-                                  <Button
-                                    variant="ghost"
-                                    size="sm"
-                                    className="h-10 px-2 text-[color:var(--dp-text-60)] hover:text-[color:var(--dp-text-hover)]"
-                                    onClick={() => saveForLater(item.product.id)}
-                                    data-testid={`button-save-later-${item.product.id}`}
-                                  >
-                                    <BookmarkPlus className="mr-1 h-3.5 w-3.5" />
-                                    Save for later
-                                  </Button>
-                                  <Button
-                                    variant="ghost"
-                                    size="sm"
-                                    onClick={() => removeFromCart(item.product.id)}
-                                    className="h-10 px-2 text-[color:var(--dp-danger)] hover:bg-[color:var(--dp-danger-hover-bg)]"
-                                    data-testid={`button-remove-${item.product.id}`}
-                                  >
-                                    <Trash2 className="mr-1 h-3.5 w-3.5" />
-                                    Remove
-                                  </Button>
-                                </div>
-                              </div>
-                            );
-                          })}
-                        </div>
-                      </div>
-                    ))}
-
-                    {canUndoRemove && (
-                      <Button
-                        variant="outline"
-                        className="h-11 w-full border-[color:var(--dp-border-15)] bg-transparent text-[color:var(--dp-text-primary)] hover:bg-[color:var(--dp-hover-bg)]"
-                        onClick={undoRemove}
-                        data-testid="button-undo-remove"
-                      >
-                        <RotateCcw className="mr-2 h-4 w-4" />
-                        Undo remove
-                      </Button>
-                    )}
-
-                    {savedForLater.length > 0 && (
-                      <div data-testid="saved-for-later">
-                        <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[color:var(--dp-text-55)]">
-                          Saved for later
-                        </h3>
-                        <div className="space-y-2">
-                          {savedForLater.map((item) => (
-                            <div
-                              key={item.product.id}
-                              className="flex items-center justify-between gap-2 rounded-lg border border-[color:var(--dp-border-10)] px-3 py-2"
-                            >
-                              <p className="truncate text-sm text-[color:var(--dp-text-primary)]">{item.product.name}</p>
-                              <Button
-                                size="sm"
-                                variant="outline"
-                                className="h-10 border-[color:var(--dp-border-15)] bg-transparent text-[color:var(--dp-text-primary)] hover:bg-[color:var(--dp-hover-bg)]"
-                                onClick={() => moveToSolution(item.product.id)}
-                              >
-                                Move to solution
-                              </Button>
-                            </div>
-                          ))}
-                        </div>
-                      </div>
-                    )}
-
-                    {complements.length > 0 && (
-                      <div
-                        className="rounded-xl border border-[color:var(--dp-border-10)] bg-[color:var(--dp-card-bg)] p-4"
-                        data-testid="cart-complements"
-                      >
-                        <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-[color:var(--dp-text-55)]">
-                          Recommended because
-                        </p>
-                        <div className="space-y-3">
-                          {complements.map((product) => {
-                            const why = recommendationWhy(product, cartProducts);
-                            return (
-                              <div key={product.sku} className="flex items-start justify-between gap-2">
-                                <div className="min-w-0">
-                                  <p className="truncate text-sm text-[color:var(--dp-text-primary)]">{product.name}</p>
-                                  <p className="text-xs text-[color:var(--dp-text-55)]">{why}</p>
-                                  <p className="text-xs text-[color:var(--dp-text-45)]">{formatPrice(product)}</p>
-                                </div>
-                                <Button
-                                  size="sm"
-                                  variant="outline"
-                                  className="h-10 shrink-0 border-[color:var(--dp-border-15)] bg-transparent text-xs text-[color:var(--dp-text-primary)] hover:bg-[color:var(--dp-hover-bg)]"
-                                  onClick={() => {
-                                    addToCart(
-                                      product,
-                                      Math.max(1, product.minimumQuantity),
-                                      product.basePrice,
-                                    );
-                                    analytics.storeAcceptRecommendation(product.name, why ?? "");
-                                    toast({ title: "Added to solution", description: product.name });
-                                  }}
-                                  data-testid={`button-complement-${product.id}`}
-                                >
-                                  Add
-                                </Button>
-                              </div>
-                            );
-                          })}
-                        </div>
-                      </div>
-                    )}
-
-                    <p className="text-xs text-[color:var(--dp-text-55)]">
-                      Estimated onboarding: typically 7–10 business days after kickoff (varies by
-                      stack). Questions?{" "}
-                      <a
-                        href={PRIMARY_PHONE.telHref}
-                        className="inline-flex items-center gap-1 text-de-accent-ink hover:text-de-accent-ink"
-                      >
-                        <Phone className="h-3 w-3" />
-                        {PRIMARY_PHONE.display}
-                      </a>
-                    </p>
-                  </>
-                )}
+            {!isMinimized && items.length === 0 && (
+              <div className="flex flex-1 flex-col items-center justify-center p-5 text-center sm:p-6">
+                <div className="mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-[color:var(--dp-card-bg)]">
+                  <Layers className="h-10 w-10 text-[color:var(--dp-text-55)]" />
+                </div>
+                <h3 className="mb-2 text-lg font-medium text-[color:var(--dp-text-primary)]">No services yet</h3>
+                <p className="mb-6 text-[color:var(--dp-text-50)]">
+                  Build a solution from outcomes, rails, or the catalog.
+                </p>
+                <Button
+                  asChild
+                  className="bg-de-accent text-white hover:bg-[#6548ff]"
+                  onClick={closeCart}
+                  data-testid="button-browse-products"
+                >
+                  <Link href="/store/co-managed">
+                    Browse Products
+                    <ArrowRight className="ml-2 h-4 w-4" />
+                  </Link>
+                </Button>
               </div>
             )}
 
-            {items.length > 0 && (
-              <div className="border-t border-[color:var(--dp-border-10)] bg-[color:var(--dp-card-bg)] p-5 sm:p-6">
-                <div className="mb-4 space-y-2">
-                  {totals.dueToday > 0 && (
-                    <div className="flex items-center justify-between text-sm">
-                      <span className="text-[color:var(--dp-text-60)]">Due today</span>
-                      <span className="text-[color:var(--dp-text-primary)]">${totals.dueToday.toFixed(2)}</span>
-                    </div>
-                  )}
-                  {totals.monthly > 0 && (
-                    <div className="flex items-center justify-between text-sm">
-                      <span className="text-[color:var(--dp-text-60)]">Monthly</span>
-                      <span className="text-[color:var(--dp-text-primary)]">${totals.monthly.toFixed(2)} / month</span>
-                    </div>
-                  )}
-                  {totals.annual > 0 && (
-                    <div className="flex items-center justify-between text-sm">
-                      <span className="text-[color:var(--dp-text-60)]">Annual</span>
-                      <span className="text-[color:var(--dp-text-primary)]">${totals.annual.toFixed(2)}/yr</span>
-                    </div>
-                  )}
-                  {savings > 0 && (
-                    <div className="flex items-center justify-between text-sm">
-                      <span className="text-[color:var(--dp-success)]">Client pricing save</span>
-                      <span className="font-medium text-[color:var(--dp-success)]">-${savings.toFixed(2)}</span>
-                    </div>
-                  )}
-                  <div className="flex items-center justify-between border-t border-[color:var(--dp-border-10)] pt-2">
-                    <span className="font-medium text-[color:var(--dp-text-primary)]">Ongoing equivalent</span>
-                    <span className="text-lg font-bold text-de-accent-ink">
-                      ${totals.recurringMonthlyEquivalent.toFixed(2)}/mo
-                    </span>
-                  </div>
-                  <p className="flex items-start gap-1.5 text-xs text-[color:var(--dp-text-45)]">
-                    <Clock className="mt-0.5 h-3 w-3 shrink-0" />
-                    Recurring services bill on the start date after kickoff. One-time work is due
-                    when the order is placed. Tax is calculated at checkout when applicable.
-                  </p>
-                </div>
+            {!isMinimized && items.length > 0 && (
+              <div className="flex min-h-0 flex-1 flex-col md:flex-row">
+                <SolutionDrawerPane
+                  id="items"
+                  title="In this solution"
+                  summary={itemsPaneSummary(items.length)}
+                  open={panes.items}
+                  onToggle={() => onTogglePane("items")}
+                >
+                  {grouped.map(([group, groupItems]) => (
+                    <div key={group} className="mb-5 last:mb-0">
+                      <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[color:var(--dp-text-55)]">
+                        {group}
+                      </h4>
+                      <div className="space-y-3">
+                        {groupItems.map((item) => {
+                          const visual = getProductVisual(item.product);
+                          const recurring = isRecurringPricing(item.product.pricingType);
+                          return (
+                            <div
+                              key={item.product.id}
+                              className="rounded-lg border border-[color:var(--dp-border-10)] bg-[color:var(--dp-card-bg)] p-4"
+                              data-testid={`cart-item-${item.product.id}`}
+                            >
+                              <div className="mb-3 flex items-start gap-3">
+                                <img
+                                  src={visual.logoUrl || visual.cardUrl}
+                                  alt=""
+                                  className="h-12 w-12 shrink-0 rounded-md border border-[color:var(--dp-border-10)] bg-white object-contain p-1"
+                                />
+                                <div className="min-w-0 flex-1">
+                                  <h4 className="line-clamp-2 font-medium text-[color:var(--dp-text-primary)]">
+                                    {item.product.name}
+                                  </h4>
+                                  <p className="text-xs text-[color:var(--dp-text-50)]">
+                                    {categoryLabels[item.product.category]} ·{" "}
+                                    {billingLabel(item.product.pricingType, item.product.pricingUnit)}
+                                  </p>
+                                  <p className="text-sm text-[color:var(--dp-text-50)]">{formatPrice(item.product)}</p>
+                                </div>
+                              </div>
 
-                <div className="space-y-2.5">
-                  <Button
-                    className="h-12 w-full bg-de-accent text-white hover:bg-[#6548ff]"
-                    onClick={goCheckout}
-                    data-testid="button-checkout"
-                  >
-                    Continue to Checkout
-                    <ArrowRight className="ml-2 h-4 w-4" />
-                  </Button>
-                  <Button
-                    variant="outline"
-                    className="h-11 w-full border-[color:var(--dp-border-15)] bg-transparent text-[color:var(--dp-text-primary)] hover:bg-[color:var(--dp-hover-bg)]"
-                    onClick={goQuote}
-                    data-testid="button-save-quote"
-                  >
-                    <FileText className="mr-2 h-4 w-4" />
-                    Request Formal Quote
-                  </Button>
-                  <div className="grid grid-cols-2 gap-2">
+                              <div className="flex items-center justify-between gap-2">
+                                <div className="flex items-center gap-1">
+                                  <Button
+                                    variant="outline"
+                                    size="icon"
+                                    onClick={() => updateQuantity(item.product.id, item.quantity - 1)}
+                                    disabled={item.quantity <= item.product.minimumQuantity}
+                                    className="h-11 w-11 border-de-accent/30 bg-de-accent/10 text-[color:var(--dp-text-primary)] hover:bg-de-accent/20"
+                                    data-testid={`button-decrease-${item.product.id}`}
+                                    aria-label={`Decrease ${item.product.name}`}
+                                  >
+                                    <Minus className="h-3 w-3" />
+                                  </Button>
+                                  <input
+                                    type="number"
+                                    min={item.product.minimumQuantity}
+                                    value={item.quantity}
+                                    onChange={(event) =>
+                                      updateQuantity(item.product.id, Number(event.target.value))
+                                    }
+                                    className="h-11 w-14 rounded-md border border-[color:var(--dp-border-10)] bg-transparent text-center text-sm text-[color:var(--dp-text-primary)]"
+                                    data-testid={`quantity-${item.product.id}`}
+                                    aria-label={`${item.product.name} quantity`}
+                                  />
+                                  <Button
+                                    variant="outline"
+                                    size="icon"
+                                    onClick={() => updateQuantity(item.product.id, item.quantity + 1)}
+                                    className="h-11 w-11 border-de-accent/30 bg-de-accent/10 text-[color:var(--dp-text-primary)] hover:bg-de-accent/20"
+                                    data-testid={`button-increase-${item.product.id}`}
+                                    aria-label={`Increase ${item.product.name}`}
+                                  >
+                                    <Plus className="h-3 w-3" />
+                                  </Button>
+                                </div>
+                                <span className="text-sm font-semibold text-de-accent-ink">
+                                  $
+                                  {(
+                                    (item.clientPrice ?? item.product.basePrice) * item.quantity
+                                  ).toFixed(2)}
+                                  {recurring
+                                    ? item.product.pricingType === "yearly"
+                                      ? "/yr"
+                                      : "/mo"
+                                    : ""}
+                                </span>
+                              </div>
+
+                              <div className="mt-3 flex flex-wrap gap-2">
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  className="h-10 px-2 text-[color:var(--dp-text-60)] hover:text-[color:var(--dp-text-hover)]"
+                                  onClick={() => saveForLater(item.product.id)}
+                                  data-testid={`button-save-later-${item.product.id}`}
+                                >
+                                  <BookmarkPlus className="mr-1 h-3.5 w-3.5" />
+                                  Save for later
+                                </Button>
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() => removeFromCart(item.product.id)}
+                                  className="h-10 px-2 text-[color:var(--dp-danger)] hover:bg-[color:var(--dp-danger-hover-bg)]"
+                                  data-testid={`button-remove-${item.product.id}`}
+                                >
+                                  <Trash2 className="mr-1 h-3.5 w-3.5" />
+                                  Remove
+                                </Button>
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  ))}
+
+                  {canUndoRemove && (
                     <Button
-                      variant="ghost"
-                      className="h-auto min-h-11 whitespace-normal text-center leading-tight text-[color:var(--dp-text-70)] hover:bg-[color:var(--dp-hover-bg)] hover:text-[color:var(--dp-text-hover)]"
-                      onClick={closeCart}
-                      data-testid="button-continue-shopping"
+                      variant="outline"
+                      className="mt-3 h-11 w-full border-[color:var(--dp-border-15)] bg-transparent text-[color:var(--dp-text-primary)] hover:bg-[color:var(--dp-hover-bg)]"
+                      onClick={undoRemove}
+                      data-testid="button-undo-remove"
                     >
-                      Continue shopping
+                      <RotateCcw className="mr-2 h-4 w-4" />
+                      Undo remove
+                    </Button>
+                  )}
+
+                  {savedForLater.length > 0 && (
+                    <div className="mt-5" data-testid="saved-for-later">
+                      <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[color:var(--dp-text-55)]">
+                        Saved for later
+                      </h4>
+                      <div className="space-y-2">
+                        {savedForLater.map((item) => (
+                          <div
+                            key={item.product.id}
+                            className="flex items-center justify-between gap-2 rounded-lg border border-[color:var(--dp-border-10)] px-3 py-2"
+                          >
+                            <p className="truncate text-sm text-[color:var(--dp-text-primary)]">{item.product.name}</p>
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              className="h-10 border-[color:var(--dp-border-15)] bg-transparent text-[color:var(--dp-text-primary)] hover:bg-[color:var(--dp-hover-bg)]"
+                              onClick={() => moveToSolution(item.product.id)}
+                            >
+                              Move to solution
+                            </Button>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </SolutionDrawerPane>
+
+                <SolutionDrawerPane
+                  id="coverage"
+                  title="Coverage"
+                  summary={coveragePaneSummary(coverage.coveredCount, coverage.dimensionCount)}
+                  open={panes.coverage}
+                  onToggle={() => onTogglePane("coverage")}
+                >
+                  <CoverageScorePanel
+                    embedded
+                    products={cartProducts}
+                    onAddSuggestion={(product) => {
+                      addToCart(product, Math.max(1, product.minimumQuantity), product.basePrice);
+                      toast({ title: "Added to solution", description: product.name });
+                    }}
+                  />
+
+                  {missing.length > 0 && (
+                    <div
+                      className="mt-4 rounded-xl border border-[color:var(--dp-warn-border)] bg-[color:var(--dp-warn-bg)] p-4"
+                      data-testid="solution-missing-requirements"
+                    >
+                      <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-[color:var(--dp-warn-text)]">
+                        Missing prerequisites
+                      </p>
+                      {missing.map((warning) => (
+                        <div key={`${warning.forSku}-${warning.sku}`} className="mb-2 last:mb-0">
+                          <p className="text-sm text-[color:var(--dp-text-80)]">{warning.message}</p>
+                          {warning.product && (
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              className="mt-2 h-10 border-[color:var(--dp-border-15)] bg-transparent text-[color:var(--dp-text-primary)] hover:bg-[color:var(--dp-hover-bg)]"
+                              onClick={() =>
+                                addToCart(
+                                  warning.product!,
+                                  Math.max(1, warning.product!.minimumQuantity),
+                                  warning.product!.basePrice,
+                                )
+                              }
+                            >
+                              Add required item
+                            </Button>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+
+                  {complements.length > 0 && (
+                    <div
+                      className="mt-4 rounded-xl border border-[color:var(--dp-border-10)] bg-[color:var(--dp-card-bg)] p-4"
+                      data-testid="cart-complements"
+                    >
+                      <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-[color:var(--dp-text-55)]">
+                        Recommended because
+                      </p>
+                      <div className="space-y-3">
+                        {complements.map((product) => {
+                          const why = recommendationWhy(product, cartProducts);
+                          return (
+                            <div key={product.sku} className="flex items-start justify-between gap-2">
+                              <div className="min-w-0">
+                                <p className="truncate text-sm text-[color:var(--dp-text-primary)]">{product.name}</p>
+                                <p className="text-xs text-[color:var(--dp-text-55)]">{why}</p>
+                                <p className="text-xs text-[color:var(--dp-text-45)]">{formatPrice(product)}</p>
+                              </div>
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                className="h-10 shrink-0 border-[color:var(--dp-border-15)] bg-transparent text-xs text-[color:var(--dp-text-primary)] hover:bg-[color:var(--dp-hover-bg)]"
+                                onClick={() => {
+                                  addToCart(
+                                    product,
+                                    Math.max(1, product.minimumQuantity),
+                                    product.basePrice,
+                                  );
+                                  analytics.storeAcceptRecommendation(product.name, why ?? "");
+                                  toast({ title: "Added to solution", description: product.name });
+                                }}
+                                data-testid={`button-complement-${product.id}`}
+                              >
+                                Add
+                              </Button>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  )}
+
+                  <p className="mt-4 text-xs text-[color:var(--dp-text-55)]">
+                    Estimated onboarding: typically 7–10 business days after kickoff (varies by
+                    stack). Questions?{" "}
+                    <a
+                      href={PRIMARY_PHONE.telHref}
+                      className="inline-flex items-center gap-1 text-de-accent-ink hover:text-de-accent-ink"
+                    >
+                      <Phone className="h-3 w-3" />
+                      {PRIMARY_PHONE.display}
+                    </a>
+                  </p>
+                </SolutionDrawerPane>
+
+                <SolutionDrawerPane
+                  id="checkout"
+                  title="Totals"
+                  summary={checkoutPaneSummary(totals)}
+                  open={panes.checkout}
+                  onToggle={() => onTogglePane("checkout")}
+                  className="md:max-w-sm"
+                >
+                  <div className="mb-4 space-y-2">
+                    {totals.dueToday > 0 && (
+                      <div className="flex items-center justify-between text-sm">
+                        <span className="text-[color:var(--dp-text-60)]">Due today</span>
+                        <span className="text-[color:var(--dp-text-primary)]">
+                          {formatSnapshotMoney(totals.dueToday)}
+                        </span>
+                      </div>
+                    )}
+                    {totals.monthly > 0 && (
+                      <div className="flex items-center justify-between text-sm">
+                        <span className="text-[color:var(--dp-text-60)]">Monthly</span>
+                        <span className="text-[color:var(--dp-text-primary)]">
+                          {formatSnapshotMoney(totals.monthly)} / month
+                        </span>
+                      </div>
+                    )}
+                    {totals.annual > 0 && (
+                      <div className="flex items-center justify-between text-sm">
+                        <span className="text-[color:var(--dp-text-60)]">Annual</span>
+                        <span className="text-[color:var(--dp-text-primary)]">
+                          {formatSnapshotMoney(totals.annual)}/yr
+                        </span>
+                      </div>
+                    )}
+                    {savings > 0 && (
+                      <div className="flex items-center justify-between text-sm">
+                        <span className="text-[color:var(--dp-success)]">Client pricing save</span>
+                        <span className="font-medium text-[color:var(--dp-success)]">
+                          -{formatSnapshotMoney(savings)}
+                        </span>
+                      </div>
+                    )}
+                    <div className="flex items-center justify-between border-t border-[color:var(--dp-border-10)] pt-2">
+                      <span className="font-medium text-[color:var(--dp-text-primary)]">Ongoing equivalent</span>
+                      <span className="text-lg font-bold text-de-accent-ink">
+                        {formatSnapshotMoney(totals.recurringMonthlyEquivalent)}/mo
+                      </span>
+                    </div>
+                    <p className="flex items-start gap-1.5 text-xs text-[color:var(--dp-text-45)]">
+                      <Clock className="mt-0.5 h-3 w-3 shrink-0" />
+                      Recurring services bill on the start date after kickoff. One-time work is due
+                      when the order is placed. Tax is calculated at checkout when applicable.
+                    </p>
+                  </div>
+
+                  <div className="space-y-2.5">
+                    <Button
+                      className="h-12 w-full bg-de-accent text-white hover:bg-[#6548ff]"
+                      onClick={goCheckout}
+                      data-testid="button-checkout"
+                    >
+                      Continue to Checkout
+                      <ArrowRight className="ml-2 h-4 w-4" />
                     </Button>
                     <Button
-                      asChild
-                      variant="ghost"
-                      className="h-auto min-h-11 whitespace-normal text-center leading-tight text-[color:var(--dp-text-70)] hover:bg-de-accent/10 hover:text-[color:var(--dp-text-hover)]"
-                      onClick={closeCart}
-                      data-testid="button-schedule-from-cart"
+                      variant="outline"
+                      className="h-11 w-full border-[color:var(--dp-border-15)] bg-transparent text-[color:var(--dp-text-primary)] hover:bg-[color:var(--dp-hover-bg)]"
+                      onClick={goQuote}
+                      data-testid="button-save-quote"
                     >
-                      <a href="/book" className="whitespace-normal text-center leading-tight">
-                        <Calendar className="mr-1 h-4 w-4 shrink-0" />
-                        {CTA.primaryShort}
-                      </a>
+                      <FileText className="mr-2 h-4 w-4" />
+                      Request Formal Quote
+                    </Button>
+                    <div className="grid grid-cols-2 gap-2">
+                      <Button
+                        variant="ghost"
+                        className="h-auto min-h-11 whitespace-normal text-center leading-tight text-[color:var(--dp-text-70)] hover:bg-[color:var(--dp-hover-bg)] hover:text-[color:var(--dp-text-hover)]"
+                        onClick={closeCart}
+                        data-testid="button-continue-shopping"
+                      >
+                        Continue shopping
+                      </Button>
+                      <Button
+                        asChild
+                        variant="ghost"
+                        className="h-auto min-h-11 whitespace-normal text-center leading-tight text-[color:var(--dp-text-70)] hover:bg-de-accent/10 hover:text-[color:var(--dp-text-hover)]"
+                        onClick={closeCart}
+                        data-testid="button-schedule-from-cart"
+                      >
+                        <a href="/book" className="whitespace-normal text-center leading-tight">
+                          <Calendar className="mr-1 h-4 w-4 shrink-0" />
+                          {CTA.primaryShort}
+                        </a>
+                      </Button>
+                    </div>
+                    <Button
+                      variant="ghost"
+                      onClick={clearCart}
+                      className="h-10 w-full text-[color:var(--dp-text-50)] hover:bg-[color:var(--dp-hover-bg)] hover:text-[color:var(--dp-text-hover)]"
+                      data-testid="button-clear-cart"
+                    >
+                      Clear solution
                     </Button>
                   </div>
-                  <Button
-                    variant="ghost"
-                    onClick={clearCart}
-                    className="h-10 w-full text-[color:var(--dp-text-50)] hover:bg-[color:var(--dp-hover-bg)] hover:text-[color:var(--dp-text-hover)]"
-                    data-testid="button-clear-cart"
-                  >
-                    Clear solution
-                  </Button>
-                </div>
+                </SolutionDrawerPane>
+              </div>
+            )}
+
+            {isMinimized && items.length > 0 && (
+              <div className="border-t border-[color:var(--dp-border-10)] px-5 py-3 text-sm text-[color:var(--dp-text-60)]">
+                {itemsPaneSummary(items.length)}
+                {totals.dueToday > 0 ? ` · ${checkoutPaneSummary(totals)}` : ""}
               </div>
             )}
           </motion.div>

--- a/client/src/components/store/ShoppingCart.tsx
+++ b/client/src/components/store/ShoppingCart.tsx
@@ -180,6 +180,7 @@ export function ShoppingCart() {
             }
             className={`de-panel fixed right-0 z-[61] flex w-full flex-col border-l border-[color:var(--dp-border-10)] bg-[color:var(--dp-panel-bg)] ${drawerWidthClass}`}
             data-theme={panelTheme}
+            data-accent="electric"
             style={getPanelThemeStyle(panelTheme)}
             data-testid="shopping-cart-panel"
           >
@@ -261,13 +262,14 @@ export function ShoppingCart() {
             )}
 
             {!isMinimized && items.length > 0 && (
-              <div className="flex min-h-0 flex-1 flex-col md:flex-row">
+              <div className="grid min-h-0 flex-1 grid-cols-1 md:grid-cols-2 md:grid-rows-[auto_minmax(0,1fr)] lg:grid-cols-[minmax(0,1.35fr)_minmax(13rem,1fr)_minmax(17rem,0.95fr)] lg:grid-rows-1">
                 <SolutionDrawerPane
                   id="items"
                   title="In this solution"
                   summary={itemsPaneSummary(items.length)}
                   open={panes.items}
                   onToggle={() => onTogglePane("items")}
+                  className="md:row-start-2 lg:col-start-1 lg:row-start-1"
                 >
                   {grouped.map(([group, groupItems]) => (
                     <div key={group} className="mb-5 last:mb-0">
@@ -424,6 +426,7 @@ export function ShoppingCart() {
                   summary={coveragePaneSummary(coverage.coveredCount, coverage.dimensionCount)}
                   open={panes.coverage}
                   onToggle={() => onTogglePane("coverage")}
+                  className="md:col-span-2 md:row-start-1 md:max-h-[42vh] md:border-b md:border-r-0 lg:col-span-1 lg:col-start-2 lg:row-start-1 lg:max-h-none lg:border-b-0 lg:border-r"
                 >
                   <CoverageScorePanel
                     embedded
@@ -527,7 +530,7 @@ export function ShoppingCart() {
                   summary={checkoutPaneSummary(totals)}
                   open={panes.checkout}
                   onToggle={() => onTogglePane("checkout")}
-                  className="md:max-w-sm"
+                  className="md:col-start-2 md:row-start-2 md:border-r-0 lg:col-start-3 lg:row-start-1"
                 >
                   <div className="mb-4 space-y-2">
                     {totals.dueToday > 0 && (

--- a/client/src/components/store/SolutionDrawerPane.tsx
+++ b/client/src/components/store/SolutionDrawerPane.tsx
@@ -28,8 +28,8 @@ export function SolutionDrawerPane({
   return (
     <section
       className={cn(
-        "flex min-w-0 flex-col border-b border-[color:var(--dp-border-10)] md:border-b-0 md:border-r md:last:border-r-0",
-        open ? "min-h-0 flex-1 md:min-w-[16rem]" : "flex-none md:w-56 md:shrink-0",
+        "flex h-full min-h-0 min-w-0 flex-col border-b border-[color:var(--dp-border-10)] md:border-b-0 md:border-r md:last:border-r-0",
+        !open && "flex-none",
         className,
       )}
       data-testid={`solution-pane-${id}`}

--- a/client/src/components/store/SolutionDrawerPane.tsx
+++ b/client/src/components/store/SolutionDrawerPane.tsx
@@ -1,0 +1,73 @@
+import type { ReactNode } from "react";
+import { ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { SolutionDrawerPaneId } from "./solutionDrawerPanes";
+
+type SolutionDrawerPaneProps = {
+  id: SolutionDrawerPaneId;
+  title: string;
+  summary: string;
+  open: boolean;
+  onToggle: () => void;
+  children: ReactNode;
+  className?: string;
+};
+
+export function SolutionDrawerPane({
+  id,
+  title,
+  summary,
+  open,
+  onToggle,
+  children,
+  className,
+}: SolutionDrawerPaneProps) {
+  const panelId = `solution-pane-panel-${id}`;
+  const headingId = `solution-pane-title-${id}`;
+
+  return (
+    <section
+      className={cn(
+        "flex min-w-0 flex-col border-b border-[color:var(--dp-border-10)] md:border-b-0 md:border-r md:last:border-r-0",
+        open ? "min-h-0 flex-1 md:min-w-[16rem]" : "flex-none md:w-56 md:shrink-0",
+        className,
+      )}
+      data-testid={`solution-pane-${id}`}
+      data-pane-open={open ? "true" : "false"}
+    >
+      <h3 id={headingId} className="sr-only">
+        {title}
+      </h3>
+      <button
+        type="button"
+        className="flex min-h-11 w-full shrink-0 items-center gap-3 px-4 py-2.5 text-left hover:bg-[color:var(--dp-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-de-accent focus-visible:ring-inset"
+        aria-expanded={open}
+        aria-controls={panelId}
+        onClick={onToggle}
+        data-testid={`button-toggle-pane-${id}`}
+      >
+        <span className="text-sm font-semibold text-[color:var(--dp-text-primary)]">{title}</span>
+        <span className="min-w-0 flex-1 truncate text-sm text-[color:var(--dp-text-50)]">
+          {summary}
+        </span>
+        <ChevronDown
+          className={cn(
+            "h-4 w-4 shrink-0 text-[color:var(--dp-text-55)] motion-safe:transition-transform motion-safe:duration-200",
+            open && "rotate-180",
+          )}
+          aria-hidden="true"
+        />
+      </button>
+      {open ? (
+        <div
+          id={panelId}
+          role="region"
+          aria-labelledby={headingId}
+          className="min-h-0 flex-1 overflow-y-auto px-4 pb-4 pt-1 sm:px-5"
+        >
+          {children}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/client/src/components/store/SolutionOrderSummary.tsx
+++ b/client/src/components/store/SolutionOrderSummary.tsx
@@ -61,7 +61,7 @@ export function SolutionOrderSummary({
 
   return (
     <div
-      className="sticky top-28 rounded-xl border border-white/10 bg-white/5 p-6"
+      className="de-checkout-summary rounded-xl border border-white/10 bg-white/5 p-6"
       data-testid={testId}
     >
       <h2 className="mb-6 flex items-center gap-2 text-xl font-semibold text-white">

--- a/client/src/components/store/solutionDrawerPanes.test.ts
+++ b/client/src/components/store/solutionDrawerPanes.test.ts
@@ -79,6 +79,9 @@ describe("Your Solution drawer source", () => {
     expect(cartSrc).toMatch(/id="coverage"/);
     expect(cartSrc).toMatch(/id="checkout"/);
     expect(cartSrc).toMatch(/lg:max-w-6xl/);
+    expect(cartSrc).toMatch(/md:grid-cols-2/);
+    expect(cartSrc).toMatch(/lg:grid-cols-\[minmax\(0,1\.35fr\)/);
+    expect(cartSrc).toMatch(/data-accent="electric"/);
     expect(paneSrc).toMatch(/data-testid=\{`solution-pane-\$\{id\}`\}/);
     expect(paneSrc).toMatch(/aria-expanded=\{open\}/);
     expect(paneSrc).toMatch(/min-h-11/);

--- a/client/src/components/store/solutionDrawerPanes.test.ts
+++ b/client/src/components/store/solutionDrawerPanes.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  checkoutPaneSummary,
+  coveragePaneSummary,
+  defaultSolutionDrawerPanes,
+  itemsPaneSummary,
+  openItemsPane,
+  readSolutionDrawerViewport,
+  toggleSolutionPane,
+} from "./solutionDrawerPanes";
+
+describe("solution drawer panes", () => {
+  it("uses stacked, two-pane, then three-pane viewports", () => {
+    expect(readSolutionDrawerViewport(390)).toBe("mobile");
+    expect(readSolutionDrawerViewport(767)).toBe("mobile");
+    expect(readSolutionDrawerViewport(768)).toBe("tablet");
+    expect(readSolutionDrawerViewport(1023)).toBe("tablet");
+    expect(readSolutionDrawerViewport(1024)).toBe("desktop");
+    expect(readSolutionDrawerViewport(1440)).toBe("desktop");
+  });
+
+  it("keeps items and checkout open; coverage only defaults open on desktop", () => {
+    expect(defaultSolutionDrawerPanes("mobile")).toEqual({
+      items: true,
+      coverage: false,
+      checkout: true,
+    });
+    expect(defaultSolutionDrawerPanes("tablet")).toEqual({
+      items: true,
+      coverage: false,
+      checkout: true,
+    });
+    expect(defaultSolutionDrawerPanes("desktop")).toEqual({
+      items: true,
+      coverage: true,
+      checkout: true,
+    });
+  });
+
+  it("reopens items after add without closing checkout", () => {
+    const collapsedItems = { items: false, coverage: true, checkout: true };
+    expect(openItemsPane(collapsedItems)).toEqual({
+      items: true,
+      coverage: true,
+      checkout: true,
+    });
+  });
+
+  it("toggles panes independently", () => {
+    const start = defaultSolutionDrawerPanes("desktop");
+    const coverageClosed = toggleSolutionPane(start, "coverage");
+    expect(coverageClosed.coverage).toBe(false);
+    expect(coverageClosed.items).toBe(true);
+    expect(coverageClosed.checkout).toBe(true);
+  });
+
+  it("summarizes existing solution data without inventing totals", () => {
+    expect(itemsPaneSummary(1)).toBe("1 service");
+    expect(itemsPaneSummary(4)).toBe("4 services");
+    expect(coveragePaneSummary(3, 6)).toBe("3 of 6 areas");
+    expect(checkoutPaneSummary({ dueToday: 2599, monthly: 224, annual: 0 })).toMatch(
+      /^Due today \$2,?599\.00$/,
+    );
+    expect(checkoutPaneSummary({ dueToday: 0, monthly: 224, annual: 0 })).toMatch(/^Monthly \$224\.00$/);
+    expect(checkoutPaneSummary({ dueToday: 0, monthly: 0, annual: 0 })).toBe("Review totals");
+  });
+});
+
+describe("Your Solution drawer source", () => {
+  const dir = dirname(fileURLToPath(import.meta.url));
+  const cartSrc = readFileSync(resolve(dir, "ShoppingCart.tsx"), "utf8");
+  const paneSrc = readFileSync(resolve(dir, "SolutionDrawerPane.tsx"), "utf8");
+
+  it("lays out independent panes instead of a single stacked max-w-xl column", () => {
+    expect(cartSrc).toMatch(/id="items"/);
+    expect(cartSrc).toMatch(/id="coverage"/);
+    expect(cartSrc).toMatch(/id="checkout"/);
+    expect(cartSrc).toMatch(/lg:max-w-6xl/);
+    expect(paneSrc).toMatch(/data-testid=\{`solution-pane-\$\{id\}`\}/);
+    expect(paneSrc).toMatch(/aria-expanded=\{open\}/);
+    expect(paneSrc).toMatch(/min-h-11/);
+  });
+
+  it("preserves checkout, quote, shopping, and assessment actions", () => {
+    expect(cartSrc).toMatch(/Continue to Checkout/);
+    expect(cartSrc).toMatch(/Request Formal Quote/);
+    expect(cartSrc).toMatch(/Continue shopping/);
+    expect(cartSrc).toMatch(/button-schedule-from-cart/);
+    expect(cartSrc).toMatch(/button-checkout/);
+    expect(cartSrc).toMatch(/button-save-quote/);
+  });
+});

--- a/client/src/components/store/solutionDrawerPanes.ts
+++ b/client/src/components/store/solutionDrawerPanes.ts
@@ -1,0 +1,59 @@
+import { formatSnapshotMoney } from "@/lib/solutionSnapshotView";
+
+export type SolutionDrawerPaneId = "items" | "coverage" | "checkout";
+export type SolutionDrawerViewport = "mobile" | "tablet" | "desktop";
+
+export type SolutionDrawerPaneState = Record<SolutionDrawerPaneId, boolean>;
+
+export const SOLUTION_PANE_IDS: SolutionDrawerPaneId[] = ["items", "coverage", "checkout"];
+
+export function readSolutionDrawerViewport(width: number): SolutionDrawerViewport {
+  if (width < 768) return "mobile";
+  if (width < 1024) return "tablet";
+  return "desktop";
+}
+
+/**
+ * Line items stay open so an add is visible. Checkout stays open so pay/quote
+ * is reachable. Coverage is a genuine third pane on desktop; it starts collapsed
+ * on smaller screens so it does not bury the cart.
+ */
+export function defaultSolutionDrawerPanes(
+  viewport: SolutionDrawerViewport,
+): SolutionDrawerPaneState {
+  return {
+    items: true,
+    coverage: viewport === "desktop",
+    checkout: true,
+  };
+}
+
+export function openItemsPane(state: SolutionDrawerPaneState): SolutionDrawerPaneState {
+  return { ...state, items: true };
+}
+
+export function toggleSolutionPane(
+  state: SolutionDrawerPaneState,
+  id: SolutionDrawerPaneId,
+): SolutionDrawerPaneState {
+  return { ...state, [id]: !state[id] };
+}
+
+export function itemsPaneSummary(count: number): string {
+  return `${count} service${count === 1 ? "" : "s"}`;
+}
+
+export function coveragePaneSummary(coveredCount: number, dimensionCount: number): string {
+  return `${coveredCount} of ${dimensionCount} areas`;
+}
+
+export function checkoutPaneSummary(totals: {
+  dueToday: number;
+  monthly: number;
+  annual: number;
+}): string {
+  if (totals.dueToday > 0) return `Due today ${formatSnapshotMoney(totals.dueToday)}`;
+  if (totals.monthly > 0) return `Monthly ${formatSnapshotMoney(totals.monthly)}`;
+  if (totals.annual > 0) return `Annual ${formatSnapshotMoney(totals.annual)}`;
+  return "Review totals";
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -337,7 +337,21 @@ html.de-marketing-canvas body {
   min-height: 100%;
   background-color: var(--de-bg);
   box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.04);
-  padding-bottom: calc(var(--de-unified-bar-h) + var(--de-sticky-cta-h) + var(--de-chrome-inset));
+  padding-bottom: calc(
+    var(--de-unified-bar-h) + var(--de-sticky-cta-h) + var(--de-cookie-h) + var(--de-chrome-inset)
+  );
+}
+
+/* Keep checkout/quote Pay Now above cookie + assessment + dock. */
+.de-checkout-summary {
+  position: sticky;
+  top: calc(var(--de-nav-current-bottom) + 0.75rem);
+  max-height: calc(
+    100dvh - var(--de-nav-current-bottom) - var(--de-cookie-h) - var(--de-sticky-cta-h) -
+      var(--de-unified-bar-h) - 2.5rem
+  );
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 .de-fixed-in-canvas {

--- a/client/src/lib/stickyCtaVisibility.test.ts
+++ b/client/src/lib/stickyCtaVisibility.test.ts
@@ -3,7 +3,9 @@ import {
   isNearDocumentEnd,
   isPageFooterOnScreen,
   isPastStickyCtaThreshold,
+  isStickyCtaPinnedRoute,
   isStickyCtaRouteAllowed,
+  isTooShortToReachStickyThreshold,
   rectOverlapsPageContent,
   shouldShowStickyCta,
 } from "./stickyCtaVisibility";
@@ -16,9 +18,22 @@ describe("sticky CTA visibility", () => {
     expect(isStickyCtaRouteAllowed("/store")).toBe(true);
   });
 
+  it("pins checkout and quote even when the page is too short to scroll", () => {
+    expect(isStickyCtaPinnedRoute("/store/checkout")).toBe(true);
+    expect(isStickyCtaPinnedRoute("/store/quote-request")).toBe(true);
+    expect(isStickyCtaPinnedRoute("/store")).toBe(false);
+    expect(isStickyCtaPinnedRoute("/solutions")).toBe(false);
+  });
+
   it("waits until the visitor is halfway down the first screen", () => {
     expect(isPastStickyCtaThreshold(100, 800)).toBe(false);
     expect(isPastStickyCtaThreshold(401, 800)).toBe(true);
+  });
+
+  it("treats a short document as already past the scroll threshold", () => {
+    expect(isTooShortToReachStickyThreshold(900, 900)).toBe(true);
+    expect(isTooShortToReachStickyThreshold(900, 1100)).toBe(true);
+    expect(isTooShortToReachStickyThreshold(900, 2400)).toBe(false);
   });
 
   it("hides while scrolling, overlapping, timed out, or dismissed", () => {
@@ -37,6 +52,21 @@ describe("sticky CTA visibility", () => {
     expect(shouldShowStickyCta({ ...base, dismissed: true })).toBe(false);
   });
 
+  it("shows on a pinned checkout page without waiting for scroll or a long document", () => {
+    const checkout = {
+      dismissed: false,
+      routeAllowed: true,
+      pastThreshold: false,
+      scrolling: true,
+      overlapping: false,
+      autoHidden: true,
+      pinned: true,
+    };
+    expect(shouldShowStickyCta(checkout)).toBe(true);
+    expect(shouldShowStickyCta({ ...checkout, overlapping: true })).toBe(false);
+    expect(shouldShowStickyCta({ ...checkout, dismissed: true })).toBe(false);
+  });
+
   it("does not treat ordinary page copy as overlap", () => {
     const article = {
       closest: () => null,
@@ -48,7 +78,7 @@ describe("sticky CTA visibility", () => {
     expect(overlaps).toBe(false);
   });
 
-  it("parks when a dialog or cookie banner sits in the same slot", () => {
+  it("parks when a dialog sits in the same slot", () => {
     const dialog = {
       closest: (selector: string) => (selector === "[role='dialog']" ? dialog : null),
     } as unknown as Element;
@@ -58,6 +88,19 @@ describe("sticky CTA visibility", () => {
         () => [dialog],
       ),
     ).toBe(true);
+  });
+
+  it("stacks with the cookie banner instead of parking behind it", () => {
+    const cookie = {
+      closest: (selector: string) =>
+        selector === "[data-testid='cookie-consent-banner']" ? cookie : null,
+    } as unknown as Element;
+    expect(
+      rectOverlapsPageContent(
+        { top: 700, left: 40, width: 1200, height: 100, right: 1240 },
+        () => [cookie],
+      ),
+    ).toBe(false);
   });
 
   it("parks near the document footer", () => {

--- a/client/src/lib/stickyCtaVisibility.ts
+++ b/client/src/lib/stickyCtaVisibility.ts
@@ -9,6 +9,9 @@ const COMPETING_CHROME_SELECTORS = [
   ".de-unified-bar",
   ".de-fab-rail",
   "[data-sticky-cta-chrome]",
+  // Cookie stacks under the assessment bar via --de-cookie-h. Treating it as a
+  // blocker hid the Risk Assessment CTA whenever the banner was on screen.
+  "[data-testid='cookie-consent-banner']",
 ];
 
 const BLOCKING_OVERLAY_SELECTORS = [
@@ -16,7 +19,6 @@ const BLOCKING_OVERLAY_SELECTORS = [
   "[aria-modal='true']",
   "[data-radix-dialog-content]",
   "[data-radix-dialog-overlay]",
-  "[data-testid='cookie-consent-banner']",
   ".de-desk-shell",
   // Commerce surfaces with their own CTAs/prices — the assessment bar must not
   // print over another product's "Add"/price link or a trust claim. Ordinary
@@ -35,8 +37,26 @@ export function isStickyCtaRouteAllowed(path: string): boolean {
   return path !== "/" && !path.startsWith("/portal");
 }
 
+/** Checkout (and quote) stay pinned even when the page is too short to scroll. */
+export function isStickyCtaPinnedRoute(path: string): boolean {
+  return (
+    path === "/store/checkout" ||
+    path.startsWith("/store/checkout/") ||
+    path === "/store/quote-request" ||
+    path.startsWith("/store/quote-request/")
+  );
+}
+
 export function isPastStickyCtaThreshold(scrollY: number, viewportH: number): boolean {
   return scrollY > viewportH * 0.5;
+}
+
+/** True when the document cannot scroll far enough to ever pass the 50% threshold. */
+export function isTooShortToReachStickyThreshold(
+  viewportH: number,
+  scrollHeight: number,
+): boolean {
+  return scrollHeight - viewportH <= viewportH * 0.5;
 }
 
 /** Park the bar when the visitor is on the page footer so links stay clickable. */
@@ -61,15 +81,16 @@ export function shouldShowStickyCta(input: {
   scrolling: boolean;
   overlapping: boolean;
   autoHidden: boolean;
+  pinned?: boolean;
 }): boolean {
-  return (
-    !input.dismissed &&
-    input.routeAllowed &&
-    input.pastThreshold &&
-    !input.scrolling &&
-    !input.overlapping &&
-    !input.autoHidden
-  );
+  if (input.dismissed || !input.routeAllowed) return false;
+  if (input.overlapping) return false;
+  if (input.pinned) {
+    // Checkout must stay on a short page: no scroll threshold, no 12s auto-hide,
+    // no “park because the footer is already in view.”
+    return true;
+  }
+  return input.pastThreshold && !input.scrolling && !input.autoHidden;
 }
 
 export function isStickyCtaChrome(el: Element | null): boolean {
@@ -77,7 +98,7 @@ export function isStickyCtaChrome(el: Element | null): boolean {
   return COMPETING_CHROME_SELECTORS.some((selector) => el.closest(selector));
 }
 
-/** Dialogs, drawers, cookie, and Desk occupy the same dock — page copy does not. */
+/** Dialogs, Desk, and store product CTAs occupy the same dock — cookie chrome stacks instead. */
 export function isBlockingStickyCtaTarget(el: Element | null): boolean {
   if (!el) return false;
   if (typeof document !== "undefined" && (el === document.documentElement || el === document.body)) {

--- a/client/src/lib/storeChromeGestures.test.ts
+++ b/client/src/lib/storeChromeGestures.test.ts
@@ -8,6 +8,7 @@ import {
 
 describe("store chrome gestures", () => {
   it("locks only store routes", () => {
+    expect(isStorePath("/store/checkout")).toBe(true);
     expect(isStorePath("/store")).toBe(true);
     expect(isStorePath("/store/managed")).toBe(true);
     expect(isStorePath("/store/product/de-proactive-office")).toBe(true);

--- a/client/src/lib/storeLightChrome.test.ts
+++ b/client/src/lib/storeLightChrome.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { isStorePath } from "./storeChromeGestures";
+
+const dir = dirname(fileURLToPath(import.meta.url));
+
+describe("store checkout light chrome", () => {
+  it("treats checkout as a store path so bottom popups can use a white surface", () => {
+    expect(isStorePath("/store/checkout")).toBe(true);
+    expect(isStorePath("/solutions")).toBe(false);
+  });
+
+  it("paints the sticky assessment bar white on store routes", () => {
+    const src = readFileSync(resolve(dir, "../components/StickyCTABar.tsx"), "utf8");
+    expect(src).toMatch(/isStorePath\(location\)/);
+    expect(src).toMatch(/data-surface=\{light \? "light" : "dark"\}/);
+    expect(src).toMatch(/border-black\/10 bg-white/);
+    expect(src).toMatch(/variant="brand"/);
+  });
+
+  it("paints the cookie banner white on store routes without restyling marketing pages", () => {
+    const src = readFileSync(resolve(dir, "../components/CookieConsentBanner.tsx"), "utf8");
+    expect(src).toMatch(/isStorePath\(location\)/);
+    expect(src).toMatch(/background: "#ffffff"/);
+    expect(src).toMatch(/background: "#0a0a0a"/);
+    expect(src).toMatch(/bg-\[#D3126A\]/);
+  });
+});

--- a/client/src/lib/storeLightChrome.test.ts
+++ b/client/src/lib/storeLightChrome.test.ts
@@ -12,6 +12,13 @@ describe("store checkout light chrome", () => {
     expect(isStorePath("/solutions")).toBe(false);
   });
 
+  it("pins the assessment bar on checkout so a short 1440 page still shows it", () => {
+    const src = readFileSync(resolve(dir, "../components/StickyCTABar.tsx"), "utf8");
+    expect(src).toMatch(/isStickyCtaPinnedRoute\(location\)/);
+    expect(src).toMatch(/useReducedMotion/);
+    expect(src).toMatch(/pinned \|\| shortPage \|\| isPastStickyCtaThreshold/);
+  });
+
   it("paints the sticky assessment bar white on store routes", () => {
     const src = readFileSync(resolve(dir, "../components/StickyCTABar.tsx"), "utf8");
     expect(src).toMatch(/isStorePath\(location\)/);
@@ -25,6 +32,17 @@ describe("store checkout light chrome", () => {
     expect(src).toMatch(/isStorePath\(location\)/);
     expect(src).toMatch(/background: "#ffffff"/);
     expect(src).toMatch(/background: "#0a0a0a"/);
+    expect(src).toMatch(/light \? "hidden" : "hidden lg:block"/);
+    expect(src).toMatch(/useReducedMotion/);
     expect(src).toMatch(/bg-\[#D3126A\]/);
+  });
+
+  it("keeps checkout Pay Now above the white bottom chrome", () => {
+    const summary = readFileSync(resolve(dir, "../components/store/SolutionOrderSummary.tsx"), "utf8");
+    const css = readFileSync(resolve(dir, "../index.css"), "utf8");
+    expect(summary).toMatch(/de-checkout-summary/);
+    expect(css).toMatch(/\.de-checkout-summary/);
+    expect(css).toMatch(/--de-cookie-h/);
+    expect(css).toMatch(/--de-sticky-cta-h/);
   });
 });

--- a/client/src/pages/store/Checkout.tsx
+++ b/client/src/pages/store/Checkout.tsx
@@ -169,9 +169,16 @@ const Checkout = () => {
     <div className="min-h-screen bg-[#0a0a0a]">
       <MegaMenu />
 
-      <main className="de-nav-clear pb-20">
+      <main className="de-nav-clear pb-[calc(5rem+var(--de-cookie-h)+var(--de-sticky-cta-h)+var(--de-unified-bar-h))]">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-          <nav className="mb-8" aria-label="Breadcrumb">
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5 }}
+            className="grid lg:grid-cols-5 gap-8 lg:items-start"
+          >
+            <div className="order-2 lg:order-1 lg:col-span-3 space-y-8">
+          <nav className="mb-2" aria-label="Breadcrumb">
             <ol className="flex items-center gap-2 text-sm text-white/50">
               <li>
                 <Link href="/store" className="hover:text-white transition-colors" data-testid="breadcrumb-store">
@@ -183,7 +190,7 @@ const Checkout = () => {
             </ol>
           </nav>
 
-          <div className="flex items-center gap-4 mb-8">
+          <div className="flex items-center gap-4">
             <Link href="/store">
               <Button variant="ghost" className="text-white/60 hover:text-white" data-testid="button-back-to-store">
                 <ArrowLeft className="w-4 h-4 mr-2" />
@@ -192,20 +199,13 @@ const Checkout = () => {
             </Link>
           </div>
 
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.5 }}
-          >
             <h1 className="text-3xl md:text-4xl font-bold text-white mb-2" data-testid="text-checkout-title">
               Checkout
             </h1>
-            <p className="text-white/60 mb-8" data-testid="text-checkout-subtitle">
+            <p className="text-white/60" data-testid="text-checkout-subtitle">
               Complete your order for IT services and solutions
             </p>
 
-            <div className="grid lg:grid-cols-5 gap-8 lg:items-start">
-              <div className="order-2 lg:order-1 lg:col-span-3 space-y-8">
                 <div className="bg-white/5 border border-white/10 rounded-xl p-6" data-testid="section-billing-info">
                   <h2 className="text-xl font-semibold text-white mb-6 flex items-center gap-2">
                     <FileText className="w-5 h-5 text-de-accent-ink" />
@@ -405,7 +405,6 @@ const Checkout = () => {
                   }
                 />
               </div>
-            </div>
           </motion.div>
         </div>
       </main>

--- a/client/src/pages/store/QuoteRequest.tsx
+++ b/client/src/pages/store/QuoteRequest.tsx
@@ -127,7 +127,7 @@ const QuoteRequest = () => {
     return (
       <div className="min-h-screen bg-[#0a0a0a]">
         <MegaMenu />
-        <main className="de-nav-clear pb-20">
+        <main className="de-nav-clear pb-[calc(5rem+var(--de-cookie-h)+var(--de-sticky-cta-h)+var(--de-unified-bar-h))]">
           <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
             <motion.div
               initial={{ opacity: 0, y: 20 }}
@@ -159,7 +159,7 @@ const QuoteRequest = () => {
     <div className="min-h-screen bg-[#0a0a0a]">
       <MegaMenu />
 
-      <main className="de-nav-clear pb-20">
+      <main className="de-nav-clear pb-[calc(5rem+var(--de-cookie-h)+var(--de-sticky-cta-h)+var(--de-unified-bar-h))]">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
           <nav className="mb-8" aria-label="Breadcrumb">
             <ol className="flex items-center gap-2 text-sm text-white/50">


### PR DESCRIPTION
## Summary
- Your Solution is no longer a single stacked ~576px column. Line items, coverage, and totals are independent collapse/expand panes that sit side by side on desktop, use a coverage strip plus two columns on tablet, and stack on mobile with coverage collapsed so it does not bury the cart.
- Store checkout bottom popups (cookie banner and sticky risk-assessment bar) use a white field and dark type on `/store/*` so they stay readable on the dark checkout page. Magenta stays on the assessment CTA. Marketing pages keep the existing dark cookie/sticky chrome.
- Store electric blue is unchanged on catalog pills and on the solution drawer checkout actions (`data-accent="electric"`). Catalog, quote, continue shopping, and Cyber Risk Assessment are preserved.

## Test plan
- [ ] Open `/store`, add a catalog item, confirm Your Solution opens with the items pane expanded and Continue to Checkout / Request Formal Quote visible.
- [ ] Desktop (~1440): three panes side by side; collapse/expand each; `aria-expanded` and keyboard (Escape still closes).
- [ ] Tablet (~768): coverage is a one-line strip on top; items and totals sit side by side.
- [ ] Mobile (~390): panes stack; coverage stays collapsed to “n of 6 areas”; touch targets remain ~44px.
- [ ] `/store/checkout`: cookie banner is white with dark text; after scrolling, Independent Risk Assessment bar is white with magenta Risk Assessment CTA.
- [ ] Confirm category pills are untouched and store accent remains electric (not magenta catalog restyle).

## CONCURRENCY AUDIT
Branch base: `6fc3d70` (`origin/main` at branch creation)
Current origin/main: `6fc3d70` (fetched before open; no new main commits)
Commits landed on main since branch creation: none
Overlapping files: none vs newer main (branch is a fast-forward of current main)
Reconciliation performed: none required
Newer-main work preserved: YES
Whole-file replacements reviewed: YES (ShoppingCart restructured in place; cookie/sticky keep dark marketing variants)
Tests: `npx vitest run client/src/components/store/solutionDrawerPanes.test.ts client/src/lib/storeLightChrome.test.ts client/src/components/store/categoryAccent.test.ts` — pass
Visual QA: Playwright Chromium at 390 / 768 / 1440 — panes, checkout, cookie (`rgb(255, 255, 255)`), sticky assessment bar (`data-surface=light`, white), checkout Pay Now electric `rgb(29, 111, 242)`

Made with [Cursor](https://cursor.com)