### PR TITLE
Isolate Digital Warehouse and destage public /store

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -17,13 +17,11 @@ import { PageLoadingSkeleton } from "@/components/LoadingSkeleton";
 import { AnnouncerProvider } from "@/components/AccessibleAnnouncer";
 import { useGlobalShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useStoreChromeGestures } from "@/hooks/useStoreChromeGestures";
-import { CartProvider } from "@/contexts/CartContext";
 import { BookingProvider } from "@/contexts/BookingContext";
 import { BookingModal } from "@/components/BookingModal";
 import { CookieConsentBanner } from "@/components/CookieConsentBanner";
-import { ShoppingCart } from "@/components/store/ShoppingCart";
-import { SolutionMobileBar } from "@/components/store/SolutionMobileBar";
 import { isDoor2Path } from "@/lib/isDoor2Path";
+import { isWarehousePath } from "@/lib/warehousePaths";
 
 const SolutionsIndex = lazy(() => import("@/pages/solutions/SolutionsIndex"));
 const ManagedITSupport = lazy(() => import("@/pages/solutions/ManagedITSupport"));
@@ -123,6 +121,7 @@ const PortalVPN = lazy(() => import("@/pages/portal/PortalVPN"));
 const PortalCytracom = lazy(() => import("@/pages/portal/PortalCytracom"));
 const PortalFiles = lazy(() => import("@/pages/portal/PortalFiles"));
 const PortalOrders = lazy(() => import("@/pages/portal/PortalOrders"));
+const PortalMarketplace = lazy(() => import("@/pages/portal/PortalMarketplace"));
 const PortalOrderDetail = lazy(() => import("@/pages/portal/PortalOrderDetail"));
 const PortalBilling = lazy(() => import("@/pages/portal/PortalBilling"));
 const PortalCompany = lazy(() => import("@/pages/portal/PortalCompany"));
@@ -150,15 +149,7 @@ const BookingPage = lazy(() => import("@/pages/BookingPage"));
 const ContactPage = lazy(() => import("@/pages/Contact"));
 const DigeratiHomepage = lazy(() => import("@/pages/DigeratiHomepage").then((m) => ({ default: m.DigeratiHomepage })));
 
-// Store pages
-const StoreLanding = lazy(() => import("@/pages/store/StoreLanding"));
-const ManagedStore = lazy(() => import("@/pages/store/ManagedStore"));
-const CoManagedStore = lazy(() => import("@/pages/store/CoManagedStore"));
-const ProductDetail = lazy(() => import("@/pages/store/ProductDetail"));
-const Checkout = lazy(() => import("@/pages/store/Checkout"));
-const OrderConfirmation = lazy(() => import("@/pages/store/OrderConfirmation"));
-const QuoteRequestPage = lazy(() => import("@/pages/store/QuoteRequest"));
-const QuoteConfirmationPage = lazy(() => import("@/pages/store/QuoteConfirmation"));
+const WarehouseGate = lazy(() => import("@/pages/store/WarehouseGate"));
 
 // Internal DE sales pages were removed from the public bundle for security.
 // They now live behind authentication in the Intelligence Hub (techsales).
@@ -258,44 +249,14 @@ function Router() {
         )} />
       ))}
       
-      {/* Store Pages */}
-      <Route path="/store" component={() => (
+      <Route path="/internal/warehouse/*" component={() => (
         <Suspense fallback={<PageLoadingSkeleton />}>
-          <StoreLanding />
+          <WarehouseGate />
         </Suspense>
       )} />
-      <Route path="/store/managed" component={() => (
+      <Route path="/internal/warehouse" component={() => (
         <Suspense fallback={<PageLoadingSkeleton />}>
-          <ManagedStore />
-        </Suspense>
-      )} />
-      <Route path="/store/co-managed" component={() => (
-        <Suspense fallback={<PageLoadingSkeleton />}>
-          <CoManagedStore />
-        </Suspense>
-      )} />      <Route path="/store/product/:sku" component={() => (
-        <Suspense fallback={<PageLoadingSkeleton />}>
-          <ProductDetail />
-        </Suspense>
-      )} />
-      <Route path="/store/checkout" component={() => (
-        <Suspense fallback={<PageLoadingSkeleton />}>
-          <Checkout />
-        </Suspense>
-      )} />
-      <Route path="/store/order-confirmation" component={() => (
-        <Suspense fallback={<PageLoadingSkeleton />}>
-          <OrderConfirmation />
-        </Suspense>
-      )} />
-      <Route path="/store/quote-request" component={() => (
-        <Suspense fallback={<PageLoadingSkeleton />}>
-          <QuoteRequestPage />
-        </Suspense>
-      )} />
-      <Route path="/store/quote-confirmation/:id" component={() => (
-        <Suspense fallback={<PageLoadingSkeleton />}>
-          <QuoteConfirmationPage />
+          <WarehouseGate />
         </Suspense>
       )} />
       
@@ -727,6 +688,11 @@ function Router() {
           <PortalProcurementStore />
         </Suspense>
       )} />
+      <Route path="/portal/marketplace" component={() => (
+        <Suspense fallback={<PageLoadingSkeleton />}>
+          <PortalMarketplace />
+        </Suspense>
+      )} />
       <Route path="/portal/forms" component={() => (
         <Suspense fallback={<PageLoadingSkeleton />}>
           <PortalAdvancedForms />
@@ -914,6 +880,7 @@ function SpaPageViews() {
  * the brand magenta default.
  */
 const ACCENT_BY_PREFIX: ReadonlyArray<readonly [string, string]> = [
+  ["/internal/warehouse", "electric"],
   ["/store", "electric"],
   ["/support", "cyan"],
   ["/resources/blog", "amber"],
@@ -931,6 +898,7 @@ function AppContent() {
   const isPortal = location.startsWith("/portal");
   const isHome = location === "/";
   const hideDoor2HelpDock = isDoor2Path(location) && location.split("?")[0] !== "/solutions/business-needs";
+  const hideWarehouseChrome = isWarehousePath(location);
   const accent = isPortal ? undefined : accentFor(location);
 
   useEffect(() => {
@@ -953,7 +921,7 @@ function AppContent() {
         <Router />
       </div>
       <MarketingChrome />
-      {!isHome && !hideDoor2HelpDock && <SiteBottomBar />}
+      {!isHome && !hideDoor2HelpDock && !hideWarehouseChrome && <SiteBottomBar />}
       <StickyCTABar />
       <ExitIntentPopup delay={5000} />
       <CookieConsentBanner />
@@ -966,17 +934,13 @@ function App() {
     <ErrorBoundary>
       <HelmetProvider>
         <QueryClientProvider client={queryClient}>
-          <CartProvider>
-            <BookingProvider>
-              <TooltipProvider>
-                <Toaster />
-                <ShoppingCart />
-                <SolutionMobileBar />
-                <BookingModal />
-                <AppContent />
-              </TooltipProvider>
-            </BookingProvider>
-          </CartProvider>
+          <BookingProvider>
+            <TooltipProvider>
+              <Toaster />
+              <BookingModal />
+              <AppContent />
+            </TooltipProvider>
+          </BookingProvider>
         </QueryClientProvider>
       </HelmetProvider>
     </ErrorBoundary>

--- a/client/src/components/ExitIntentPopup.tsx
+++ b/client/src/components/ExitIntentPopup.tsx
@@ -8,6 +8,7 @@ import { CTA } from "@/lib/ctaCopy";
 import logoImage from "@assets/DE-Logo-new_1762461524794.webp";
 import { PRIMARY_PHONE } from "@/data/companyContact";
 import { isDoor2Path } from "@/lib/isDoor2Path";
+import { isWarehousePath } from "@/lib/warehousePaths";
 
 const PUBLIC_EMAIL_DOMAINS = [
   "gmail.com",
@@ -62,6 +63,7 @@ export function ExitIntentPopup({ delay = 30000 }: ExitIntentPopupProps) {
     if (shownRef.current) return;
     if (window.location.pathname.startsWith("/portal")) return;
     if (isDoor2Path(window.location.pathname)) return;
+    if (isWarehousePath(window.location.pathname)) return;
     if (document.documentElement.hasAttribute("data-de-desk-open")) return;
     if (!force) {
       try {
@@ -110,6 +112,7 @@ export function ExitIntentPopup({ delay = 30000 }: ExitIntentPopupProps) {
   useEffect(() => {
     if (window.location.pathname.startsWith("/portal")) return;
     if (isDoor2Path(window.location.pathname)) return;
+    if (isWarehousePath(window.location.pathname)) return;
 
     // Desktop leave toward the tab/address chrome only. No timer, no scroll bait.
     let armed = false;

--- a/client/src/components/MegaMenu.tsx
+++ b/client/src/components/MegaMenu.tsx
@@ -375,7 +375,7 @@ export function MegaMenu() {
     },
     {
       name: 'Store',
-      href: '/store',
+      href: '/solutions/business-needs',
       isSimple: true
     },
     {

--- a/client/src/components/store/CoverageScorePanel.tsx
+++ b/client/src/components/store/CoverageScorePanel.tsx
@@ -32,9 +32,12 @@ export function CoverageScorePanel({
 
   const details = (
     <>
-      <p className={`${compact ? "mb-3" : "mb-4"} text-xs leading-relaxed text-[color:var(--dp-text-55,#ffffff8c)]`}>
-        Heuristic stack coverage (endpoint, identity, email, backup, network, compliance) —
-        not a security audit or certification claim.
+      <p
+        className={`${compact ? "mb-3" : "mb-4"} text-xs leading-relaxed text-[color:var(--dp-text-55,#ffffff8c)]`}
+        data-testid="coverage-experimental-heuristic"
+      >
+        Experimental heuristic — not an authoritative security score, audit, or certification.
+        Stack coverage is estimated from cart categories (endpoint, identity, email, backup, network, compliance).
       </p>
 
       <div className="space-y-2.5">
@@ -107,7 +110,7 @@ export function CoverageScorePanel({
                     Add
                   </Button>
                 ) : (
-                  <Link href={`/store/product/${s.product.sku}`}>
+                  <Link href={`/internal/warehouse/product/${s.product.sku}`}>
                     <span className="text-xs text-de-accent-ink hover:text-de-accent-ink">View</span>
                   </Link>
                 )}

--- a/client/src/components/store/ShoppingCart.tsx
+++ b/client/src/components/store/ShoppingCart.tsx
@@ -133,13 +133,13 @@ export function ShoppingCart() {
   const goCheckout = () => {
     analytics.storeCheckoutStarted(totals.dueToday + totals.monthly + totals.annual);
     closeCart();
-    setLocation("/store/checkout");
+    setLocation("/internal/warehouse/checkout");
   };
 
   const goQuote = () => {
     analytics.storeRequestQuote(totals.dueToday + totals.monthly + totals.annual);
     closeCart();
-    setLocation("/store/checkout");
+    setLocation("/internal/warehouse/checkout");
   };
 
   const lastUpdatedLabel = lastUpdated
@@ -256,7 +256,7 @@ export function ShoppingCart() {
                   onClick={closeCart}
                   data-testid="button-browse-products"
                 >
-                  <Link href="/store/co-managed">
+                  <Link href="/internal/warehouse/co-managed">
                     Browse Products
                     <ArrowRight className="ml-2 h-4 w-4" />
                   </Link>

--- a/client/src/components/store/SolutionMobileBar.tsx
+++ b/client/src/components/store/SolutionMobileBar.tsx
@@ -21,11 +21,11 @@ import { rectOverlapsPageContent } from "@/lib/stickyCtaVisibility";
 export function SolutionMobileBar() {
   const [location] = useLocation();
   const { items, totals, openCart, isOpen } = useCart();
-  const onStore = location.startsWith("/store");
+  const onStore = location.startsWith("/internal/warehouse");
   const onCheckoutFlow = /\/store\/(checkout|quote-request|quote-confirmation|order-confirmation)/.test(
     location,
   );
-  const onPdp = location.startsWith("/store/product/");
+  const onPdp = location.startsWith("/internal/warehouse/product/");
   const barRef = useRef<HTMLDivElement>(null);
   const [overlapping, setOverlapping] = useState(false);
 

--- a/client/src/components/store/StoreAssessmentPanel.tsx
+++ b/client/src/components/store/StoreAssessmentPanel.tsx
@@ -89,7 +89,7 @@ export function StoreAssessmentPanel({
         <p className="mt-1 text-xs text-white/50">
           ProActive Ecosystem packages include layered security and support in one plan.
         </p>
-        <Link href="/store/managed">
+        <Link href="/internal/warehouse/managed">
           <span className="mt-3 inline-flex items-center text-sm text-de-accent-ink hover:text-de-accent-ink">
             View managed packages
             <ArrowRight className="ml-1 h-3.5 w-3.5" />

--- a/client/src/components/store/StoreProductCard.tsx
+++ b/client/src/components/store/StoreProductCard.tsx
@@ -119,7 +119,7 @@ export function StoreProductCard({
         </label>
       )}
 
-      <Link href={`/store/product/${product.sku}`} className="relative block">
+      <Link href={`/internal/warehouse/product/${product.sku}`} className="relative block">
         <ProductMedia
           product={product}
           variant="card"
@@ -154,7 +154,7 @@ export function StoreProductCard({
           <h3
             className="text-base font-bold leading-snug text-[#1A1228] transition-colors group-hover:text-de-accent line-clamp-2"
           >
-            <Link href={`/store/product/${product.sku}`}>
+            <Link href={`/internal/warehouse/product/${product.sku}`}>
               <span title={product.name}>
                 {product.name}
               </span>
@@ -213,7 +213,7 @@ export function StoreProductCard({
           </div>
 
           <div className="flex gap-2">
-            <Link href={`/store/product/${product.sku}`} className="flex-1">
+            <Link href={`/internal/warehouse/product/${product.sku}`} className="flex-1">
               <Button
                 variant="outline"
                 size="sm"

--- a/client/src/lib/stickyCtaVisibility.test.ts
+++ b/client/src/lib/stickyCtaVisibility.test.ts
@@ -15,14 +15,16 @@ describe("sticky CTA visibility", () => {
     expect(isStickyCtaRouteAllowed("/")).toBe(false);
     expect(isStickyCtaRouteAllowed("/portal/dashboard")).toBe(false);
     expect(isStickyCtaRouteAllowed("/solutions")).toBe(true);
-    expect(isStickyCtaRouteAllowed("/store")).toBe(true);
+    expect(isStickyCtaRouteAllowed("/store")).toBe(false);
+    expect(isStickyCtaRouteAllowed("/internal/warehouse")).toBe(false);
     expect(isStickyCtaRouteAllowed("/solutions/business-needs")).toBe(false);
     expect(isStickyCtaRouteAllowed("/solutions/request")).toBe(false);
   });
 
   it("pins checkout and quote even when the page is too short to scroll", () => {
-    expect(isStickyCtaPinnedRoute("/store/checkout")).toBe(true);
-    expect(isStickyCtaPinnedRoute("/store/quote-request")).toBe(true);
+    expect(isStickyCtaPinnedRoute("/internal/warehouse/checkout")).toBe(true);
+    expect(isStickyCtaPinnedRoute("/internal/warehouse/quote-request")).toBe(true);
+    expect(isStickyCtaPinnedRoute("/store/checkout")).toBe(false);
     expect(isStickyCtaPinnedRoute("/store")).toBe(false);
     expect(isStickyCtaPinnedRoute("/solutions")).toBe(false);
   });

--- a/client/src/lib/stickyCtaVisibility.ts
+++ b/client/src/lib/stickyCtaVisibility.ts
@@ -1,4 +1,5 @@
 import { isDoor2Path } from "./isDoor2Path";
+import { isWarehousePath } from "./warehousePaths";
 
 export const STICKY_CTA_SCROLL_IDLE_MS = 900;
 export const STICKY_CTA_AUTO_HIDE_MS = 12_000;
@@ -36,16 +37,24 @@ const BLOCKING_OVERLAY_SELECTORS = [
 ];
 
 export function isStickyCtaRouteAllowed(path: string): boolean {
-  return path !== "/" && !path.startsWith("/portal") && !isDoor2Path(path);
+  const pathname = path.split("?")[0] ?? path;
+  return (
+    pathname !== "/" &&
+    !pathname.startsWith("/portal") &&
+    !pathname.startsWith("/store") &&
+    !isDoor2Path(pathname) &&
+    !isWarehousePath(pathname)
+  );
 }
 
 /** Checkout (and quote) stay pinned even when the page is too short to scroll. */
 export function isStickyCtaPinnedRoute(path: string): boolean {
+  const pathname = path.split("?")[0] ?? path;
   return (
-    path === "/store/checkout" ||
-    path.startsWith("/store/checkout/") ||
-    path === "/store/quote-request" ||
-    path.startsWith("/store/quote-request/")
+    pathname === "/internal/warehouse/checkout" ||
+    pathname.startsWith("/internal/warehouse/checkout/") ||
+    pathname === "/internal/warehouse/quote-request" ||
+    pathname.startsWith("/internal/warehouse/quote-request/")
   );
 }
 

--- a/client/src/lib/storeChromeGestures.test.ts
+++ b/client/src/lib/storeChromeGestures.test.ts
@@ -12,6 +12,8 @@ describe("store chrome gestures", () => {
     expect(isStorePath("/store")).toBe(true);
     expect(isStorePath("/store/managed")).toBe(true);
     expect(isStorePath("/store/product/de-proactive-office")).toBe(true);
+    expect(isStorePath("/internal/warehouse")).toBe(true);
+    expect(isStorePath("/internal/warehouse/checkout")).toBe(true);
     expect(isStorePath("/")).toBe(false);
     expect(isStorePath("/solutions/managed-it-support")).toBe(false);
     expect(isStorePath("/storage")).toBe(false);

--- a/client/src/lib/storeChromeGestures.ts
+++ b/client/src/lib/storeChromeGestures.ts
@@ -10,7 +10,13 @@ export const STORE_HORIZONTAL_RAIL_CLASS = "de-store-h-rail";
 export const STORE_TRAVERSE_WINDOW_MS = 450;
 
 export function isStorePath(path: string): boolean {
-  return path === "/store" || path.startsWith("/store/");
+  const pathname = path.split("?")[0] ?? path;
+  return (
+    pathname === "/store" ||
+    pathname.startsWith("/store/") ||
+    pathname === "/internal/warehouse" ||
+    pathname.startsWith("/internal/warehouse/")
+  );
 }
 
 export function isHorizontalDominantDelta(deltaX: number, deltaY: number, min = 1): boolean {

--- a/client/src/lib/warehousePaths.test.ts
+++ b/client/src/lib/warehousePaths.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { WAREHOUSE_BASE, isWarehousePath, warehousePath } from "./warehousePaths";
+
+describe("warehouse paths", () => {
+  it("builds staff-only routes under /internal/warehouse", () => {
+    expect(WAREHOUSE_BASE).toBe("/internal/warehouse");
+    expect(warehousePath()).toBe("/internal/warehouse");
+    expect(warehousePath("/product/DE-SVC-MGD-IT-MO")).toBe(
+      "/internal/warehouse/product/DE-SVC-MGD-IT-MO",
+    );
+  });
+
+  it("does not treat public store or Door 2 as warehouse", () => {
+    expect(isWarehousePath("/internal/warehouse/managed")).toBe(true);
+    expect(isWarehousePath("/store")).toBe(false);
+    expect(isWarehousePath("/solutions/business-needs")).toBe(false);
+  });
+});

--- a/client/src/lib/warehousePaths.ts
+++ b/client/src/lib/warehousePaths.ts
@@ -1,0 +1,13 @@
+/** Staff Digital Warehouse — never link here from public marketing chrome. */
+export const WAREHOUSE_BASE = "/internal/warehouse";
+
+export function warehousePath(subpath = ""): string {
+  if (!subpath || subpath === "/") return WAREHOUSE_BASE;
+  const suffix = subpath.startsWith("/") ? subpath : `/${subpath}`;
+  return `${WAREHOUSE_BASE}${suffix}`;
+}
+
+export function isWarehousePath(path: string): boolean {
+  const pathname = path.split("?")[0] ?? path;
+  return pathname === WAREHOUSE_BASE || pathname.startsWith(`${WAREHOUSE_BASE}/`);
+}

--- a/client/src/pages/portal/PortalLayout.tsx
+++ b/client/src/pages/portal/PortalLayout.tsx
@@ -74,6 +74,7 @@ const navItems: NavItem[] = [
   { href: "/portal/vpn", label: "VPN Access", icon: Shield, key: "other" },
   { href: "/portal/cytracom", label: "ControlOne Phone", icon: Phone, key: "other" },
   { href: "/portal/ship-center", label: "Ship Center", icon: Truck, key: "other" },
+  { href: "/portal/marketplace", label: "Client Marketplace", icon: ShoppingCart, key: "other" },
   { href: "/portal/procurement", label: "Procurement Store", icon: ShoppingCart, key: "other" },
   { href: "/portal/roadmap", label: "IT Roadmap", icon: Map, key: "other" },
   { href: "/portal/qbr", label: "Business Reviews", icon: BarChart3, key: "other" },

--- a/client/src/pages/portal/PortalMarketplace.tsx
+++ b/client/src/pages/portal/PortalMarketplace.tsx
@@ -1,0 +1,73 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "wouter";
+import { ClipboardCheck, ShoppingCart } from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { PortalLayout } from "./PortalLayout";
+import { portalGet } from "@/lib/portalApi";
+import { MARKETPLACE_ELIGIBILITY } from "@shared/checkoutEligibility";
+
+type MarketplaceResponse = {
+  eligibility: typeof MARKETPLACE_ELIGIBILITY;
+  items: unknown[];
+  status: "unavailable" | "unmapped";
+  reason: string;
+};
+
+export default function PortalMarketplace() {
+  const { data, isLoading, isError } = useQuery<MarketplaceResponse>({
+    queryKey: ["/api/portal/marketplace"],
+    queryFn: () => portalGet<MarketplaceResponse>("/api/portal/marketplace"),
+  });
+
+  return (
+    <PortalLayout title="Client Marketplace">
+      <div className="space-y-6">
+        <div className="space-y-1">
+          <h2 className="text-2xl font-bold">Client Marketplace</h2>
+          <p className="text-gray-600 dark:text-gray-400">
+            Standardized items for your organization. Pay Now is not available until Hub
+            entitlements exist.
+          </p>
+        </div>
+
+        {isError && (
+          <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800 dark:border-red-900/30 dark:bg-red-900/20 dark:text-red-300">
+            Marketplace is temporarily unavailable. Request approval below or contact DE.
+          </div>
+        )}
+
+        <Card data-testid="marketplace-empty">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <ShoppingCart className="h-5 w-5 text-[#D3126A]" />
+              Request Approval
+            </CardTitle>
+            <CardDescription>
+              {isLoading
+                ? "Checking your tenant catalog…"
+                : data?.reason || "Tenant catalog is not available from Hub yet."}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              Eligibility for this surface is <code>{data?.eligibility || MARKETPLACE_ELIGIBILITY}</code>.
+              No warehouse SKUs, vendors, costs, or margins are listed here.
+            </p>
+            <div className="flex flex-wrap gap-3">
+              <Button asChild className="bg-[#D3126A] text-white hover:bg-[#D3126A]/90">
+                <Link href="/portal/forms">
+                  <ClipboardCheck className="mr-2 h-4 w-4" />
+                  Request Approval
+                </Link>
+              </Button>
+              <Button asChild variant="outline">
+                <Link href="/portal/procurement">Open procurement</Link>
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </PortalLayout>
+  );
+}

--- a/client/src/pages/portal/PortalOrders.tsx
+++ b/client/src/pages/portal/PortalOrders.tsx
@@ -346,8 +346,8 @@ export default function PortalOrders() {
                 <p className="text-gray-500 dark:text-gray-400 mb-2">No orders found</p>
                 <p className="text-sm text-gray-400 dark:text-gray-500">
                   {statusFilter !== "all" || sourceFilter !== "all" ? "Try a different filter or " : ""}
-                  <Link href="/store" className="text-[#D3126A] hover:underline">
-                    browse our store
+                  <Link href="/portal/marketplace" className="text-[#D3126A] hover:underline">
+                    browse the client marketplace
                   </Link>
                   {" · "}
                   <Link href="/portal/contracts" className="text-[#D3126A] hover:underline">

--- a/client/src/pages/solutions/SolutionRequest.tsx
+++ b/client/src/pages/solutions/SolutionRequest.tsx
@@ -15,6 +15,7 @@ import {
   parseDeliveryModel,
   type CuratedDeliveryModel,
 } from "@/lib/businessNeeds";
+import { DOOR_2_ELIGIBILITY } from "@shared/checkoutEligibility";
 
 type Intent = "request" | "quote" | "assessment" | "consultation";
 
@@ -205,7 +206,12 @@ export default function SolutionRequest() {
               </Button>
             </section>
           ) : (
-            <form onSubmit={onSubmit} className="space-y-5" noValidate>
+            <form
+              onSubmit={onSubmit}
+              className="space-y-5"
+              noValidate
+              data-eligibility={DOOR_2_ELIGIBILITY}
+            >
               <div className="space-y-2">
                 <Label htmlFor="sr-org" className="text-white/80">
                   Organization

--- a/client/src/pages/solutions/SolutionsIndex.tsx
+++ b/client/src/pages/solutions/SolutionsIndex.tsx
@@ -169,6 +169,29 @@ const SolutionsIndex = () => {
               </Button>
             </div>
 
+            <div className="mx-auto mt-10 grid max-w-4xl gap-4 text-left sm:grid-cols-2" data-testid="solutions-two-doors">
+              <a
+                href="/solutions/proactive-ecosystem"
+                className="rounded-2xl border border-de-hairline bg-de-raised p-6 transition-colors hover:border-[#D3126A]"
+              >
+                <p className="text-xs font-semibold uppercase tracking-wide text-de-accent-ink">Door 1</p>
+                <h2 className="mt-2 font-heading text-xl text-white">Handle Our IT</h2>
+                <p className="mt-2 text-sm leading-relaxed text-white/65">
+                  ProActive operating models. Assessment first — not a catalog checkout.
+                </p>
+              </a>
+              <a
+                href="/solutions/business-needs"
+                className="rounded-2xl border border-de-hairline bg-de-raised p-6 transition-colors hover:border-[#D3126A]"
+              >
+                <p className="text-xs font-semibold uppercase tracking-wide text-de-accent-ink">Door 2</p>
+                <h2 className="mt-2 font-heading text-xl text-white">Solve a Business Need</h2>
+                <p className="mt-2 text-sm leading-relaxed text-white/65">
+                  Thirteen solution families. Request a scoped recommendation — not a catalog checkout.
+                </p>
+              </a>
+            </div>
+
             {/* Factual Proof Chips */}
             <div className="mt-10 flex flex-wrap items-center justify-center gap-3">
               <ProofChip metric="24/7" label="Human-Led SOC" icon={Lock} />

--- a/client/src/pages/solutions/door1Leakage.test.ts
+++ b/client/src/pages/solutions/door1Leakage.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = path.resolve(import.meta.dirname, "../../../..");
+
+const door1Files = [
+  "client/src/pages/solutions/SolutionsIndex.tsx",
+  "client/src/pages/solutions/ProActiveEcosystemPage.tsx",
+  "client/src/pages/solutions/ProActiveITEcosystemPage.tsx",
+  "client/src/pages/solutions/ProActiveOfficeEcosystemPage.tsx",
+  "client/src/pages/solutions/ProActiveBusinessEcosystemPage.tsx",
+  "client/src/pages/solutions/ProActiveEnterpriseEcosystemPage.tsx",
+];
+
+describe("Door 1 public leakage", () => {
+  it("never offers Pay Now and keeps assessment as the primary action", () => {
+    for (const file of door1Files) {
+      const src = readFileSync(path.join(root, file), "utf8");
+      expect(src).not.toContain("Pay Now");
+      expect(src).not.toContain("storeProducts");
+      expect(src).not.toContain("vendorLogos");
+    }
+    const index = readFileSync(path.join(root, "client/src/pages/solutions/SolutionsIndex.tsx"), "utf8");
+    expect(index).toContain("/solutions/proactive-ecosystem");
+    expect(index).toContain("/solutions/business-needs");
+    expect(index).toContain("/book");
+  });
+});

--- a/client/src/pages/store/Checkout.tsx
+++ b/client/src/pages/store/Checkout.tsx
@@ -49,7 +49,7 @@ const Checkout = () => {
   useSEO({
     title: "Checkout | Digerati Experts Store",
     description: "Complete your purchase of IT services and solutions from Digerati Experts.",
-    canonical: "/store/checkout",
+    canonical: "/internal/warehouse/checkout",
     noIndex: true,
   });
 
@@ -71,7 +71,7 @@ const Checkout = () => {
 
   useEffect(() => {
     if (items.length === 0) {
-      navigate("/store");
+      navigate("/internal/warehouse");
     }
   }, [items.length, navigate]);
 
@@ -143,10 +143,10 @@ const Checkout = () => {
           window.location.href = result.url;
         } else if (result.orderId) {
           clearCart();
-          navigate(`/store/order-confirmation?orderId=${result.orderId}`);
+          navigate(`/internal/warehouse/order-confirmation?orderId=${result.orderId}`);
         }
       } else if (paymentMethod === "quote_request") {
-        navigate("/store/quote-request");
+        navigate("/internal/warehouse/quote-request");
         return;
       }
     } catch (error: any) {
@@ -181,7 +181,7 @@ const Checkout = () => {
           <nav className="mb-2" aria-label="Breadcrumb">
             <ol className="flex items-center gap-2 text-sm text-white/50">
               <li>
-                <Link href="/store" className="hover:text-white transition-colors" data-testid="breadcrumb-store">
+                <Link href="/internal/warehouse" className="hover:text-white transition-colors" data-testid="breadcrumb-store">
                   Store
                 </Link>
               </li>
@@ -191,7 +191,7 @@ const Checkout = () => {
           </nav>
 
           <div className="flex items-center gap-4">
-            <Link href="/store">
+            <Link href="/internal/warehouse">
               <Button variant="ghost" className="text-white/60 hover:text-white" data-testid="button-back-to-store">
                 <ArrowLeft className="w-4 h-4 mr-2" />
                 Back to Store
@@ -348,7 +348,7 @@ const Checkout = () => {
                       href={portalLoginWithReturn(
                         typeof window !== "undefined"
                           ? `${window.location.origin}/store/checkout`
-                          : "/store/checkout",
+                          : "/internal/warehouse/checkout",
                       )}
                       className="text-de-accent-ink underline-offset-4 hover:underline"
                       data-testid="checkout-portal-login"

--- a/client/src/pages/store/CoManagedStore.tsx
+++ b/client/src/pages/store/CoManagedStore.tsx
@@ -207,8 +207,8 @@ const CoManagedStore = () => {
     if (selectedPurchasePath !== "all") params.set("path", selectedPurchasePath);
     if (selectedCoverage !== "all") params.set("coverage", selectedCoverage);
     const qs = params.toString();
-    const next = qs ? `/store/co-managed?${qs}` : "/store/co-managed";
-    const current = `/store/co-managed${searchString ? `?${searchString}` : ""}`;
+    const next = qs ? `/internal/warehouse/co-managed?${qs}` : "/internal/warehouse/co-managed";
+    const current = `/internal/warehouse/co-managed${searchString ? `?${searchString}` : ""}`;
     if (next !== current) {
       setLocation(next, { replace: true });
     }
@@ -229,10 +229,11 @@ const CoManagedStore = () => {
   ]);
 
   useSEO({
+    noIndex: true,
     title: "IT Store Catalog | Digerati Experts",
     description:
       "Guided IT storefront: shop by outcome, browse curated rails, and purchase co-managed products — endpoint, security, UCaaS, hardware, and professional services.",
-    canonical: "/store/co-managed",
+    canonical: "/internal/warehouse/co-managed",
   });
 
   const checkoutProducts = useMemo(() => getCheckoutEnabledProducts(), []);
@@ -479,7 +480,7 @@ const CoManagedStore = () => {
       description: "Items added to Your Solution — continue to request a quote.",
     });
     openCart();
-    setLocation("/store/checkout");
+    setLocation("/internal/warehouse/checkout");
   };
 
   const toggleCompare = (product: StoreProduct) => {
@@ -567,7 +568,7 @@ const CoManagedStore = () => {
           <StoreClientBar />
 
           <div className="mb-8 flex items-center gap-2 text-base text-white/50">
-            <Link href="/store" className="transition-colors hover:text-white">
+            <Link href="/internal/warehouse" className="transition-colors hover:text-white">
               Store
             </Link>
             <span>/</span>
@@ -617,7 +618,7 @@ const CoManagedStore = () => {
                 onClick={() => {
                   markGuidedSkipped();
                   setGuidanceTick((n) => n + 1);
-                  setLocation("/store/co-managed?catalog=full", { replace: true });
+                  setLocation("/internal/warehouse/co-managed?catalog=full", { replace: true });
                   scrollToCatalog();
                 }}
                 data-testid="button-browse-everything"
@@ -636,7 +637,7 @@ const CoManagedStore = () => {
                   onClick={() => {
                     markGuidedSkipped();
                     setGuidanceTick((n) => n + 1);
-                    setLocation("/store/co-managed?catalog=full", { replace: true });
+                    setLocation("/internal/warehouse/co-managed?catalog=full", { replace: true });
                   }}
                 >
                   Browse the full catalog
@@ -914,7 +915,7 @@ const CoManagedStore = () => {
               Ecosystem plans for all-inclusive support — or ask Digerati to recommend a stack.
             </p>
             <div className="flex flex-col justify-center gap-4 sm:flex-row">
-              <Link href="/store/managed">
+              <Link href="/internal/warehouse/managed">
                 <Button
                   size="lg"
                   className="h-12 bg-de-accent px-6 text-white hover:bg-[#6548ff]"
@@ -978,7 +979,7 @@ const CoManagedStore = () => {
         onSkipCatalog={() => {
           markGuidedSkipped();
           setGuidanceTick((n) => n + 1);
-          setLocation("/store/co-managed?catalog=full", { replace: true });
+          setLocation("/internal/warehouse/co-managed?catalog=full", { replace: true });
         }}
         onComplete={(next) => {
           setGuidanceTick((n) => n + 1);

--- a/client/src/pages/store/ManagedStore.tsx
+++ b/client/src/pages/store/ManagedStore.tsx
@@ -26,9 +26,10 @@ const ManagedStore = () => {
   const prefersReducedMotion = useReducedMotion();
 
   useSEO({
+    noIndex: true,
     title: 'Managed IT Packages | Digerati Experts Store',
     description: 'Complete managed IT packages and ProActive Ecosystem plans for businesses. Full-service IT support, security, compliance, and strategy—all in one predictable subscription.',
-    canonical: '/store/managed',
+    canonical: '/internal/warehouse/managed',
   });
 
   const contractOnlyProducts = getContractOnlyProducts();
@@ -54,7 +55,7 @@ const ManagedStore = () => {
   const ProductCard = ({ product, featured = false }: { product: StoreProduct; featured?: boolean }) => {
     const visual = getProductVisual(product);
     return (
-    <Link href={`/store/product/${product.sku}`}>
+    <Link href={`/internal/warehouse/product/${product.sku}`}>
       <motion.div
         variants={itemVariants}
         className={`relative overflow-hidden rounded-xl border transition-all duration-300 hover:-translate-y-1 cursor-pointer ${
@@ -147,7 +148,7 @@ const ManagedStore = () => {
           
           <StoreClientBar />
           <div className="mb-8 flex items-center gap-2 text-sm text-white/50">
-            <Link href="/store" className="transition-colors hover:text-white">Store</Link>
+            <Link href="/internal/warehouse" className="transition-colors hover:text-white">Store</Link>
             <span>/</span>
             <span className="text-white">Managed Clients</span>
           </div>
@@ -315,7 +316,7 @@ const ManagedStore = () => {
             </div>
             
             <div className="mt-8">
-              <Link href="/store/co-managed">
+              <Link href="/internal/warehouse/co-managed">
                 <Button 
                   variant="link" 
                   className="text-de-accent-ink hover:text-de-accent-ink"

--- a/client/src/pages/store/OrderConfirmation.tsx
+++ b/client/src/pages/store/OrderConfirmation.tsx
@@ -66,7 +66,7 @@ const OrderConfirmation = () => {
   useSEO({
     title: "Order Confirmation | Digerati Experts Store",
     description: "Your order has been received. Thank you for your purchase.",
-    canonical: "/store/order-confirmation",
+    canonical: "/internal/warehouse/order-confirmation",
     noIndex: true,
   });
 
@@ -131,7 +131,7 @@ const OrderConfirmation = () => {
             <p className="text-white/60 mb-8">
               We couldn't find your order. Please check your email for confirmation or contact support.
             </p>
-            <Link href="/store">
+            <Link href="/internal/warehouse">
               <Button className="bg-de-accent hover:bg-de-accent text-white" data-testid="button-back-to-store">
                 <ShoppingBag className="w-4 h-4 mr-2" />
                 Continue Shopping
@@ -330,7 +330,7 @@ const OrderConfirmation = () => {
             transition={{ duration: 0.5, delay: 0.3 }}
             className="flex flex-col sm:flex-row gap-4 justify-center"
           >
-            <Link href="/store">
+            <Link href="/internal/warehouse">
               <Button
                 variant="outline"
                 className="border-white/20 text-white hover:bg-white/10"

--- a/client/src/pages/store/ProductDetail.tsx
+++ b/client/src/pages/store/ProductDetail.tsx
@@ -81,11 +81,12 @@ const ProductDetail = () => {
   }, [product, isLoggedIn]);
 
   useSEO({
+    noIndex: true,
     title: product ? `${product.name} | Store` : "Product Not Found | Store",
     description:
       product?.description ||
       "Product details for Digerati Experts IT services and solutions.",
-    canonical: `/store/product/${sku}`,
+    canonical: `/internal/warehouse/product/${sku}`,
   });
 
   if (!product) {
@@ -96,7 +97,7 @@ const ProductDetail = () => {
           <div className="mx-auto max-w-7xl px-4 text-center sm:px-6 lg:px-8">
             <h1 className="mb-4 text-3xl font-bold text-white">Product Not Found</h1>
             <p className="mb-8 text-white/60">The product you're looking for doesn't exist.</p>
-            <Link href="/store">
+            <Link href="/internal/warehouse">
               <Button className="bg-de-accent text-white hover:bg-[#6548ff]">
                 <ArrowLeft className="mr-2 h-4 w-4" />
                 Back to Store
@@ -114,7 +115,7 @@ const ProductDetail = () => {
   const tags = getProductTags(product);
   const configurable = isConfigurableProduct(product);
   const productPricing = getProductPrice(product.id, product.basePrice);
-  const storeLink = product.isContractOnly ? "/store/managed" : "/store/co-managed";
+  const storeLink = product.isContractOnly ? "/internal/warehouse/managed" : "/internal/warehouse/co-managed";
   const storeLabel = product.isContractOnly ? "Managed Services" : "Co-Managed Products";
   const includedHint = getIncludedInHint(product.sku);
   const relationships = getProductRelationships(product.sku);
@@ -173,16 +174,16 @@ const ProductDetail = () => {
         description={product.description}
         price={productPricing.price.toFixed(2)}
         image={seoImage}
-        url={`/store/product/${product.sku}`}
+        url={`/internal/warehouse/product/${product.sku}`}
         sku={product.sku}
         category={product.category}
       />
       <BreadcrumbJsonLd
         items={[
           { name: "Home", url: "/" },
-          { name: "Store", url: "/store" },
+          { name: "Store", url: "/internal/warehouse" },
           { name: storeLabel, url: storeLink },
-          { name: product.name, url: `/store/product/${product.sku}` },
+          { name: product.name, url: `/internal/warehouse/product/${product.sku}` },
         ]}
       />
       <MegaMenu />
@@ -195,7 +196,7 @@ const ProductDetail = () => {
             <ol className="flex items-center gap-2 text-sm text-white/50">
               <li>
                 <Link
-                  href="/store"
+                  href="/internal/warehouse"
                   className="transition-colors hover:text-white"
                   data-testid="breadcrumb-store"
                 >
@@ -558,7 +559,7 @@ const ProductDetail = () => {
                     <ul className="space-y-3">
                       {worksWithProducts.map((related) => (
                         <li key={related.id}>
-                          <Link href={`/store/product/${related.sku}`}>
+                          <Link href={`/internal/warehouse/product/${related.sku}`}>
                             <span className="group flex items-center justify-between gap-3 rounded-lg border border-transparent px-2 py-2 transition-colors hover:border-white/10 hover:bg-white/[0.03]">
                               <span>
                                 <span className="block font-medium text-white group-hover:text-de-accent-ink">
@@ -584,7 +585,7 @@ const ProductDetail = () => {
                     <ul className="space-y-3">
                       {upgradeProducts.map((related) => (
                         <li key={related.id}>
-                          <Link href={`/store/product/${related.sku}`}>
+                          <Link href={`/internal/warehouse/product/${related.sku}`}>
                             <span className="group flex items-center justify-between gap-3 rounded-lg border border-transparent px-2 py-2 transition-colors hover:border-white/10 hover:bg-white/[0.03]">
                               <span>
                                 <span className="block font-medium text-white group-hover:text-de-accent-ink">
@@ -617,7 +618,7 @@ const ProductDetail = () => {
               <h2 className="mb-6 text-2xl font-bold text-white">Recommended with this service</h2>
               <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
                 {relatedProducts.map((related) => (
-                  <Link key={related.id} href={`/store/product/${related.sku}`}>
+                  <Link key={related.id} href={`/internal/warehouse/product/${related.sku}`}>
                     <div
                       className="group h-full cursor-pointer overflow-hidden rounded-xl border border-white/10 bg-white/[0.03] transition-all duration-300 hover:border-de-accent/30"
                       data-testid={`related-${related.id}`}

--- a/client/src/pages/store/QuoteConfirmation.tsx
+++ b/client/src/pages/store/QuoteConfirmation.tsx
@@ -21,7 +21,7 @@ import {
 import { PRIMARY_PHONE } from "@/data/companyContact";
 
 const QuoteConfirmation = () => {
-  const [, params] = useRoute("/store/quote-confirmation/:id");
+  const [, params] = useRoute("/internal/warehouse/quote-confirmation/:id");
   const quoteId = params?.id;
   const [isDownloadingPdf, setIsDownloadingPdf] = useState(false);
   const [pdfError, setPdfError] = useState<string | null>(null);
@@ -29,7 +29,7 @@ const QuoteConfirmation = () => {
   useSEO({
     title: "Quote Request Submitted | Digerati Experts Store",
     description: "Your quote request has been submitted successfully. Our team will contact you shortly.",
-    canonical: `/store/quote-confirmation/${quoteId}`,
+    canonical: `/internal/warehouse/quote-confirmation/${quoteId}`,
     noIndex: true,
   });
 
@@ -89,7 +89,7 @@ const QuoteConfirmation = () => {
               <p className="text-white/60 mb-8" data-testid="text-error-message">
                 We couldn't find the quote request you're looking for.
               </p>
-              <Link href="/store">
+              <Link href="/internal/warehouse">
                 <Button className="bg-de-accent hover:bg-de-accent text-white" data-testid="button-back-to-store">
                   Back to Store
                 </Button>
@@ -303,7 +303,7 @@ const QuoteConfirmation = () => {
                   Back to Home
                 </Button>
               </Link>
-              <Link href="/store">
+              <Link href="/internal/warehouse">
                 <Button
                   className="bg-de-accent hover:bg-de-accent text-white"
                   data-testid="button-continue-browsing"

--- a/client/src/pages/store/QuoteRequest.tsx
+++ b/client/src/pages/store/QuoteRequest.tsx
@@ -43,7 +43,7 @@ const QuoteRequest = () => {
   useSEO({
     title: "Request a Quote | Digerati Experts Store",
     description: "Request a custom quote for IT services and solutions from Digerati Experts.",
-    canonical: "/store/quote-request",
+    canonical: "/internal/warehouse/quote-request",
     noIndex: true,
   });
 
@@ -110,7 +110,7 @@ const QuoteRequest = () => {
 
       const result = await response.json();
       clearCart();
-      navigate(`/store/quote-confirmation/${result.id}`);
+      navigate(`/internal/warehouse/quote-confirmation/${result.id}`);
     } catch (error: any) {
       console.error("Quote request error:", error);
       toast({
@@ -142,7 +142,7 @@ const QuoteRequest = () => {
               <p className="text-white/60 mb-8" data-testid="text-empty-cart-message">
                 Add items to your solution before requesting a quote.
               </p>
-              <Link href="/store">
+              <Link href="/internal/warehouse">
                 <Button className="bg-de-accent hover:bg-de-accent text-white" data-testid="button-browse-store">
                   Browse Store
                 </Button>
@@ -164,7 +164,7 @@ const QuoteRequest = () => {
           <nav className="mb-8" aria-label="Breadcrumb">
             <ol className="flex items-center gap-2 text-sm text-white/50">
               <li>
-                <Link href="/store" className="hover:text-white transition-colors" data-testid="breadcrumb-store">
+                <Link href="/internal/warehouse" className="hover:text-white transition-colors" data-testid="breadcrumb-store">
                   Store
                 </Link>
               </li>
@@ -174,7 +174,7 @@ const QuoteRequest = () => {
           </nav>
 
           <div className="flex items-center gap-4 mb-8">
-            <Link href="/store/checkout">
+            <Link href="/internal/warehouse/checkout">
               <Button variant="ghost" className="text-white/60 hover:text-white" data-testid="button-back-to-checkout">
                 <ArrowLeft className="w-4 h-4 mr-2" />
                 Back to Checkout

--- a/client/src/pages/store/StoreLanding.tsx
+++ b/client/src/pages/store/StoreLanding.tsx
@@ -104,10 +104,11 @@ const StoreLanding = () => {
   const showFullCatalog = mode === "catalog";
 
   useSEO({
+    noIndex: true,
     title: "IT Services Store | Digerati Experts",
     description:
       "Guided IT storefront from Digerati Experts — shop by outcome, curated merchandising rails, managed packages, and co-managed products with live catalog pricing.",
-    canonical: "/store",
+    canonical: "/internal/warehouse",
   });
 
   const contractOnlyProducts = getContractOnlyProducts();
@@ -153,7 +154,7 @@ const StoreLanding = () => {
   const handleOutcomeSelect = (id: StoreOutcomeId | null) => {
     setOutcomeHighlight(id);
     if (id) {
-      setLocation(`/store/co-managed?outcome=${id}#store-catalog`);
+      setLocation(`/internal/warehouse/co-managed?outcome=${id}#store-catalog`);
     }
   };
 
@@ -245,7 +246,7 @@ const StoreLanding = () => {
                       Ask DE
                     </Button>
                     {showFullCatalog && (
-                      <Link href="/store/co-managed?catalog=full">
+                      <Link href="/internal/warehouse/co-managed?catalog=full">
                         <Button
                           variant="ghost"
                           className="h-12 w-full px-6 text-base text-white/70 hover:bg-white/5 hover:text-white sm:w-auto"
@@ -301,7 +302,7 @@ const StoreLanding = () => {
                       </p>
                       <div className="mt-4">
                         <Button asChild className="h-11 bg-de-accent text-white hover:bg-[#6548ff]">
-                          <Link href="/store/managed">See this plan</Link>
+                          <Link href="/internal/warehouse/managed">See this plan</Link>
                         </Button>
                       </div>
                     </div>
@@ -411,7 +412,7 @@ const StoreLanding = () => {
                     <span className="text-base text-white/50">
                       {contractOnlyProducts.length} packages available
                     </span>
-                    <Link href="/store/managed">
+                    <Link href="/internal/warehouse/managed">
                       <Button
                         className="h-11 w-full bg-de-accent px-5 text-base text-white hover:bg-[#6548ff] sm:w-auto"
                         data-testid="button-view-managed"
@@ -446,7 +447,7 @@ const StoreLanding = () => {
                     <span className="text-base text-white/50">
                       {checkoutProducts.length} products available
                     </span>
-                    <Link href="/store/co-managed">
+                    <Link href="/internal/warehouse/co-managed">
                       <Button
                         className="h-11 w-full border-none bg-de-accent px-5 text-base text-white hover:bg-[#6548ff] sm:w-auto"
                         data-testid="button-view-comanaged"
@@ -510,7 +511,7 @@ const StoreLanding = () => {
                 const productCount = storeProducts.filter((p) => p.category === category).length;
                 return (
                   <motion.div key={category} variants={itemVariants}>
-                    <Link href={`/store/co-managed?category=${category}`}>
+                    <Link href={`/internal/warehouse/co-managed?category=${category}`}>
                       <div
                         className="group flex h-full cursor-pointer items-center gap-3 rounded-xl border border-white/10 bg-[#141414] px-3.5 py-3 text-left transition-colors duration-200 hover:border-de-accent/30 hover:bg-[#171717]"
                         data-testid={`category-${category}`}
@@ -546,7 +547,7 @@ const StoreLanding = () => {
                 <h2 className="mb-2 text-2xl font-bold text-white md:text-3xl">Available for checkout</h2>
                 <p className="text-white/60">Configure or add these catalog items now.</p>
               </div>
-              <Link href="/store/co-managed">
+              <Link href="/internal/warehouse/co-managed">
                 <Button
                   variant="outline"
                   className="w-full border-white/20 text-white hover:bg-white/10 sm:w-auto"

--- a/client/src/pages/store/WarehouseApp.tsx
+++ b/client/src/pages/store/WarehouseApp.tsx
@@ -1,0 +1,75 @@
+import { lazy, Suspense, type ReactNode } from "react";
+import { Route, Switch } from "wouter";
+import { Helmet } from "react-helmet-async";
+import { CartProvider } from "@/contexts/CartContext";
+import { ShoppingCart } from "@/components/store/ShoppingCart";
+import { SolutionMobileBar } from "@/components/store/SolutionMobileBar";
+import { PageLoadingSkeleton } from "@/components/LoadingSkeleton";
+import { WAREHOUSE_BASE } from "@/lib/warehousePaths";
+
+const StoreLanding = lazy(() => import("@/pages/store/StoreLanding"));
+const ManagedStore = lazy(() => import("@/pages/store/ManagedStore"));
+const CoManagedStore = lazy(() => import("@/pages/store/CoManagedStore"));
+const ProductDetail = lazy(() => import("@/pages/store/ProductDetail"));
+const Checkout = lazy(() => import("@/pages/store/Checkout"));
+const OrderConfirmation = lazy(() => import("@/pages/store/OrderConfirmation"));
+const QuoteRequestPage = lazy(() => import("@/pages/store/QuoteRequest"));
+const QuoteConfirmationPage = lazy(() => import("@/pages/store/QuoteConfirmation"));
+
+function Screen({ children }: { children: ReactNode }) {
+  return <Suspense fallback={<PageLoadingSkeleton />}>{children}</Suspense>;
+}
+
+export default function WarehouseApp() {
+  return (
+    <CartProvider>
+      <Helmet>
+        <meta name="robots" content="noindex, nofollow" />
+      </Helmet>
+      <ShoppingCart />
+      <SolutionMobileBar />
+      <Switch>
+        <Route path={WAREHOUSE_BASE}>
+          <Screen>
+            <StoreLanding />
+          </Screen>
+        </Route>
+        <Route path={`${WAREHOUSE_BASE}/managed`}>
+          <Screen>
+            <ManagedStore />
+          </Screen>
+        </Route>
+        <Route path={`${WAREHOUSE_BASE}/co-managed`}>
+          <Screen>
+            <CoManagedStore />
+          </Screen>
+        </Route>
+        <Route path={`${WAREHOUSE_BASE}/product/:sku`}>
+          <Screen>
+            <ProductDetail />
+          </Screen>
+        </Route>
+        <Route path={`${WAREHOUSE_BASE}/checkout`}>
+          <Screen>
+            <Checkout />
+          </Screen>
+        </Route>
+        <Route path={`${WAREHOUSE_BASE}/order-confirmation`}>
+          <Screen>
+            <OrderConfirmation />
+          </Screen>
+        </Route>
+        <Route path={`${WAREHOUSE_BASE}/quote-request`}>
+          <Screen>
+            <QuoteRequestPage />
+          </Screen>
+        </Route>
+        <Route path={`${WAREHOUSE_BASE}/quote-confirmation/:id`}>
+          <Screen>
+            <QuoteConfirmationPage />
+          </Screen>
+        </Route>
+      </Switch>
+    </CartProvider>
+  );
+}

--- a/client/src/pages/store/WarehouseGate.tsx
+++ b/client/src/pages/store/WarehouseGate.tsx
@@ -1,0 +1,36 @@
+import { lazy, Suspense, useEffect, useState } from "react";
+import { PageLoadingSkeleton } from "@/components/LoadingSkeleton";
+import NotFound from "@/pages/not-found";
+
+const WarehouseApp = lazy(() => import("./WarehouseApp"));
+
+/**
+ * Tiny gate with no catalog imports. WarehouseApp (SKUs, vendors, cart)
+ * loads only after the server confirms admin staff.
+ */
+export default function WarehouseGate() {
+  const [state, setState] = useState<"loading" | "ok" | "deny">("loading");
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/internal/warehouse/session", { credentials: "include" })
+      .then((response) => {
+        if (!cancelled) setState(response.ok ? "ok" : "deny");
+      })
+      .catch(() => {
+        if (!cancelled) setState("deny");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (state === "loading") return <PageLoadingSkeleton />;
+  if (state === "deny") return <NotFound />;
+
+  return (
+    <Suspense fallback={<PageLoadingSkeleton />}>
+      <WarehouseApp />
+    </Suspense>
+  );
+}

--- a/client/src/pages/store/warehouseIsolation.test.ts
+++ b/client/src/pages/store/warehouseIsolation.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = path.resolve(import.meta.dirname, "../../../..");
+
+const prohibitedInApp = [
+  "storeProducts",
+  "vendorLogos",
+  "CartContext",
+  "ShoppingCart",
+  "SolutionMobileBar",
+  "StoreLanding",
+  "CoManagedStore",
+  "ManagedStore",
+  "ProductDetail",
+];
+
+describe("public SPA isolation from the Digital Warehouse", () => {
+  it("does not statically import the warehouse catalog from App.tsx", () => {
+    const app = readFileSync(path.join(root, "client/src/App.tsx"), "utf8");
+    expect(app).toContain("WarehouseGate");
+    expect(app).not.toMatch(/from ["']@\/contexts\/CartContext["']/);
+    expect(app).not.toMatch(/from ["']@\/data\/storeProducts["']/);
+    expect(app).not.toMatch(/from ["']@\/data\/vendorLogos["']/);
+    expect(app).not.toMatch(/from ["']@\/pages\/store\/StoreLanding["']/);
+    for (const term of prohibitedInApp.filter((name) => name !== "storeProducts")) {
+      if (term === "WarehouseGate") continue;
+      if (["StoreLanding", "CoManagedStore", "ManagedStore", "ProductDetail", "ShoppingCart", "SolutionMobileBar", "CartContext"].includes(term)) {
+        expect(app).not.toContain(`pages/store/${term}`);
+      }
+    }
+  });
+
+  it("loads catalog code only after WarehouseGate", () => {
+    const gate = readFileSync(path.join(root, "client/src/pages/store/WarehouseGate.tsx"), "utf8");
+    expect(gate).not.toContain("storeProducts");
+    expect(gate).not.toContain("vendorLogos");
+    expect(gate).toContain('import("./WarehouseApp")');
+  });
+});

--- a/docs/STORE-ARCHITECTURE-DESIGN.md
+++ b/docs/STORE-ARCHITECTURE-DESIGN.md
@@ -1,6 +1,6 @@
 # DE Store Architecture — Phase 0 design packet
 
-**Status:** DRAFT — awaiting Joe (DE) approval. **No product implementation.**  
+**Status:** APPROVED by Joe (DE). Door 2 is live. Warehouse isolation, Door 1 two-door entry, and fail-safe marketplace are implemented in follow-on slices. **MERGED ≠ LIVE.**  
 **Date:** 2026-08-29  
 **Inspected `origin/main`:** `9b2ffdc` (Merge PR #93). **MERGED ≠ LIVE.** This packet describes current *code*, not production verification.  
 **Governing spec:** Three public doors + Client Marketplace + DE Digital Warehouse (supersedes earlier kitchen-sink and three-door implementation instructions).  

--- a/docs/STORE-WAREHOUSE.md
+++ b/docs/STORE-WAREHOUSE.md
@@ -1,0 +1,45 @@
+# DE Digital Warehouse
+
+**Status:** Implemented on website `main` after merge (MERGED ≠ LIVE until production SHA is verified).  
+**Staff identity this phase:** live portal `role === "admin"`. Ordinary authenticated clients are denied.  
+**Portal login:** `https://portal.digeratiexperts.com/portal/login`
+
+## What this is
+
+The former public `/store` workshop (SKU catalog, vendor marks, coverage heuristic, cart) is the **DE Digital Warehouse**. It is staff-only.
+
+| Surface | Route | Auth |
+| --- | --- | --- |
+| Warehouse | `/internal/warehouse` and product/checkout subroutes | Live `admin` at route **and** catalog API |
+| Public destage | `/store`, `/store/managed`, `/store/co-managed` | 301 to Door 1 / Door 2 |
+| Staff-only SKU URLs | `/store/product/:sku` except four ProActive models | Generic 404 — same body as unknown, no `Location` |
+| Client Marketplace | `/portal/marketplace` | Authenticated client; fail-safe Request Approval (no Hub catalog) |
+
+## How staff open it
+
+1. Sign in at `https://portal.digeratiexperts.com/portal/login`.
+2. Open `/internal/warehouse`.
+3. An admin bookmark to `/store` 302s into the warehouse. Unauthorized users never receive `Location: /internal/...`.
+
+## Authorization
+
+- JWT proves the session. The **live** portal record is authoritative (`role === "admin"`).
+- Catalog-bearing APIs (`/api/store/solutions/*`, `/api/store/cart/*`) return generic `{ error: "Not found" }` unless staff.
+- Unauthorized warehouse HTML is a generic 404. Do not reveal whether a SKU, vendor, or price exists.
+
+## Public leakage
+
+- `App.tsx` lazy-loads `WarehouseGate` only. `WarehouseApp` (catalog, cart, vendors) loads after `/api/internal/warehouse/session` succeeds.
+- Sitemap and `robots.txt` exclude warehouse and destaged `/store` SKUs.
+- Coverage scoring is labeled **experimental heuristic** — not an authoritative security score.
+
+## Checkout eligibility
+
+See `shared/checkoutEligibility.ts`.
+
+- Door 1: `assessment_first`
+- Door 2: `request_quote`
+- Marketplace: `request_approval`
+- Warehouse staff: `pay_now` (not a public default)
+
+Do not invent Hub tenant catalogs or prices.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
-# Digerati Experts — index website + store products. Keep portal/checkout out of SERPs.
+# Digerati Experts — index marketing site. Keep portal, warehouse, and destaged /store out of SERPs.
 User-agent: *
 Allow: /
 Allow: /llms.txt
@@ -10,11 +10,8 @@ Disallow: /admin/
 Disallow: /internal/
 Disallow: /official-network-planner
 Disallow: /de-ecosystem-matrix-offical
-Disallow: /store/checkout
-Disallow: /store/cart
-Disallow: /store/order-confirmation
-Disallow: /store/quote-request
-Disallow: /store/quote-confirmation/
+Disallow: /store
+Disallow: /store/
 Disallow: /thanks
 Disallow: /quote-confirmation
 Disallow: /404

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -87,9 +87,6 @@
   <url><loc>https://digeratiexperts.com/legal/privacy-policy</loc><changefreq>yearly</changefreq><priority>0.4</priority></url>
   <url><loc>https://digeratiexperts.com/legal/terms-of-use</loc><changefreq>yearly</changefreq><priority>0.4</priority></url>
   <url><loc>https://digeratiexperts.com/contact</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
-  <url><loc>https://digeratiexperts.com/store</loc><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://digeratiexperts.com/store/managed</loc><changefreq>weekly</changefreq><priority>0.7</priority></url>
-  <url><loc>https://digeratiexperts.com/store/co-managed</loc><changefreq>weekly</changefreq><priority>0.7</priority></url>
   <url><loc>https://digeratiexperts.com/solutions/business-needs</loc><changefreq>weekly</changefreq><priority>0.8</priority></url>
   <url><loc>https://digeratiexperts.com/solutions/request</loc><changefreq>monthly</changefreq><priority>0.3</priority></url>
   <!-- Door 2 solution families (13) -->
@@ -120,69 +117,4 @@
   <url><loc>https://digeratiexperts.com/resources/datasheets/ucaas-voice-meetings-datasheet</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
   <url><loc>https://digeratiexperts.com/resources/reports/compliance-risk-reports-overview</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
   <url><loc>https://digeratiexperts.com/resources/reports/sample-quarterly-business-review</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
-  <!-- Store products (64) -->
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-MGD-IT-MO</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-MGD-OFFICE-MO</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-MGD-BUSINESS-MO</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-MGD-ENTERPRISE-MO</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-MGD-WORKPLACE-MO</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-MGD-CYBER-MO</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-MGD-BCDR-MO</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-COMANAGED-CUSTOM-MO</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-CM-ENDPOINT-CORE-MO</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-CM-ENDPOINT-EDR-MO</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-CM-EMAIL-SEC-MO</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-CM-IDENTITY-CORE-MO</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-CM-SAAS-MGMT-MO</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-CM-HELPDESK-ASSIST-MO</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-CM-SERVER-MON-MO</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-CM-ONBOARD-S-OT</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-CM-ONBOARD-M-OT</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-CM-ONBOARD-L-OT</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-CM-DOC-PACK-OT</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-NET-MANAGED-CORE-MO</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-NET-MANAGED-ADV-MO</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-NET-MANAGED-MSITE-MO</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-NET-ENG-HR</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-NET-ONSITE-HR</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-NET-CUTOVER-OT</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-UC-SEAT-STD-MO</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-UC-SEAT-PRO-MO</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-UC-AUTOATT-MO</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-UC-SMS-MO</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-UC-ONBOARD-S-OT</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-UC-ONBOARD-M-OT</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-UC-ONBOARD-L-OT</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-UC-PORT-OT</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-UC-CALLFLOW-OT</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-HW-PROV-ENDPOINT-OT</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-HW-PROV-NET-OT</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-HW-PROV-VOIP-OT</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-HW-NET-FW-SMB-OT</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-HW-NET-SW-24-OT</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-HW-NET-AP-BIZ-OT</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-HW-INFRA-UPS-1500-OT</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-HW-ENDPOINT-PC-BASE-OT</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-HW-ENDPOINT-LT-BASE-OT</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-HW-UC-PHONE-STD-OT</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-HW-UC-PHONE-EXEC-OT</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-HW-UC-HDST-STD-OT</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-HW-SHIP-HANDLE-OT</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-FIELD-INSTALL-HR</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-DIG-ASMT-QUICK-OT</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-DIG-ASMT-DMARC-OT</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-DIG-ASMT-PHISH-MO</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-DIG-TPL-POLICY-CORE-OT</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-DIG-TPL-POLICY-ADV-OT</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-DIG-TPL-IR-RUNBOOK-OT</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-DIG-TPL-BCP-OT</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-DIG-TRN-AWARE-BASIC-YR</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-DIG-TRN-AWARE-PRO-YR</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-DIG-TRN-ONBOARD-OT</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-CONSULT-VCIO-HR</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-CONSULT-SEC-HR</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-CONSULT-SYS-HR</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-BLK-5HR-OT</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-BLK-10HR-OT</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://digeratiexperts.com/store/product/DE-SVC-BLK-20HR-OT</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>
 </urlset>

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -1,6 +1,6 @@
 /**
- * Regenerates public/sitemap.xml with marketing URLs + public store product pages.
- * Portal / checkout / transactional URLs are intentionally excluded (noindex).
+ * Regenerates public/sitemap.xml with marketing URLs + Door 2 family pages.
+ * Warehouse, portal, checkout, and SKU PDPs are intentionally excluded (noindex).
  */
 import fs from "node:fs";
 import path from "node:path";
@@ -97,17 +97,9 @@ const STATIC = [
   ["/legal/privacy-policy", "yearly", "0.4"],
   ["/legal/terms-of-use", "yearly", "0.4"],
   ["/contact", "monthly", "0.7"],
-  ["/store", "weekly", "0.8"],
-  ["/store/managed", "weekly", "0.7"],
-  ["/store/co-managed", "weekly", "0.7"],
   ["/solutions/business-needs", "weekly", "0.8"],
   ["/solutions/request", "monthly", "0.3"],
 ];
-
-const productsPath = path.join(root, "client/src/data/storeProducts.ts");
-const productSrc = fs.readFileSync(productsPath, "utf8");
-const skus = [...productSrc.matchAll(/sku:\s*"([^"]+)"/g)].map((m) => m[1]);
-const uniqueSkus = [...new Set(skus)];
 
 const curatedPath = path.join(root, "client/src/data/curatedSolutions.ts");
 const curatedSrc = fs.readFileSync(curatedPath, "utf8");
@@ -139,8 +131,6 @@ const lines = [
   ...familyPaths.map((loc) => urlEntry(loc, "weekly", "0.7")),
   `  <!-- Resource PDFs (${resourceRoutes.length}) -->`,
   ...resourceRoutes.map((loc) => urlEntry(loc, "monthly", "0.6")),
-  `  <!-- Store products (${uniqueSkus.length}) -->`,
-  ...uniqueSkus.map((sku) => urlEntry(`/store/product/${encodeURIComponent(sku)}`, "weekly", "0.6")),
   `</urlset>`,
   ``,
 ];
@@ -148,5 +138,5 @@ const lines = [
 const out = path.join(root, "public/sitemap.xml");
 fs.writeFileSync(out, lines.join("\n"), "utf8");
 console.log(
-  `Wrote ${out} (${STATIC.length} static + ${familyPaths.length} families + ${resourceRoutes.length} resources + ${uniqueSkus.length} products)`,
+  `Wrote ${out} (${STATIC.length} static + ${familyPaths.length} families + ${resourceRoutes.length} resources)`,
 );

--- a/scripts/public-route-smoke.mjs
+++ b/scripts/public-route-smoke.mjs
@@ -27,7 +27,7 @@ const routes = [
   "/trust",
   "/trust/trust-center",
   "/contact",
-  "/store",
+  "/solutions/business-needs",
   "/about/press",
 ];
 
@@ -68,6 +68,28 @@ for (const path of routes) {
     }
   } catch (err) {
     fails.push(`/api/google-reviews → ${err.message}`);
+  }
+}
+
+{
+  const destaged = await fetch(`${BASE}/store`, { redirect: "manual" });
+  if (destaged.status !== 301) {
+    fails.push(`/store → expected 301 destage, got ${destaged.status}`);
+  } else if ((destaged.headers.get("location") || "") !== "/solutions/business-needs") {
+    fails.push(`/store → expected Location /solutions/business-needs, got ${destaged.headers.get("location")}`);
+  }
+
+  const warehouse = await fetch(`${BASE}/internal/warehouse`, { redirect: "manual" });
+  const staffSku = await fetch(`${BASE}/store/product/DE-SVC-CM-ENDPOINT-EDR-MO`, {
+    redirect: "manual",
+  });
+  const unknownSku = await fetch(`${BASE}/store/product/not-a-real-sku`, { redirect: "manual" });
+  if (warehouse.status !== 404) fails.push(`/internal/warehouse → expected 404, got ${warehouse.status}`);
+  if (staffSku.status !== 404 || unknownSku.status !== 404) {
+    fails.push(`legacy SKU destage → expected generic 404s, got ${staffSku.status}/${unknownSku.status}`);
+  }
+  if (warehouse.headers.get("location") || staffSku.headers.get("location")) {
+    fails.push(`warehouse denial leaked Location`);
   }
 }
 

--- a/scripts/sitemap-no-warehouse.test.ts
+++ b/scripts/sitemap-no-warehouse.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = path.resolve(import.meta.dirname, "..");
+
+describe("public sitemap destage", () => {
+  it("does not index warehouse or SKU store URLs", () => {
+    const script = readFileSync(path.join(root, "scripts/generate-sitemap.mjs"), "utf8");
+    const sitemap = readFileSync(path.join(root, "public/sitemap.xml"), "utf8");
+    expect(script).not.toContain("/store/product/");
+    expect(script).not.toContain('["/store"');
+    expect(sitemap).not.toContain("/store/product/");
+    expect(sitemap).not.toContain("/internal/warehouse");
+    expect(sitemap).toContain("/solutions/business-needs");
+    expect(sitemap).toContain("/solutions/proactive-ecosystem");
+  });
+});

--- a/server/index.ts
+++ b/server/index.ts
@@ -7,6 +7,8 @@ import { registerRoutes, authMiddleware, requireRole } from "./routes";
 import { registerSecureZohoStoreCheckout } from "./secureStoreCheckout";
 import { registerStoreSolutionRoutes } from "./storeSolutionRoutes";
 import { registerPublicSolutionRoutes } from "./publicSolutionRoutes";
+import { registerWarehouseGates } from "./warehouseRoutes";
+import { registerPortalMarketplaceRoutes } from "./portalMarketplaceRoutes";
 import { registerPublicSupportChat } from "./publicSupportChat";
 import { createServer as createViteServer } from "vite";
 import path from "path";
@@ -270,9 +272,11 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 
+registerWarehouseGates(app);
 registerSecureZohoStoreCheckout(app, authMiddleware as any, requireRole as any);
 registerStoreSolutionRoutes(app, authMiddleware as any);
 registerPublicSolutionRoutes(app);
+registerPortalMarketplaceRoutes(app, authMiddleware as any);
 
 app.use((req, res, next) => {
   if (req.path.toLowerCase() === "/solutions/proactive-ecosystem-packages") {
@@ -284,12 +288,7 @@ app.use((req, res, next) => {
   next();
 });
 
-app.use((req, res, next) => {
-  if (req.path === "/internal" || req.path.startsWith("/internal/")) {
-    return res.redirect(301, "/");
-  }
-  next();
-});
+// /internal/warehouse is gated in registerWarehouseGates. Other /internal paths stay destaged.
 
 app.use((req, res, next) => {
   if (req.path === "/login") {

--- a/server/portalMarketplaceRoutes.test.ts
+++ b/server/portalMarketplaceRoutes.test.ts
@@ -1,0 +1,48 @@
+import express from "express";
+import { createServer, type Server } from "http";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { registerPortalMarketplaceRoutes } from "./portalMarketplaceRoutes";
+import { MARKETPLACE_ELIGIBILITY } from "@shared/checkoutEligibility";
+
+describe("portal marketplace fail-safe", () => {
+  let server: Server;
+  let baseUrl = "";
+
+  beforeAll(async () => {
+    const app = express();
+    const auth = (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+      (req as express.Request & { user?: { clientId: string } }).user = {
+        clientId: "client-1",
+      };
+      next();
+    };
+    registerPortalMarketplaceRoutes(app, auth);
+    server = createServer(app);
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("No test port");
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  });
+
+  it("returns an empty Request Approval catalog without warehouse fields", async () => {
+    const response = await fetch(`${baseUrl}/api/portal/marketplace`);
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.eligibility).toBe(MARKETPLACE_ELIGIBILITY);
+    expect(body.items).toEqual([]);
+    expect(body.status).toBe("unavailable");
+    const raw = JSON.stringify(body).toLowerCase();
+    expect(raw).not.toContain("sku");
+    expect(raw).not.toContain("margin");
+    expect(raw).not.toContain("ninjaone");
+    expect(raw).not.toContain("pay_now");
+  });
+});

--- a/server/portalMarketplaceRoutes.ts
+++ b/server/portalMarketplaceRoutes.ts
@@ -1,0 +1,28 @@
+import type { Express, NextFunction, Request, Response } from "express";
+import { MARKETPLACE_ELIGIBILITY } from "@shared/checkoutEligibility";
+
+type AuthedRequest = Request & {
+  user?: { role?: string; clientId?: string | null };
+};
+
+export function registerPortalMarketplaceRoutes(
+  app: Express,
+  authMiddleware: (req: AuthedRequest, res: Response, next: NextFunction) => unknown,
+): void {
+  app.get(
+    "/api/portal/marketplace",
+    authMiddleware,
+    (req: AuthedRequest, res: Response) => {
+      const clientId = req.user?.clientId ?? null;
+      res.setHeader("Cache-Control", "no-store");
+      res.json({
+        eligibility: MARKETPLACE_ELIGIBILITY,
+        items: [],
+        status: clientId ? "unavailable" : "unmapped",
+        reason: clientId
+          ? "Tenant catalog is not available from Hub yet."
+          : "This account is not mapped to a client tenant.",
+      });
+    },
+  );
+}

--- a/server/storeLegacyRedirects.test.ts
+++ b/server/storeLegacyRedirects.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { classifyLegacyStorePath, toWarehousePath } from "./storeLegacyRedirects";
+
+describe("legacy /store destage", () => {
+  it("sends public workshop URLs to Door 1 or Door 2", () => {
+    expect(classifyLegacyStorePath("/store")).toEqual({
+      kind: "public_redirect",
+      to: "/solutions/business-needs",
+    });
+    expect(classifyLegacyStorePath("/store/managed")).toEqual({
+      kind: "public_redirect",
+      to: "/solutions/proactive-ecosystem",
+    });
+    expect(classifyLegacyStorePath("/store/co-managed")).toEqual({
+      kind: "public_redirect",
+      to: "/solutions/business-needs",
+    });
+    expect(classifyLegacyStorePath("/store/product/DE-SVC-MGD-IT-MO")).toEqual({
+      kind: "public_redirect",
+      to: "/solutions/proactive-it-ecosystem",
+    });
+  });
+
+  it("does not reveal staff-only SKU destinations", () => {
+    expect(classifyLegacyStorePath("/store/product/DE-SVC-CM-ENDPOINT-EDR-MO")).toEqual({
+      kind: "generic_deny",
+    });
+    expect(classifyLegacyStorePath("/store/product/unknown-sku")).toEqual({
+      kind: "generic_deny",
+    });
+  });
+
+  it("maps authorized bookmarks into the warehouse", () => {
+    expect(toWarehousePath("/store")).toBe("/internal/warehouse");
+    expect(toWarehousePath("/store/product/DE-SVC-MGD-IT-MO")).toBe(
+      "/internal/warehouse/product/DE-SVC-MGD-IT-MO",
+    );
+  });
+});

--- a/server/storeLegacyRedirects.ts
+++ b/server/storeLegacyRedirects.ts
@@ -1,0 +1,51 @@
+/** Public destage map for legacy /store URLs. Server-only — no vendor/SKU catalog dump. */
+
+export const PUBLIC_STORE_PATH_REDIRECTS: Record<string, string> = {
+  "/store": "/solutions/business-needs",
+  "/store/managed": "/solutions/proactive-ecosystem",
+  "/store/co-managed": "/solutions/business-needs",
+  "/store/checkout": "/solutions/request",
+  "/store/quote-request": "/solutions/request",
+  "/store/order-confirmation": "/solutions/business-needs",
+};
+
+/** Four public ProActive operating-model SKUs → Door 1 pages. Everything else is generic deny. */
+export const PUBLIC_SKU_REDIRECTS: Record<string, string> = {
+  "DE-SVC-MGD-IT-MO": "/solutions/proactive-it-ecosystem",
+  "DE-SVC-MGD-OFFICE-MO": "/solutions/proactive-office-ecosystem",
+  "DE-SVC-MGD-BUSINESS-MO": "/solutions/proactive-business-ecosystem",
+  "DE-SVC-MGD-ENTERPRISE-MO": "/solutions/proactive-enterprise-ecosystem",
+};
+
+export type LegacyStoreClassification =
+  | { kind: "public_redirect"; to: string }
+  | { kind: "generic_deny" };
+
+export function toWarehousePath(storePath: string): string {
+  if (storePath === "/store") return "/internal/warehouse";
+  if (storePath.startsWith("/store/")) {
+    return `/internal/warehouse${storePath.slice("/store".length)}`;
+  }
+  return "/internal/warehouse";
+}
+
+export function classifyLegacyStorePath(pathname: string): LegacyStoreClassification {
+  const path = pathname.split("?")[0] || pathname;
+  if (PUBLIC_STORE_PATH_REDIRECTS[path]) {
+    return { kind: "public_redirect", to: PUBLIC_STORE_PATH_REDIRECTS[path] };
+  }
+  if (path.startsWith("/store/quote-confirmation/")) {
+    return { kind: "public_redirect", to: "/solutions/request" };
+  }
+  const skuMatch = path.match(/^\/store\/product\/([^/]+)$/);
+  if (skuMatch) {
+    const sku = decodeURIComponent(skuMatch[1] || "");
+    const dest = PUBLIC_SKU_REDIRECTS[sku];
+    if (dest) return { kind: "public_redirect", to: dest };
+    return { kind: "generic_deny" };
+  }
+  if (path === "/store" || path.startsWith("/store/")) {
+    return { kind: "generic_deny" };
+  }
+  return { kind: "generic_deny" };
+}

--- a/server/warehouseAccess.test.ts
+++ b/server/warehouseAccess.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import jwt from "jsonwebtoken";
+
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret-warehouse-access";
+
+vi.mock("./portalAuthStore", async () => {
+  const actual = await vi.importActual<typeof import("./portalAuthStore")>("./portalAuthStore");
+  return { ...actual, getUser: vi.fn() };
+});
+
+vi.mock("./portalOrg", async () => {
+  const actual = await vi.importActual<typeof import("./portalOrg")>("./portalOrg");
+  return { ...actual, findUserById: vi.fn() };
+});
+
+function sign(claims: Record<string, unknown>) {
+  return jwt.sign(claims, process.env.JWT_SECRET as string, { expiresIn: "1h" });
+}
+
+describe("warehouse staff resolution", () => {
+  beforeEach(async () => {
+    const { getUser } = await import("./portalAuthStore");
+    const { findUserById } = await import("./portalOrg");
+    (getUser as ReturnType<typeof vi.fn>).mockReset();
+    (findUserById as ReturnType<typeof vi.fn>).mockReset();
+  });
+
+  it("denies missing tokens and non-admin live records", async () => {
+    const { resolveWarehouseStaff } = await import("./warehouseAccess");
+    const { getUser } = await import("./portalAuthStore");
+    expect(resolveWarehouseStaff({ headers: {}, cookies: {} } as any)).toBeNull();
+
+    (getUser as ReturnType<typeof vi.fn>).mockReturnValue({
+      id: "c1",
+      email: "client@example.com",
+      role: "user",
+      isActive: true,
+    });
+    const req = {
+      headers: { authorization: `Bearer ${sign({ userId: "c1", email: "client@example.com", role: "admin" })}` },
+      cookies: {},
+    } as any;
+    expect(resolveWarehouseStaff(req)).toBeNull();
+  });
+
+  it("allows only a live admin record", async () => {
+    const { resolveWarehouseStaff } = await import("./warehouseAccess");
+    const { getUser } = await import("./portalAuthStore");
+    (getUser as ReturnType<typeof vi.fn>).mockReturnValue({
+      id: "a1",
+      email: "admin@digeratiexperts.com",
+      role: "admin",
+      isActive: true,
+    });
+    const req = {
+      headers: { authorization: `Bearer ${sign({ userId: "a1", email: "admin@digeratiexperts.com", role: "user" })}` },
+      cookies: {},
+    } as any;
+    expect(resolveWarehouseStaff(req)).toEqual({
+      id: "a1",
+      email: "admin@digeratiexperts.com",
+    });
+  });
+});

--- a/server/warehouseAccess.ts
+++ b/server/warehouseAccess.ts
@@ -1,0 +1,111 @@
+import type { Request, Response, NextFunction } from "express";
+import jwt from "jsonwebtoken";
+import { findUserById } from "./portalOrg";
+import { getUser as portalAuthGetUser } from "./portalAuthStore";
+
+export const PORTAL_AUTH_COOKIE = "portalAuth";
+export const GENERIC_NOT_FOUND_JSON = { error: "Not found" } as const;
+
+const GENERIC_NOT_FOUND_HTML = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Not found</title>
+  <meta name="robots" content="noindex, nofollow">
+</head>
+<body>
+  <p>Not found</p>
+</body>
+</html>
+`;
+
+type JwtClaims = {
+  userId?: string;
+  email?: string;
+  role?: string;
+};
+
+function jwtSecret(): string | null {
+  return process.env.JWT_SECRET || null;
+}
+
+function readSessionToken(req: Request): string {
+  const authHeader = req.headers.authorization;
+  const bearer =
+    authHeader && authHeader.startsWith("Bearer ")
+      ? authHeader.slice("Bearer ".length).trim()
+      : "";
+  const cookieToken =
+    typeof req.cookies?.[PORTAL_AUTH_COOKIE] === "string"
+      ? req.cookies[PORTAL_AUTH_COOKIE]
+      : "";
+  return bearer || cookieToken;
+}
+
+function isDisabled(live: object): boolean {
+  const record = live as { disabled?: unknown; status?: unknown; isActive?: unknown };
+  return (
+    Boolean(record.disabled) ||
+    record.status === "disabled" ||
+    record.status === "revoked" ||
+    record.isActive === false
+  );
+}
+
+/** Live portal record only. JWT role claims are not authorization. */
+export function resolveWarehouseStaff(req: Request): { id: string; email: string } | null {
+  const token = readSessionToken(req);
+  const secret = jwtSecret();
+  if (!token || !secret) return null;
+
+  try {
+    const decoded = jwt.verify(token, secret) as JwtClaims;
+    const live =
+      (decoded.email ? portalAuthGetUser(decoded.email) : undefined) ||
+      (decoded.userId ? findUserById(decoded.userId) : null);
+    if (!live || isDisabled(live)) return null;
+    if ((live.role || "user") !== "admin") return null;
+    return { id: live.id, email: live.email };
+  } catch {
+    return null;
+  }
+}
+
+export function isWarehouseHtmlPath(path: string): boolean {
+  return path === "/internal/warehouse" || path.startsWith("/internal/warehouse/");
+}
+
+export function isWarehouseCatalogApiPath(path: string): boolean {
+  return (
+    path === "/api/store/solutions" ||
+    path.startsWith("/api/store/solutions/") ||
+    path === "/api/store/cart" ||
+    path.startsWith("/api/store/cart/")
+  );
+}
+
+export function applyPrivateCacheHeaders(res: Response): void {
+  res.setHeader("X-Robots-Tag", "noindex, nofollow");
+  res.setHeader("Cache-Control", "no-store");
+  res.removeHeader("Location");
+}
+
+export function sendGenericNotFound(req: Request, res: Response): void {
+  applyPrivateCacheHeaders(res);
+  const wantsJson =
+    req.path.startsWith("/api") ||
+    (typeof req.headers.accept === "string" && req.headers.accept.includes("application/json"));
+  if (wantsJson) {
+    res.status(404).json(GENERIC_NOT_FOUND_JSON);
+    return;
+  }
+  res.status(404).type("html").send(GENERIC_NOT_FOUND_HTML);
+}
+
+export function requireWarehouseStaffApi(req: Request, res: Response, next: NextFunction): void {
+  if (resolveWarehouseStaff(req)) {
+    next();
+    return;
+  }
+  sendGenericNotFound(req, res);
+}

--- a/server/warehouseRoutes.test.ts
+++ b/server/warehouseRoutes.test.ts
@@ -1,0 +1,116 @@
+import express from "express";
+import cookieParser from "cookie-parser";
+import { createServer, type Server } from "http";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import jwt from "jsonwebtoken";
+
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret-warehouse-routes";
+
+vi.mock("./portalAuthStore", async () => {
+  const actual = await vi.importActual<typeof import("./portalAuthStore")>("./portalAuthStore");
+  return { ...actual, getUser: vi.fn() };
+});
+
+vi.mock("./portalOrg", async () => {
+  const actual = await vi.importActual<typeof import("./portalOrg")>("./portalOrg");
+  return { ...actual, findUserById: vi.fn() };
+});
+
+function sign(claims: Record<string, unknown>) {
+  return jwt.sign(claims, process.env.JWT_SECRET as string, { expiresIn: "1h" });
+}
+
+describe("warehouse HTTP gates", () => {
+  let server: Server;
+  let baseUrl = "";
+  let getUser: ReturnType<typeof vi.fn>;
+
+  beforeAll(async () => {
+    const { registerWarehouseGates } = await import("./warehouseRoutes");
+    const { getUser: mockedGetUser } = await import("./portalAuthStore");
+    getUser = mockedGetUser as ReturnType<typeof vi.fn>;
+
+    const app = express();
+    app.use(cookieParser());
+    registerWarehouseGates(app);
+    app.get("/api/store/solutions/current", (_req, res) => res.json({ leaked: true }));
+    app.get("/internal/warehouse", (_req, res) => res.status(200).send("WAREHOUSE_OK"));
+    app.get("/internal/warehouse/product/:sku", (_req, res) => res.status(200).send("WAREHOUSE_PDP"));
+
+    server = createServer(app);
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("No test port");
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  });
+
+  beforeEach(() => {
+    getUser.mockReset();
+  });
+
+  it("301s public /store to Door 2 without a warehouse Location", async () => {
+    const response = await fetch(`${baseUrl}/store`, { redirect: "manual" });
+    expect(response.status).toBe(301);
+    expect(response.headers.get("location")).toBe("/solutions/business-needs");
+    expect(response.headers.get("location") || "").not.toContain("/internal");
+  });
+
+  it("returns the same generic 404 for unknown and staff-only SKUs", async () => {
+    const unknown = await fetch(`${baseUrl}/store/product/not-a-real-sku`, { redirect: "manual" });
+    const staffSku = await fetch(`${baseUrl}/store/product/DE-SVC-CM-ENDPOINT-EDR-MO`, {
+      redirect: "manual",
+    });
+    expect(unknown.status).toBe(404);
+    expect(staffSku.status).toBe(404);
+    expect(unknown.headers.get("location")).toBeNull();
+    expect(staffSku.headers.get("location")).toBeNull();
+    const unknownBody = await unknown.text();
+    const staffBody = await staffSku.text();
+    expect(unknownBody).toBe(staffBody);
+    expect(unknownBody.toLowerCase()).not.toContain("sku");
+    expect(unknownBody.toLowerCase()).not.toContain("warehouse");
+    expect(unknownBody.toLowerCase()).not.toContain("ninjaone");
+  });
+
+  it("denies warehouse HTML and catalog APIs without revealing existence", async () => {
+    const html = await fetch(`${baseUrl}/internal/warehouse`, { redirect: "manual" });
+    expect(html.status).toBe(404);
+    expect(html.headers.get("location")).toBeNull();
+    expect(await html.text()).not.toContain("WAREHOUSE_OK");
+
+    const api = await fetch(`${baseUrl}/api/store/solutions/current?sessionId=abc`);
+    expect(api.status).toBe(404);
+    expect(await api.json()).toEqual({ error: "Not found" });
+  });
+
+  it("lets a live admin open the warehouse and catalog APIs", async () => {
+    getUser.mockReturnValue({
+      id: "a1",
+      email: "admin@digeratiexperts.com",
+      role: "admin",
+      isActive: true,
+    });
+    const token = sign({ userId: "a1", email: "admin@digeratiexperts.com" });
+    const headers = { cookie: `portalAuth=${token}` };
+
+    const html = await fetch(`${baseUrl}/internal/warehouse`, { headers, redirect: "manual" });
+    expect(html.status).toBe(200);
+    expect(await html.text()).toBe("WAREHOUSE_OK");
+
+    const destage = await fetch(`${baseUrl}/store/co-managed`, { headers, redirect: "manual" });
+    expect(destage.status).toBe(302);
+    expect(destage.headers.get("location")).toBe("/internal/warehouse/co-managed");
+
+    const api = await fetch(`${baseUrl}/api/store/solutions/current?sessionId=abc`, { headers });
+    expect(api.status).toBe(200);
+    expect(await api.json()).toEqual({ leaked: true });
+  });
+});

--- a/server/warehouseRoutes.ts
+++ b/server/warehouseRoutes.ts
@@ -1,0 +1,61 @@
+import type { Express, Request, Response } from "express";
+import {
+  applyPrivateCacheHeaders,
+  isWarehouseCatalogApiPath,
+  isWarehouseHtmlPath,
+  requireWarehouseStaffApi,
+  resolveWarehouseStaff,
+  sendGenericNotFound,
+} from "./warehouseAccess";
+import { classifyLegacyStorePath, toWarehousePath } from "./storeLegacyRedirects";
+
+function withQuery(req: Request, dest: string): string {
+  const q = req.url.includes("?") ? req.url.slice(req.url.indexOf("?")) : "";
+  return `${dest}${q}`;
+}
+
+export function registerWarehouseGates(app: Express): void {
+  app.get("/api/internal/warehouse/session", (req: Request, res: Response) => {
+    applyPrivateCacheHeaders(res);
+    if (!resolveWarehouseStaff(req)) {
+      sendGenericNotFound(req, res);
+      return;
+    }
+    res.json({ ok: true });
+  });
+
+  app.use((req, res, next) => {
+    if (!isWarehouseCatalogApiPath(req.path)) return next();
+    return requireWarehouseStaffApi(req, res, next);
+  });
+
+  app.use((req, res, next) => {
+    const path = req.path;
+    if (path !== "/store" && !path.startsWith("/store/")) return next();
+
+    applyPrivateCacheHeaders(res);
+    const staff = resolveWarehouseStaff(req);
+    if (staff) {
+      return res.redirect(302, withQuery(req, toWarehousePath(path)));
+    }
+
+    const classified = classifyLegacyStorePath(path);
+    if (classified.kind === "public_redirect") {
+      return res.redirect(301, withQuery(req, classified.to));
+    }
+    sendGenericNotFound(req, res);
+  });
+
+  app.use((req, res, next) => {
+    const path = req.path;
+    if (path !== "/internal" && !path.startsWith("/internal/")) return next();
+
+    applyPrivateCacheHeaders(res);
+    if (isWarehouseHtmlPath(path)) {
+      if (resolveWarehouseStaff(req)) return next();
+      sendGenericNotFound(req, res);
+      return;
+    }
+    return res.redirect(301, "/");
+  });
+}

--- a/shared/checkoutEligibility.test.ts
+++ b/shared/checkoutEligibility.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import {
+  DOOR_1_ELIGIBILITY,
+  DOOR_2_ELIGIBILITY,
+  MARKETPLACE_ELIGIBILITY,
+  WAREHOUSE_STAFF_ELIGIBILITY,
+  isPayNowAllowed,
+} from "./checkoutEligibility";
+
+describe("checkout eligibility", () => {
+  it("keeps Pay Now off public doors and the fail-safe marketplace", () => {
+    expect(isPayNowAllowed(DOOR_1_ELIGIBILITY)).toBe(false);
+    expect(isPayNowAllowed(DOOR_2_ELIGIBILITY)).toBe(false);
+    expect(isPayNowAllowed(MARKETPLACE_ELIGIBILITY)).toBe(false);
+    expect(DOOR_1_ELIGIBILITY).toBe("assessment_first");
+    expect(DOOR_2_ELIGIBILITY).toBe("request_quote");
+    expect(MARKETPLACE_ELIGIBILITY).toBe("request_approval");
+  });
+
+  it("reserves pay_now for staff warehouse only", () => {
+    expect(isPayNowAllowed(WAREHOUSE_STAFF_ELIGIBILITY)).toBe(true);
+  });
+});

--- a/shared/checkoutEligibility.ts
+++ b/shared/checkoutEligibility.ts
@@ -1,0 +1,22 @@
+/**
+ * Checkout eligibility is an explicit enum — not a hidden Pay Now default.
+ * Website-local until Hub entitlements exist. Do not invent tenant catalogs.
+ */
+export const CHECKOUT_ELIGIBILITY = [
+  "assessment_first",
+  "request_quote",
+  "request_approval",
+  "pay_now",
+] as const;
+
+export type CheckoutEligibility = (typeof CHECKOUT_ELIGIBILITY)[number];
+
+export const DOOR_1_ELIGIBILITY: CheckoutEligibility = "assessment_first";
+export const DOOR_2_ELIGIBILITY: CheckoutEligibility = "request_quote";
+export const MARKETPLACE_ELIGIBILITY: CheckoutEligibility = "request_approval";
+/** Staff warehouse only this phase — never expose as a public default. */
+export const WAREHOUSE_STAFF_ELIGIBILITY: CheckoutEligibility = "pay_now";
+
+export function isPayNowAllowed(eligibility: CheckoutEligibility): boolean {
+  return eligibility === "pay_now";
+}


### PR DESCRIPTION
## Summary
- Relocate the SKU catalog to `/internal/warehouse` with live `admin` checks at the HTML route and catalog API layers. Unauthorized warehouse and staff-only SKU lookups return the same generic 404 with no `Location: /internal/...`.
- Destage public `/store` (301 to Door 1/2). Catalog JS loads only after `WarehouseGate` confirms `/api/internal/warehouse/session`. Sitemap and robots no longer index SKU PDPs.
- Add fail-safe `/portal/marketplace` (Request Approval, empty Hub catalog) and an explicit checkout eligibility enum so Pay Now is never the public default. Door 1 two-door entry on `/solutions` is assessment-first.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx vitest run` (325 passed)
- [ ] Confirm unauthenticated `GET /store` is 301 → `/solutions/business-needs`
- [ ] Confirm unauthenticated `GET /internal/warehouse` and a non-ProActive `/store/product/:sku` are identical generic 404s
- [ ] Confirm admin session can open `/internal/warehouse`
- [ ] Confirm `/portal/marketplace` is Request Approval only (no warehouse SKUs)
- [ ] Confirm Door 1/2 public pages have no Pay Now

```
CONCURRENCY AUDIT
Branch base: aba811075df0bf011acb131568f0dfa1b1e4e019
Current origin/main: aba811075df0bf011acb131568f0dfa1b1e4e019
Commits landed on main since branch creation: none
Overlapping files: none
Reconciliation performed: none needed; branch started from current origin/main
Newer-main work preserved: YES
Whole-file replacements reviewed: YES — none used
Tests: tsc --noEmit; vitest run (325 passed)
Visual QA:
390: N/A — isolation/auth/destage; public Door 2 already live; warehouse is staff-only
768: N/A
1440: N/A
Screenshots captured: NO
```

Made with [Cursor](https://cursor.com)