### PR TITLE
Replace public Store cart with a Solution Builder draft

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -242,6 +242,11 @@ function Router() {
           <BusinessNeedsFamily />
         </Suspense>
       )} />
+      <Route path="/store/solution" component={() => (
+        <Suspense fallback={<PageLoadingSkeleton />}>
+          <PublicStoreCheckout />
+        </Suspense>
+      )} />
       <Route path="/store/checkout" component={() => (
         <Suspense fallback={<PageLoadingSkeleton />}>
           <PublicStoreCheckout />

--- a/client/src/components/store/PublicSolutionCart.tsx
+++ b/client/src/components/store/PublicSolutionCart.tsx
@@ -1,26 +1,39 @@
 import { useEffect, useRef, useState } from "react";
 import { Link } from "wouter";
-import { ShoppingCart, Trash2 } from "lucide-react";
+import { Layers, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
-import { getFamilyById, offerForDelivery } from "@/lib/businessNeeds";
-import { readSolutionCart, removeSolutionCartItem, SOLUTION_CART_EVENT, type PublicSolutionCartItem } from "@/lib/publicSolutionCart";
+import { getFamilyById, offerForDelivery, SOLUTION_WORKSPACE_PATH } from "@/lib/businessNeeds";
+import {
+  readSolutionDraft,
+  removeDraftNeed,
+  SOLUTION_DRAFT_EVENT,
+  type SolutionDraftNeed,
+} from "@/lib/solutionDraft";
 import { useDockHiddenWhileOpen } from "@/hooks/useDockHiddenWhileOpen";
 
+function deliveryCopy(need: SolutionDraftNeed, preference: string): string {
+  const delivery = need.delivery || preference;
+  if (delivery === "co_managed") return "Work with your IT team";
+  if (delivery === "standalone") return "DE manages this";
+  if (delivery === "unsure") return "Help me decide";
+  return "Delivery not chosen yet";
+}
+
 export function PublicSolutionCart() {
-  const [items, setItems] = useState<PublicSolutionCartItem[]>([]);
+  const [needs, setNeeds] = useState<SolutionDraftNeed[]>([]);
   const [open, setOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
 
   useDockHiddenWhileOpen(open);
 
   useEffect(() => {
-    const refresh = () => setItems(readSolutionCart());
+    const refresh = () => setNeeds(readSolutionDraft().needs);
     refresh();
-    window.addEventListener(SOLUTION_CART_EVENT, refresh);
+    window.addEventListener(SOLUTION_DRAFT_EVENT, refresh);
     window.addEventListener("storage", refresh);
     return () => {
-      window.removeEventListener(SOLUTION_CART_EVENT, refresh);
+      window.removeEventListener(SOLUTION_DRAFT_EVENT, refresh);
       window.removeEventListener("storage", refresh);
     };
   }, []);
@@ -44,6 +57,8 @@ export function PublicSolutionCart() {
     };
   }, []);
 
+  const preference = typeof window === "undefined" ? "" : readSolutionDraft().deliveryPreference;
+
   return (
     <Sheet open={open} onOpenChange={setOpen}>
       <SheetTrigger asChild>
@@ -58,33 +73,34 @@ export function PublicSolutionCart() {
           }}
           data-testid="public-solution-cart"
         >
-          <ShoppingCart className="mr-2 h-5 w-5 text-de-accent-ink" />Your Solution
-          {items.length > 0 && <span className="ml-2 rounded-full bg-de-accent px-2 py-0.5 text-xs font-bold text-white">{items.length}</span>}
+          <Layers className="mr-2 h-5 w-5 text-de-accent-ink" />Your Solution
+          {needs.length > 0 && <span className="ml-2 rounded-full bg-de-accent px-2 py-0.5 text-xs font-bold text-white">{needs.length}</span>}
         </Button>
       </SheetTrigger>
       <SheetContent className="w-[min(92vw,28rem)] border-white/10 bg-[#0d0d0d] text-white sm:max-w-md">
         <SheetHeader>
           <SheetTitle className="text-2xl text-white">Your Solution</SheetTitle>
-          <SheetDescription className="text-white/55">Review the curated lanes you want Digerati Experts to scope.</SheetDescription>
+          <SheetDescription className="text-white/55">Review the business needs you want Digerati Experts to scope together.</SheetDescription>
         </SheetHeader>
         <div className="mt-7 space-y-3">
-          {items.length ? items.map((item) => {
+          {needs.length ? needs.map((item) => {
             const family = getFamilyById(item.familyId);
             if (!family) return null;
-            const offer = offerForDelivery(family, item.delivery);
+            const delivery = item.delivery === "co_managed" || item.delivery === "standalone" ? item.delivery : null;
+            const offer = delivery ? offerForDelivery(family, delivery) : null;
             return <div key={item.familyId} className="rounded-xl border border-white/10 bg-[#151515] p-4">
-              <div className="flex items-start justify-between gap-3"><div><h3 className="font-semibold text-white">{family.label}</h3><p className="mt-1 text-sm text-white/55">{offer.name}</p></div><button type="button" onClick={() => removeSolutionCartItem(item.familyId)} className="flex h-11 w-11 items-center justify-center rounded-lg text-white/50 hover:bg-white/5 hover:text-white" aria-label={`Remove ${family.label}`}><Trash2 className="h-4 w-4" /></button></div>
+              <div className="flex items-start justify-between gap-3"><div><h3 className="font-semibold text-white">{family.label}</h3><p className="mt-1 text-sm text-white/55">{offer?.name ?? deliveryCopy(item, preference)}</p></div><button type="button" onClick={() => removeDraftNeed(item.familyId)} className="flex h-11 w-11 items-center justify-center rounded-lg text-white/50 hover:bg-white/5 hover:text-white" aria-label={`Remove ${family.label}`}><Trash2 className="h-4 w-4" /></button></div>
             </div>;
-          }) : <div className="rounded-xl border border-dashed border-white/15 p-8 text-center"><ShoppingCart className="mx-auto h-7 w-7 text-white/30" /><p className="mt-3 text-white/60">Your Solution is empty.</p></div>}
+          }) : <div className="rounded-xl border border-dashed border-white/15 p-8 text-center"><Layers className="mx-auto h-7 w-7 text-white/30" /><p className="mt-3 text-white/60">Your Solution is empty.</p></div>}
         </div>
-        {items.length ? (
+        {needs.length ? (
           <Button asChild className="mt-6 h-12 w-full bg-[#D3126A] text-white hover:bg-[#b90f5d]">
-            <Link href="/store/checkout" onClick={() => setOpen(false)}>Review and continue</Link>
+            <Link href={SOLUTION_WORKSPACE_PATH} onClick={() => setOpen(false)}>Review Your Solution</Link>
           </Button>
         ) : (
-          <Button className="mt-6 h-12 w-full" disabled>Review and continue</Button>
+          <Button className="mt-6 h-12 w-full" disabled>Review Your Solution</Button>
         )}
-        <p className="mt-3 text-xs leading-relaxed text-white/40">Checkout shows the correct next step for each solution. Complex managed services remain assessment or quote-first.</p>
+        <p className="mt-3 text-xs leading-relaxed text-white/40">No payment is required. We'll confirm fit, scope, and pricing before you commit.</p>
       </SheetContent>
     </Sheet>
   );

--- a/client/src/lib/businessNeeds.ts
+++ b/client/src/lib/businessNeeds.ts
@@ -8,7 +8,42 @@ import {
 export type { CuratedDeliveryModel, CuratedSolutionFamily, CuratedSolutionOffer };
 
 export const BUSINESS_NEEDS_INDEX_PATH = "/store";
+export const SOLUTION_WORKSPACE_PATH = "/store/solution";
 export const SOLUTION_REQUEST_PATH = "/solutions/request";
+
+export const BUSINESS_GOALS = [
+  {
+    id: "productive",
+    label: "Keep my team productive",
+    familyIds: ["it_operations", "endpoint_devices"],
+  },
+  {
+    id: "protect",
+    label: "Protect the business",
+    familyIds: ["identity_access", "email_collaboration", "cybersecurity_operations", "backup_continuity"],
+  },
+  {
+    id: "requirements",
+    label: "Meet requirements",
+    familyIds: ["compliance_risk", "documentation_standards", "security_awareness"],
+  },
+  {
+    id: "connect",
+    label: "Connect my people & locations",
+    familyIds: ["network_connectivity", "business_communications"],
+  },
+  {
+    id: "modernize",
+    label: "Equip & modernize",
+    familyIds: ["hardware_lifecycle", "technology_strategy"],
+  },
+] as const satisfies ReadonlyArray<{
+  id: string;
+  label: string;
+  familyIds: CuratedSolutionFamily["id"][];
+}>;
+
+export type BusinessGoalId = (typeof BUSINESS_GOALS)[number]["id"];
 
 export function familyToSlug(id: CuratedSolutionFamily["id"]): string {
   return id.replaceAll("_", "-");
@@ -41,6 +76,13 @@ export function parseDeliveryModel(value: string | null | undefined): CuratedDel
   return value === "co_managed" ? "co_managed" : "standalone";
 }
 
+export function parseDeliveryPreference(
+  value: string | null | undefined,
+): "standalone" | "co_managed" | "unsure" | "" {
+  if (value === "standalone" || value === "co_managed" || value === "unsure") return value;
+  return "";
+}
+
 /** Public wire contract — #101 fields only. */
 export function toPublicFamily(family: CuratedSolutionFamily) {
   return {
@@ -69,16 +111,17 @@ export function publicSolutionFamilies() {
   return curatedSolutionFamilies.map(toPublicFamily);
 }
 
-export function requestPath(opts: {
-  family: CuratedSolutionFamily["id"] | string;
-  delivery?: CuratedDeliveryModel;
+export function requestPath(opts?: {
+  family?: CuratedSolutionFamily["id"] | string;
+  delivery?: CuratedDeliveryModel | "unsure";
   intent?: "request" | "quote" | "assessment" | "consultation";
 }): string {
   const params = new URLSearchParams();
-  params.set("family", familyToSlug(opts.family as CuratedSolutionFamily["id"]));
-  if (opts.delivery) params.set("delivery", opts.delivery);
-  if (opts.intent) params.set("intent", opts.intent);
-  return `${SOLUTION_REQUEST_PATH}?${params.toString()}`;
+  if (opts?.family) params.set("family", familyToSlug(opts.family as CuratedSolutionFamily["id"]));
+  if (opts?.delivery) params.set("delivery", opts.delivery);
+  if (opts?.intent) params.set("intent", opts.intent);
+  const query = params.toString();
+  return query ? `${SOLUTION_REQUEST_PATH}?${query}` : SOLUTION_REQUEST_PATH;
 }
 
 export function familyPath(id: CuratedSolutionFamily["id"]): string {

--- a/client/src/lib/isDoor2Path.test.ts
+++ b/client/src/lib/isDoor2Path.test.ts
@@ -7,6 +7,8 @@ describe("isDoor2Path", () => {
     expect(isDoor2Path("/solutions/business-needs/identity-access")).toBe(true);
     expect(isDoor2Path("/solutions/request?family=identity-access")).toBe(true);
     expect(isDoor2Path("/store")).toBe(true);
+    expect(isDoor2Path("/store/solution")).toBe(true);
+    expect(isDoor2Path("/store/checkout")).toBe(true);
     expect(isDoor2Path("/store/solutions/identity-access")).toBe(true);
     expect(isDoor2Path("/solutions")).toBe(false);
     expect(isDoor2Path("/solutions/proactive-ecosystem")).toBe(false);

--- a/client/src/lib/isDoor2Path.ts
+++ b/client/src/lib/isDoor2Path.ts
@@ -3,6 +3,8 @@ export function isDoor2Path(path: string): boolean {
   const pathname = path.split("?")[0] ?? path;
   return (
     pathname === "/store" ||
+    pathname === "/store/checkout" ||
+    pathname === "/store/solution" ||
     pathname.startsWith("/store/solutions/") ||
     pathname === "/solutions/business-needs" ||
     pathname.startsWith("/solutions/business-needs/") ||

--- a/client/src/lib/publicSolutionCart.ts
+++ b/client/src/lib/publicSolutionCart.ts
@@ -1,37 +1,11 @@
-import type { CuratedDeliveryModel, CuratedSolutionFamily } from "@/data/curatedSolutions";
-
-export type PublicSolutionCartItem = {
-  familyId: CuratedSolutionFamily["id"];
-  delivery: CuratedDeliveryModel;
-};
-
-const STORAGE_KEY = "de-public-solution-cart-v1";
-export const SOLUTION_CART_EVENT = "de-solution-cart-change";
-
-export function readSolutionCart(): PublicSolutionCartItem[] {
-  if (typeof window === "undefined") return [];
-  try {
-    const value = JSON.parse(window.localStorage.getItem(STORAGE_KEY) || "[]");
-    return Array.isArray(value) ? value.filter((item) => item?.familyId && item?.delivery) : [];
-  } catch {
-    return [];
-  }
-}
-
-function write(items: PublicSolutionCartItem[]) {
-  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
-  window.dispatchEvent(new CustomEvent(SOLUTION_CART_EVENT));
-}
-
-export function addSolutionCartItem(item: PublicSolutionCartItem) {
-  const items = readSolutionCart().filter((entry) => entry.familyId !== item.familyId);
-  write([...items, item]);
-}
-
-export function removeSolutionCartItem(familyId: string) {
-  write(readSolutionCart().filter((entry) => entry.familyId !== familyId));
-}
-
-export function clearSolutionCart() {
-  write([]);
-}
+/**
+ * Compatibility shim. Public Door 2 no longer uses a cart.
+ * New code should import `@/lib/solutionDraft`.
+ */
+export {
+  addDraftNeed as addSolutionCartItem,
+  readSolutionDraft,
+  removeDraftNeed as removeSolutionCartItem,
+  SOLUTION_DRAFT_EVENT as SOLUTION_CART_EVENT,
+  type SolutionDraftNeed as PublicSolutionCartItem,
+} from "./solutionDraft";

--- a/client/src/lib/solutionDraft.test.ts
+++ b/client/src/lib/solutionDraft.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  emptyDraft,
+  parseDraft,
+  recommendedCtaLabel,
+  recommendedIntent,
+  removeNeed,
+  resolvedNeedDelivery,
+  toRequestNeeds,
+  toggleNeed,
+  upsertNeed,
+} from "./solutionDraft";
+
+describe("SolutionDraft", () => {
+  it("does not assign a delivery model when a need is toggled on", () => {
+    const draft = toggleNeed(emptyDraft(), "identity_access");
+    expect(draft.needs).toEqual([{ familyId: "identity_access" }]);
+    expect(draft.deliveryPreference).toBe("");
+    expect(resolvedNeedDelivery(draft.needs[0], draft.deliveryPreference)).toBe("");
+  });
+
+  it("composes multiple families into one request payload", () => {
+    const withNeeds = ["identity_access", "backup_continuity", "cybersecurity_operations", "email_collaboration", "network_connectivity"].reduce(
+      (draft, familyId) => toggleNeed(draft, familyId as "identity_access"),
+      emptyDraft(),
+    );
+    const ready = {
+      ...withNeeds,
+      deliveryPreference: "unsure" as const,
+    };
+    const payload = toRequestNeeds(ready);
+    expect(payload).toHaveLength(5);
+    expect(payload.map((need) => need.familyId)).toEqual([
+      "identity_access",
+      "backup_continuity",
+      "cybersecurity_operations",
+      "email_collaboration",
+      "network_connectivity",
+    ]);
+    expect(payload.every((need) => need.deliveryModel === "unsure")).toBe(true);
+    expect(payload.every((need) => need.offerId === null)).toBe(true);
+    expect(recommendedIntent(ready)).toBe("assessment");
+    expect(recommendedCtaLabel("assessment")).toBe("Start a Cyber Risk Assessment");
+  });
+
+  it("keeps a chosen delivery on a need without forcing the rest", () => {
+    const draft = upsertNeed(emptyDraft(), { familyId: "backup_continuity", delivery: "co_managed" });
+    expect(draft.needs[0]?.delivery).toBe("co_managed");
+    expect(toggleNeed(draft, "identity_access").needs).toEqual([
+      { familyId: "backup_continuity", delivery: "co_managed" },
+      { familyId: "identity_access" },
+    ]);
+    expect(removeNeed(draft, "backup_continuity").needs).toEqual([]);
+  });
+
+  it("ignores unknown families and cart-shaped legacy noise", () => {
+    const parsed = parseDraft({
+      version: 1,
+      needs: [{ familyId: "not_a_family" }, { familyId: "identity_access", delivery: "standalone" }],
+      deliveryPreference: "standalone",
+    });
+    expect(parsed.needs).toEqual([{ familyId: "identity_access", delivery: "standalone" }]);
+  });
+});

--- a/client/src/lib/solutionDraft.ts
+++ b/client/src/lib/solutionDraft.ts
@@ -1,0 +1,301 @@
+import type { CuratedSolutionFamily } from "@/data/curatedSolutions";
+import { getFamilyById, offerForDelivery } from "@/lib/businessNeeds";
+
+export type DeliveryPreference = "standalone" | "co_managed" | "unsure";
+export type DeviceOwnership = "company" | "byod" | "hybrid" | "";
+export type InternalItStatus = "yes" | "no" | "unsure" | "";
+export type SolutionRequestIntent = "request" | "quote" | "assessment" | "consultation";
+
+export type SolutionDraftNeed = {
+  familyId: CuratedSolutionFamily["id"];
+  delivery?: DeliveryPreference;
+};
+
+export type SolutionEnvironment = {
+  userCount: string;
+  siteCount: string;
+  deviceOwnership: DeviceOwnership;
+  deviceMix: string;
+  internalIt: InternalItStatus;
+  complianceNeeds: string;
+  currentProvider: string;
+  urgency: string;
+};
+
+export type SolutionDraft = {
+  version: 1;
+  needs: SolutionDraftNeed[];
+  deliveryPreference: DeliveryPreference | "";
+  environment: SolutionEnvironment;
+  intent: SolutionRequestIntent;
+};
+
+const STORAGE_KEY = "de-solution-draft-v1";
+const LEGACY_CART_KEY = "de-public-solution-cart-v1";
+export const SOLUTION_DRAFT_EVENT = "de-solution-draft-change";
+/** @deprecated Use SOLUTION_DRAFT_EVENT. Kept so existing listeners keep working. */
+export const SOLUTION_CART_EVENT = SOLUTION_DRAFT_EVENT;
+
+const FAMILY_IDS = new Set<string>([
+  "it_operations",
+  "endpoint_devices",
+  "identity_access",
+  "email_collaboration",
+  "cybersecurity_operations",
+  "network_connectivity",
+  "backup_continuity",
+  "compliance_risk",
+  "security_awareness",
+  "business_communications",
+  "hardware_lifecycle",
+  "documentation_standards",
+  "technology_strategy",
+]);
+
+export function emptyEnvironment(): SolutionEnvironment {
+  return {
+    userCount: "",
+    siteCount: "",
+    deviceOwnership: "",
+    deviceMix: "",
+    internalIt: "",
+    complianceNeeds: "",
+    currentProvider: "",
+    urgency: "",
+  };
+}
+
+export function emptyDraft(): SolutionDraft {
+  return {
+    version: 1,
+    needs: [],
+    deliveryPreference: "",
+    environment: emptyEnvironment(),
+    intent: "assessment",
+  };
+}
+
+function isFamilyId(value: unknown): value is CuratedSolutionFamily["id"] {
+  return typeof value === "string" && FAMILY_IDS.has(value);
+}
+
+function asDeliveryPreference(value: unknown): DeliveryPreference | undefined {
+  if (value === "standalone" || value === "co_managed" || value === "unsure") return value;
+  return undefined;
+}
+
+function asDeviceOwnership(value: unknown): DeviceOwnership {
+  if (value === "company" || value === "byod" || value === "hybrid") return value;
+  return "";
+}
+
+function asInternalIt(value: unknown): InternalItStatus {
+  if (value === "yes" || value === "no" || value === "unsure") return value;
+  return "";
+}
+
+function asIntent(value: unknown): SolutionRequestIntent {
+  if (value === "quote" || value === "assessment" || value === "consultation" || value === "request") {
+    return value;
+  }
+  return "assessment";
+}
+
+function clip(value: unknown, max: number): string {
+  return typeof value === "string" ? value.trim().slice(0, max) : "";
+}
+
+export function parseDraft(raw: unknown): SolutionDraft {
+  const base = emptyDraft();
+  if (!raw || typeof raw !== "object") return base;
+  const input = raw as Record<string, unknown>;
+  const needs = Array.isArray(input.needs)
+    ? input.needs.flatMap((entry) => {
+        if (!entry || typeof entry !== "object") return [];
+        const familyId = (entry as { familyId?: unknown }).familyId;
+        if (!isFamilyId(familyId)) return [];
+        const delivery = asDeliveryPreference((entry as { delivery?: unknown }).delivery);
+        return delivery ? [{ familyId, delivery }] : [{ familyId }];
+      })
+    : [];
+  const seen = new Set<string>();
+  const uniqueNeeds = needs.filter((need) => {
+    if (seen.has(need.familyId)) return false;
+    seen.add(need.familyId);
+    return true;
+  });
+  const environmentInput =
+    input.environment && typeof input.environment === "object"
+      ? (input.environment as Record<string, unknown>)
+      : {};
+  return {
+    version: 1,
+    needs: uniqueNeeds,
+    deliveryPreference: asDeliveryPreference(input.deliveryPreference) ?? "",
+    intent: asIntent(input.intent),
+    environment: {
+      userCount: clip(environmentInput.userCount, 12),
+      siteCount: clip(environmentInput.siteCount, 12),
+      deviceOwnership: asDeviceOwnership(environmentInput.deviceOwnership),
+      deviceMix: clip(environmentInput.deviceMix, 200),
+      internalIt: asInternalIt(environmentInput.internalIt),
+      complianceNeeds: clip(environmentInput.complianceNeeds, 400),
+      currentProvider: clip(environmentInput.currentProvider, 200),
+      urgency: clip(environmentInput.urgency, 200),
+    },
+  };
+}
+
+export function resolvedNeedDelivery(
+  need: SolutionDraftNeed,
+  preference: DeliveryPreference | "",
+): DeliveryPreference | "" {
+  return need.delivery || preference || "";
+}
+
+export function upsertNeed(draft: SolutionDraft, need: SolutionDraftNeed): SolutionDraft {
+  return {
+    ...draft,
+    needs: [...draft.needs.filter((entry) => entry.familyId !== need.familyId), need],
+  };
+}
+
+export function removeNeed(draft: SolutionDraft, familyId: string): SolutionDraft {
+  return {
+    ...draft,
+    needs: draft.needs.filter((entry) => entry.familyId !== familyId),
+  };
+}
+
+export function toggleNeed(draft: SolutionDraft, familyId: CuratedSolutionFamily["id"]): SolutionDraft {
+  if (draft.needs.some((entry) => entry.familyId === familyId)) {
+    return removeNeed(draft, familyId);
+  }
+  return upsertNeed(draft, { familyId });
+}
+
+export function setDeliveryPreference(
+  draft: SolutionDraft,
+  deliveryPreference: DeliveryPreference | "",
+): SolutionDraft {
+  return { ...draft, deliveryPreference };
+}
+
+export function patchEnvironment(
+  draft: SolutionDraft,
+  patch: Partial<SolutionEnvironment>,
+): SolutionDraft {
+  return {
+    ...draft,
+    environment: { ...draft.environment, ...patch },
+  };
+}
+
+export function recommendedIntent(draft: SolutionDraft): SolutionRequestIntent {
+  const steps = draft.needs.flatMap((need) => {
+    const family = getFamilyById(need.familyId);
+    if (!family) return [];
+    const delivery = resolvedNeedDelivery(need, draft.deliveryPreference);
+    if (delivery === "standalone" || delivery === "co_managed") {
+      return [offerForDelivery(family, delivery).nextStep];
+    }
+    return family.offers.map((offer) => offer.nextStep);
+  });
+  if (steps.some((step) => /assess/i.test(step))) return "assessment";
+  if (steps.some((step) => /consult/i.test(step))) return "consultation";
+  if (steps.some((step) => /quote/i.test(step))) return "quote";
+  return draft.intent || "request";
+}
+
+export function recommendedCtaLabel(intent: SolutionRequestIntent): string {
+  if (intent === "assessment") return "Start a Cyber Risk Assessment";
+  if (intent === "consultation") return "Schedule a consultation";
+  if (intent === "quote") return "Request a quote";
+  return "Submit this solution";
+}
+
+export type PublicSolutionNeedPayload = {
+  familyId: string;
+  offerId: string | null;
+  deliveryModel: DeliveryPreference;
+};
+
+export function toRequestNeeds(draft: SolutionDraft): PublicSolutionNeedPayload[] {
+  const preference = draft.deliveryPreference || "unsure";
+  return draft.needs.flatMap((need) => {
+    const family = getFamilyById(need.familyId);
+    if (!family) return [];
+    const delivery = resolvedNeedDelivery(need, preference) || "unsure";
+    const offer =
+      delivery === "standalone" || delivery === "co_managed"
+        ? offerForDelivery(family, delivery)
+        : null;
+    return [
+      {
+        familyId: need.familyId,
+        offerId: offer?.id ?? null,
+        deliveryModel: delivery === "standalone" || delivery === "co_managed" ? delivery : "unsure",
+      },
+    ];
+  });
+}
+
+function migrateLegacyCart(): SolutionDraftNeed[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const value = JSON.parse(window.localStorage.getItem(LEGACY_CART_KEY) || "[]");
+    if (!Array.isArray(value)) return [];
+    return value.flatMap((item) => {
+      if (!isFamilyId(item?.familyId)) return [];
+      const delivery = asDeliveryPreference(item?.delivery);
+      return delivery ? [{ familyId: item.familyId, delivery }] : [{ familyId: item.familyId }];
+    });
+  } catch {
+    return [];
+  }
+}
+
+export function readSolutionDraft(): SolutionDraft {
+  if (typeof window === "undefined") return emptyDraft();
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (stored) return parseDraft(JSON.parse(stored));
+    const migrated = migrateLegacyCart();
+    if (migrated.length === 0) return emptyDraft();
+    const draft = { ...emptyDraft(), needs: migrated };
+    writeSolutionDraft(draft);
+    window.localStorage.removeItem(LEGACY_CART_KEY);
+    return draft;
+  } catch {
+    return emptyDraft();
+  }
+}
+
+export function writeSolutionDraft(draft: SolutionDraft): SolutionDraft {
+  const next = parseDraft(draft);
+  if (typeof window !== "undefined") {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+    window.dispatchEvent(new CustomEvent(SOLUTION_DRAFT_EVENT));
+  }
+  return next;
+}
+
+export function addDraftNeed(need: SolutionDraftNeed): SolutionDraft {
+  return writeSolutionDraft(upsertNeed(readSolutionDraft(), need));
+}
+
+export function removeDraftNeed(familyId: string): SolutionDraft {
+  return writeSolutionDraft(removeNeed(readSolutionDraft(), familyId));
+}
+
+export function toggleDraftNeed(familyId: CuratedSolutionFamily["id"]): SolutionDraft {
+  return writeSolutionDraft(toggleNeed(readSolutionDraft(), familyId));
+}
+
+export function patchSolutionDraft(patch: Partial<SolutionDraft>): SolutionDraft {
+  return writeSolutionDraft({ ...readSolutionDraft(), ...patch });
+}
+
+export function clearSolutionDraft(): SolutionDraft {
+  return writeSolutionDraft(emptyDraft());
+}

--- a/client/src/pages/solutions/BusinessNeedsFamily.tsx
+++ b/client/src/pages/solutions/BusinessNeedsFamily.tsx
@@ -94,21 +94,23 @@ export default function BusinessNeedsFamily() {
         <main className="de-nav-clear mx-auto max-w-5xl px-4 pb-40 sm:px-6 lg:px-8">
           <Link
             href={BUSINESS_NEEDS_INDEX_PATH}
-            className="mb-8 inline-flex h-11 items-center text-sm text-white/65 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A] focus-visible:ring-offset-2 focus-visible:ring-offset-[#050312]"
+            className="mb-10 inline-flex h-11 items-center text-sm text-white/55 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A] focus-visible:ring-offset-2 focus-visible:ring-offset-[#050312]"
           >
             <ArrowLeft className="mr-2 h-4 w-4" aria-hidden="true" />
             Back to the Store
           </Link>
 
-          <p className="mb-2 text-xs font-semibold uppercase tracking-[0.18em] text-de-accent-ink">
-            Curated DE solution
-          </p>
-          <h1 className="mb-4 text-4xl font-bold text-white md:text-5xl" data-testid="heading-family">
-            {family.label}
-          </h1>
-          <p className="mb-8 max-w-3xl text-lg leading-relaxed text-white/75">{family.description}</p>
+          <header className="max-w-3xl pb-10">
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-de-accent-ink">
+              Curated DE solution
+            </p>
+            <h1 className="mt-4 text-[clamp(2.25rem,5vw,3.75rem)] font-bold leading-[1.08] tracking-[-0.035em] text-white" data-testid="heading-family">
+              {family.label}
+            </h1>
+            <p className="mt-5 max-w-xl text-lg leading-relaxed text-white/65">{family.description}</p>
+          </header>
 
-          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-white/55">
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-white/45">
             What fits your organization?
           </h2>
           <div

--- a/client/src/pages/solutions/BusinessNeedsFamily.tsx
+++ b/client/src/pages/solutions/BusinessNeedsFamily.tsx
@@ -1,6 +1,6 @@
 import { Link, useParams } from "wouter";
-import { useMemo, useState } from "react";
-import { ArrowLeft, ArrowRight, CheckCircle2, ShoppingCart } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { ArrowLeft, CheckCircle2 } from "lucide-react";
 import { MegaMenu } from "@/components/MegaMenu";
 import { DigeratiEnhancedFooterSection } from "@/pages/sections/DigeratiEnhancedFooterSection";
 import { Button } from "@/components/ui/button";
@@ -11,14 +11,11 @@ import {
   familyPath,
   getFamilyBySlug,
   offerForDelivery,
-  parseDeliveryModel,
-  requestPath,
-  type CuratedDeliveryModel,
 } from "@/lib/businessNeeds";
 import { openMspAdvisor } from "@/lib/openMspAdvisor";
 import { StorePageAtmosphere } from "@/components/store/StorePageAtmosphere";
 import { PublicSolutionCart } from "@/components/store/PublicSolutionCart";
-import { addSolutionCartItem } from "@/lib/publicSolutionCart";
+import { addDraftNeed, patchSolutionDraft, readSolutionDraft, type DeliveryPreference } from "@/lib/solutionDraft";
 import { useToast } from "@/hooks/use-toast";
 
 function OfferList({ title, items }: { title: string; items: string[] }) {
@@ -36,13 +33,33 @@ function OfferList({ title, items }: { title: string; items: string[] }) {
   );
 }
 
+const DELIVERY_OPTIONS: Array<[DeliveryPreference, string]> = [
+  ["standalone", "DE manages this"],
+  ["co_managed", "Work with our IT team"],
+  ["unsure", "Not sure — help me decide"],
+];
+
 export default function BusinessNeedsFamily() {
   const params = useParams<{ family?: string }>();
   const family = getFamilyBySlug(params.family || "");
-  const [delivery, setDelivery] = useState<CuratedDeliveryModel>("standalone");
+  const [delivery, setDelivery] = useState<DeliveryPreference | "">("");
   const { toast } = useToast();
 
-  const offer = useMemo(() => (family ? offerForDelivery(family, delivery) : null), [family, delivery]);
+  useEffect(() => {
+    if (!family) return;
+    const draft = readSolutionDraft();
+    setDelivery(
+      draft.needs.find((need) => need.familyId === family.id)?.delivery || draft.deliveryPreference || "",
+    );
+  }, [family?.id]);
+
+  const offer = useMemo(() => {
+    if (!family) return null;
+    if (delivery === "co_managed" || delivery === "standalone") {
+      return offerForDelivery(family, delivery);
+    }
+    return offerForDelivery(family, "standalone");
+  }, [family, delivery]);
 
   useSEO(
     family
@@ -65,11 +82,11 @@ export default function BusinessNeedsFamily() {
   const askAbout = () => {
     openMspAdvisor({
       context: "other",
-      seedMessage: `I am reviewing the Digerati Experts ${family.label} ${
-        delivery === "co_managed" ? "co-managed" : "standalone"
-      } solution and want to ask about fit, scope, and next steps.`,
+      seedMessage: `I am reviewing the Digerati Experts ${family.label} solution and want to ask about fit, scope, and next steps.`,
     });
   };
+
+  const showingFallbackOffer = delivery !== "co_managed" && delivery !== "standalone";
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-[#0a0a0a]">
@@ -93,23 +110,21 @@ export default function BusinessNeedsFamily() {
           </h1>
           <p className="mb-8 max-w-3xl text-lg leading-relaxed text-white/75">{family.description}</p>
 
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-white/55">
+            What fits your organization?
+          </h2>
           <div
-            className="mb-8 grid grid-cols-2 gap-2 rounded-xl border border-de-hairline bg-de-raised p-2"
+            className="mb-8 grid grid-cols-1 gap-2 rounded-xl border border-de-hairline bg-de-raised p-2 sm:grid-cols-3"
             role="tablist"
-            aria-label="Delivery model"
+            aria-label="What fits your organization?"
           >
-            {(
-              [
-                ["standalone", "DE owns this solution"],
-                ["co_managed", "Work with your IT team"],
-              ] as const
-            ).map(([value, label]) => (
+            {DELIVERY_OPTIONS.map(([value, label]) => (
               <button
                 key={value}
                 type="button"
                 role="tab"
                 aria-selected={delivery === value}
-                className={`h-11 rounded-lg text-sm font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A] ${
+                className={`h-11 rounded-lg px-3 text-sm font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A] ${
                   delivery === value
                     ? "bg-[#D3126A] text-white"
                     : "text-white/70 hover:bg-white/5"
@@ -127,10 +142,20 @@ export default function BusinessNeedsFamily() {
             data-testid="offer-panel"
           >
             <p className="mb-2 text-xs uppercase tracking-wide text-de-accent-ink">
-              {delivery === "co_managed" ? "Shared delivery" : "DE-managed delivery"}
+              {delivery === "co_managed"
+                ? "Shared delivery"
+                : delivery === "standalone"
+                  ? "DE-managed delivery"
+                  : "We'll help you choose"}
             </p>
-            <h2 className="mb-3 text-2xl font-semibold text-white">{offer.name}</h2>
-            <p className="mb-8 text-white/75 leading-relaxed">{offer.summary}</p>
+            <h2 className="mb-3 text-2xl font-semibold text-white">
+              {showingFallbackOffer ? family.label : offer.name}
+            </h2>
+            <p className="mb-8 text-white/75 leading-relaxed">
+              {showingFallbackOffer
+                ? "Tell us whether DE should manage this, work with your IT team, or help you decide. The outcomes below stay the same."
+                : offer.summary}
+            </p>
 
             <div className="grid gap-8 md:grid-cols-2">
               <section>
@@ -174,26 +199,28 @@ export default function BusinessNeedsFamily() {
 
           <section className="mt-8" aria-label="Solution actions">
             <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
-              <Button variant="brand" className="h-11" onClick={() => {
-                addSolutionCartItem({ familyId: family.id, delivery });
-                toast({ title: "Added to Your Solution", description: `${offer.name} is ready to review.` });
-              }}>
-                <ShoppingCart className="mr-2 h-4 w-4" aria-hidden="true" />Add to Your Solution
-              </Button>
-              <Button asChild variant="outline" className="h-11 border-white/20 text-white hover:bg-white/10">
-                <Link href={requestPath({ family: family.id, delivery, intent: "quote" })}>
-                  Request a quote
-                </Link>
-              </Button>
-              <Button asChild variant="outline" className="h-11 border-white/20 text-white hover:bg-white/10">
-                <Link href={requestPath({ family: family.id, delivery, intent: "assessment" })}>
-                  Start an assessment
-                </Link>
-              </Button>
-              <Button asChild variant="outline" className="h-11 border-white/20 text-white hover:bg-white/10">
-                <Link href={requestPath({ family: family.id, delivery, intent: "consultation" })}>
-                  Schedule a consultation
-                </Link>
+              <Button
+                variant="brand"
+                className="h-11"
+                disabled={!delivery}
+                data-testid="continue-building"
+                onClick={() => {
+                  if (!delivery) return;
+                  addDraftNeed({
+                    familyId: family.id,
+                    delivery,
+                  });
+                  const current = readSolutionDraft();
+                  if (!current.deliveryPreference) {
+                    patchSolutionDraft({ deliveryPreference: delivery });
+                  }
+                  toast({
+                    title: "Added to Your Solution",
+                    description: `${family.label} is in Your Solution.`,
+                  });
+                }}
+              >
+                Continue building
               </Button>
               <Button
                 type="button"
@@ -205,7 +232,10 @@ export default function BusinessNeedsFamily() {
                 Ask DE about this solution
               </Button>
             </div>
-            <p className="mt-4 flex items-start gap-2 text-sm text-white/50"><CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-de-accent-ink" />Your cart stays public-safe. Manufacturers, product codes, costs, and internal implementation mappings remain private.</p>
+            <p className="mt-4 flex items-start gap-2 text-sm text-white/50">
+              <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-de-accent-ink" />
+              No payment is required. We'll confirm fit, scope, and pricing before you commit.
+            </p>
           </section>
         </main>
         <PublicSolutionCart />

--- a/client/src/pages/solutions/BusinessNeedsFamily.tsx
+++ b/client/src/pages/solutions/BusinessNeedsFamily.tsx
@@ -86,8 +86,6 @@ export default function BusinessNeedsFamily() {
     });
   };
 
-  const showingFallbackOffer = delivery !== "co_managed" && delivery !== "standalone";
-
   return (
     <div className="relative min-h-screen overflow-hidden bg-[#0a0a0a]">
       <StorePageAtmosphere />
@@ -124,10 +122,10 @@ export default function BusinessNeedsFamily() {
                 type="button"
                 role="tab"
                 aria-selected={delivery === value}
-                className={`h-11 rounded-lg px-3 text-sm font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A] ${
+                className={`h-11 rounded-lg px-3 text-left text-sm font-semibold sm:text-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A] ${
                   delivery === value
                     ? "bg-[#D3126A] text-white"
-                    : "text-white/70 hover:bg-white/5"
+                    : "bg-white/5 text-white/70 hover:bg-white/10"
                 }`}
                 onClick={() => setDelivery(value)}
                 data-testid={`delivery-${value}`}
@@ -146,15 +144,13 @@ export default function BusinessNeedsFamily() {
                 ? "Shared delivery"
                 : delivery === "standalone"
                   ? "DE-managed delivery"
-                  : "We'll help you choose"}
+                  : "Select how DE should be involved"}
             </p>
             <h2 className="mb-3 text-2xl font-semibold text-white">
-              {showingFallbackOffer ? family.label : offer.name}
+              {delivery === "co_managed" || delivery === "standalone" ? offer.name : family.label}
             </h2>
             <p className="mb-8 text-white/75 leading-relaxed">
-              {showingFallbackOffer
-                ? "Tell us whether DE should manage this, work with your IT team, or help you decide. The outcomes below stay the same."
-                : offer.summary}
+              {delivery === "co_managed" || delivery === "standalone" ? offer.summary : family.description}
             </p>
 
             <div className="grid gap-8 md:grid-cols-2">

--- a/client/src/pages/solutions/BusinessNeedsIndex.tsx
+++ b/client/src/pages/solutions/BusinessNeedsIndex.tsx
@@ -1,7 +1,7 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Link } from "wouter";
 import { motion, useReducedMotion } from "framer-motion";
-import { ArrowRight, Briefcase, CheckCircle2, Eye, FileText, GraduationCap, HardDrive, Headphones, KeyRound, LockKeyhole, Mail, Network, Phone, RefreshCw, Search, Server, Shield, ShieldAlert, ShoppingCart } from "lucide-react";
+import { ArrowRight, Briefcase, CheckCircle2, Eye, FileText, GraduationCap, HardDrive, Headphones, KeyRound, LockKeyhole, Mail, Network, Phone, RefreshCw, Search, Server, Shield, ShieldAlert } from "lucide-react";
 import { MegaMenu } from "@/components/MegaMenu";
 import { DigeratiEnhancedFooterSection } from "@/pages/sections/DigeratiEnhancedFooterSection";
 import { Button } from "@/components/ui/button";
@@ -10,9 +10,9 @@ import { StorePageAtmosphere } from "@/components/store/StorePageAtmosphere";
 import { PublicSolutionCart } from "@/components/store/PublicSolutionCart";
 import { useSEO } from "@/hooks/useSEO";
 import { curatedSolutionFamilies, type CuratedSolutionFamily } from "@/data/curatedSolutions";
-import { familyPath } from "@/lib/businessNeeds";
+import { BUSINESS_GOALS, familyPath, type BusinessGoalId } from "@/lib/businessNeeds";
 import { PORTAL_LOGIN } from "@/lib/portalUrls";
-import { addSolutionCartItem } from "@/lib/publicSolutionCart";
+import { emptyDraft, readSolutionDraft, SOLUTION_DRAFT_EVENT, toggleDraftNeed, type SolutionDraft } from "@/lib/solutionDraft";
 import { useToast } from "@/hooks/use-toast";
 
 const FAMILY_ICONS: Record<CuratedSolutionFamily["id"], typeof Shield> = {
@@ -50,7 +50,20 @@ const FAMILY_ACCENTS: Record<CuratedSolutionFamily["id"], string> = {
 export default function BusinessNeedsIndex() {
   const prefersReducedMotion = useReducedMotion();
   const [query, setQuery] = useState("");
+  const [goal, setGoal] = useState<BusinessGoalId | "all">("all");
+  const [draft, setDraft] = useState<SolutionDraft>(emptyDraft);
   const { toast } = useToast();
+
+  useEffect(() => {
+    const refresh = () => setDraft(readSolutionDraft());
+    refresh();
+    window.addEventListener(SOLUTION_DRAFT_EVENT, refresh);
+    window.addEventListener("storage", refresh);
+    return () => {
+      window.removeEventListener(SOLUTION_DRAFT_EVENT, refresh);
+      window.removeEventListener("storage", refresh);
+    };
+  }, []);
 
   useSEO({
     title: "IT Solutions Store | Digerati Experts",
@@ -60,14 +73,17 @@ export default function BusinessNeedsIndex() {
 
   const families = useMemo(() => {
     const needle = query.trim().toLowerCase();
-    if (!needle) return curatedSolutionFamilies;
-    return curatedSolutionFamilies.filter((family) =>
-      [family.label, family.description, ...family.offers.flatMap((offer) => [offer.name, offer.summary, ...offer.outcomes, ...offer.includes])]
+    const goalFamilyIds =
+      goal === "all" ? null : new Set(BUSINESS_GOALS.find((entry) => entry.id === goal)?.familyIds ?? []);
+    return curatedSolutionFamilies.filter((family) => {
+      if (goalFamilyIds && !goalFamilyIds.has(family.id)) return false;
+      if (!needle) return true;
+      return [family.label, family.description, ...family.offers.flatMap((offer) => [offer.name, offer.summary, ...offer.outcomes, ...offer.includes])]
         .join(" ")
         .toLowerCase()
-        .includes(needle),
-    );
-  }, [query]);
+        .includes(needle);
+    });
+  }, [query, goal]);
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-[#0a0a0a]">
@@ -80,7 +96,7 @@ export default function BusinessNeedsIndex() {
               <motion.div initial={prefersReducedMotion ? false : { opacity: 0, y: 16 }} animate={{ opacity: 1, y: 0 }}>
                 <div className="mb-5 inline-flex items-center gap-2 rounded-full border border-de-accent/30 bg-de-accent/10 px-4 py-2">
                   <Shield className="h-4 w-4 text-de-accent-ink" aria-hidden="true" />
-                  <span className="text-sm font-medium text-de-accent-ink">Digerati Experts Store</span>
+                  <span className="text-sm font-medium text-de-accent-ink">Solution Builder</span>
                 </div>
                 <h1 className="max-w-4xl text-[clamp(2.5rem,6vw,4.75rem)] font-bold leading-[1.02] tracking-[-0.04em] text-white" data-testid="heading-business-needs">
                   Start with what your business needs to <span className="text-de-accent-ink">solve.</span>
@@ -107,9 +123,9 @@ export default function BusinessNeedsIndex() {
 
             <section className="mb-12 grid gap-4 rounded-2xl border border-white/10 bg-[#121212]/90 p-5 sm:grid-cols-3 sm:p-6" aria-label="How the Store works">
               {[
-                ["1", "Choose a business need", "Start with the outcome, not a manufacturer."],
-                ["2", "Build Your Solution", "Choose the delivery approach and approved options."],
-                ["3", "Review and continue", "Use the cart to request a quote, assessment, or eligible checkout."],
+                ["1", "Choose what to improve", "Start with the outcome, not a manufacturer."],
+                ["2", "Tell us how DE should help", "DE managed, with your IT team, or not sure yet."],
+                ["3", "Review Your Solution", "One summary, then one recommended next step."],
               ].map(([number, title, body]) => (
                 <div key={number} className="flex gap-3">
                   <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-de-accent/30 bg-de-accent/10 font-mono text-sm text-de-accent-ink">{number}</span>
@@ -129,6 +145,36 @@ export default function BusinessNeedsIndex() {
                   <Search className="pointer-events-none absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-white/40" aria-hidden="true" />
                   <Input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="Search business needs" className="h-12 border-white/15 bg-[#121212] pl-12 text-white placeholder:text-white/35" />
                 </label>
+              </div>
+              <div className="mb-6 flex flex-wrap gap-2" role="group" aria-label="Start from a business goal">
+                <button
+                  type="button"
+                  className={`h-10 rounded-full border px-4 text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A] ${
+                    goal === "all"
+                      ? "border-[#D3126A] text-white"
+                      : "border-white/15 text-white/70 hover:bg-white/5"
+                  }`}
+                  aria-pressed={goal === "all"}
+                  onClick={() => setGoal("all")}
+                >
+                  Browse all solutions
+                </button>
+                {BUSINESS_GOALS.map((entry) => (
+                  <button
+                    key={entry.id}
+                    type="button"
+                    className={`h-10 rounded-full border px-4 text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A] ${
+                      goal === entry.id
+                        ? "border-[#D3126A] text-white"
+                        : "border-white/15 text-white/70 hover:bg-white/5"
+                    }`}
+                    aria-pressed={goal === entry.id}
+                    onClick={() => setGoal(entry.id)}
+                    data-testid={`business-goal-${entry.id}`}
+                  >
+                    {entry.label}
+                  </button>
+                ))}
               </div>
 
               {families.length ? (
@@ -157,8 +203,8 @@ export default function BusinessNeedsIndex() {
                               {(family.offers[0]?.outcomes ?? []).slice(0, 2).map((outcome) => <li key={outcome} className="flex gap-2 text-xs leading-relaxed text-[#4A4556]"><CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0 text-de-accent" aria-hidden="true" />{outcome}</li>)}
                             </ul>
                             <div className="mt-auto grid grid-cols-2 gap-2 border-t border-black/10 pt-4">
-                              <Button asChild variant="outline" size="sm" className="h-10 min-w-0 border-black/15 bg-white px-2 text-xs font-semibold text-[#1A1228] hover:bg-black/5 sm:px-3"><Link href={familyPath(family.id)}><Eye className="mr-1 h-3.5 w-3.5" />Details</Link></Button>
-                              <Button size="sm" className="h-10 min-w-0 bg-de-accent px-2 text-xs font-bold text-white hover:bg-[#6548ff] sm:px-3" onClick={() => { addSolutionCartItem({ familyId: family.id, delivery: "standalone" }); toast({ title: "Added to Your Solution", description: `${family.label} is ready to configure.` }); }}><ShoppingCart className="mr-1 h-3.5 w-3.5" />Add</Button>
+                              <Button asChild variant="outline" size="sm" className="h-10 min-w-0 border-black/15 bg-white px-2 text-xs font-semibold text-[#1A1228] hover:bg-black/5 sm:px-3"><Link href={familyPath(family.id)}><Eye className="mr-1 h-3.5 w-3.5" />Explore</Link></Button>
+                              <Button size="sm" className="h-10 min-w-0 bg-de-accent px-2 text-xs font-bold text-white hover:bg-[#6548ff] sm:px-3" aria-pressed={draft.needs.some((need) => need.familyId === family.id)} onClick={() => { const next = toggleDraftNeed(family.id); const included = next.needs.some((need) => need.familyId === family.id); toast({ title: included ? "Added to Your Solution" : "Removed from Your Solution", description: included ? `${family.label} is in Your Solution.` : `${family.label} was removed.` }); }}>{draft.needs.some((need) => need.familyId === family.id) ? "Included" : "Include"}</Button>
                             </div>
                           </div>
                         </article>

--- a/client/src/pages/solutions/BusinessNeedsIndex.tsx
+++ b/client/src/pages/solutions/BusinessNeedsIndex.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link } from "wouter";
 import { motion, useReducedMotion } from "framer-motion";
-import { ArrowRight, Briefcase, CheckCircle2, Eye, FileText, GraduationCap, HardDrive, Headphones, KeyRound, LockKeyhole, Mail, Network, Phone, RefreshCw, Search, Server, Shield, ShieldAlert } from "lucide-react";
+import { ArrowRight, Briefcase, FileText, GraduationCap, HardDrive, Headphones, KeyRound, Mail, Network, Phone, RefreshCw, Search, Server, Shield, ShieldAlert } from "lucide-react";
 import { MegaMenu } from "@/components/MegaMenu";
 import { DigeratiEnhancedFooterSection } from "@/pages/sections/DigeratiEnhancedFooterSection";
 import { Button } from "@/components/ui/button";
@@ -92,67 +92,63 @@ export default function BusinessNeedsIndex() {
         <MegaMenu />
         <main className="de-nav-clear pb-24">
           <div className="mx-auto max-w-[var(--de-canvas)] px-4 sm:px-6 lg:px-8">
-            <header className="grid gap-8 pb-10 pt-2 lg:grid-cols-[minmax(0,1fr)_22rem] lg:items-end">
-              <motion.div initial={prefersReducedMotion ? false : { opacity: 0, y: 16 }} animate={{ opacity: 1, y: 0 }}>
-                <div className="mb-5 inline-flex items-center gap-2 rounded-full border border-de-accent/30 bg-de-accent/10 px-4 py-2">
-                  <Shield className="h-4 w-4 text-de-accent-ink" aria-hidden="true" />
-                  <span className="text-sm font-medium text-de-accent-ink">Solution Builder</span>
-                </div>
-                <h1 className="max-w-4xl text-[clamp(2.5rem,6vw,4.75rem)] font-bold leading-[1.02] tracking-[-0.04em] text-white" data-testid="heading-business-needs">
+            <header className="max-w-3xl pb-16 pt-8 md:pb-20 md:pt-14">
+              <motion.div initial={prefersReducedMotion ? false : { opacity: 0, y: 12 }} animate={{ opacity: 1, y: 0 }}>
+                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-de-accent-ink">Solution Builder</p>
+                <h1 className="mt-5 text-[clamp(2.25rem,5.4vw,4.25rem)] font-bold leading-[1.08] tracking-[-0.035em] text-white" data-testid="heading-business-needs">
                   Start with what your business needs to <span className="text-de-accent-ink">solve.</span>
                 </h1>
-                <p className="mt-6 max-w-3xl text-lg leading-relaxed text-white/70 md:text-xl">
+                <p className="mt-6 max-w-xl text-base leading-relaxed text-white/65 md:text-lg">
                   Browse complete DE solutions by outcome without an email address. We choose and manage the technology behind each solution, so you never have to compare a public wall of manufacturers and product codes.
                 </p>
+                <p className="mt-8 text-sm text-white/45">
+                  Client or DE staff?{" "}
+                  <a href={PORTAL_LOGIN} className="font-medium text-de-accent-ink underline-offset-4 hover:underline">
+                    Open Client Marketplace
+                  </a>
+                </p>
               </motion.div>
-              <aside className="rounded-2xl border border-white/10 bg-[#121212]/95 p-5">
-                <div className="flex gap-3">
-                  <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-de-accent/25 bg-de-accent/10">
-                    <LockKeyhole className="h-5 w-5 text-de-accent-ink" aria-hidden="true" />
-                  </span>
-                  <div>
-                    <h2 className="font-semibold text-white">Client or DE staff?</h2>
-                    <p className="mt-1 text-sm text-white/55">Sign in for approved purchasing, client pricing, and the private catalog.</p>
-                  </div>
-                </div>
-                <Button asChild variant="outline" className="mt-5 h-11 w-full border-de-accent/40 bg-transparent text-de-accent-ink hover:bg-de-accent/10">
-                  <a href={PORTAL_LOGIN}>Open Client Marketplace</a>
-                </Button>
-              </aside>
             </header>
 
-            <section className="mb-12 grid gap-4 rounded-2xl border border-white/10 bg-[#121212]/90 p-5 sm:grid-cols-3 sm:p-6" aria-label="How the Store works">
+            <ol className="mb-16 grid gap-8 border-y border-white/10 py-8 sm:grid-cols-3 sm:gap-10 sm:py-10" aria-label="How the Store works">
               {[
-                ["1", "Choose what to improve", "Start with the outcome, not a manufacturer."],
-                ["2", "Tell us how DE should help", "DE managed, with your IT team, or not sure yet."],
-                ["3", "Review Your Solution", "One summary, then one recommended next step."],
+                ["01", "Choose what to improve", "Start with the outcome, not a manufacturer."],
+                ["02", "Tell us how DE should help", "DE managed, with your IT team, or not sure yet."],
+                ["03", "Review Your Solution", "One summary, then one recommended next step."],
               ].map(([number, title, body]) => (
-                <div key={number} className="flex gap-3">
-                  <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-de-accent/30 bg-de-accent/10 font-mono text-sm text-de-accent-ink">{number}</span>
-                  <div><h2 className="font-semibold text-white">{title}</h2><p className="mt-1 text-sm leading-relaxed text-white/50">{body}</p></div>
-                </div>
+                <li key={number}>
+                  <p className="font-mono text-[11px] tracking-[0.16em] text-de-accent-ink">{number}</p>
+                  <h2 className="mt-3 text-lg font-semibold text-white">{title}</h2>
+                  <p className="mt-2 max-w-xs text-sm leading-relaxed text-white/50">{body}</p>
+                </li>
               ))}
-            </section>
+            </ol>
 
             <section aria-labelledby="curated-solutions-heading">
-              <div className="mb-7 flex flex-col gap-5 md:flex-row md:items-end md:justify-between">
-                <div>
-                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-de-accent-ink">Curated solution lanes</p>
-                  <h2 id="curated-solutions-heading" className="mt-2 text-3xl font-bold text-white md:text-4xl">Everything DE offers, organized by use case</h2>
+              <div className="mb-6 flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+                <div className="max-w-xl">
+                  <h2 id="curated-solutions-heading" className="text-2xl font-semibold tracking-tight text-white md:text-3xl">
+                    {goal === "all"
+                      ? "What needs attention?"
+                      : BUSINESS_GOALS.find((entry) => entry.id === goal)?.label}
+                  </h2>
+                  <p className="mt-2 text-sm leading-relaxed text-white/50">
+                    Pick a business goal, or browse all thirteen solutions.
+                  </p>
                 </div>
-                <label className="relative block w-full md:w-80">
+                <label className="relative block w-full lg:w-80">
                   <span className="sr-only">Search solutions</span>
-                  <Search className="pointer-events-none absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-white/40" aria-hidden="true" />
-                  <Input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="Search business needs" className="h-12 border-white/15 bg-[#121212] pl-12 text-white placeholder:text-white/35" />
+                  <Search className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-white/40" aria-hidden="true" />
+                  <Input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="Search business needs" className="h-11 border-white/10 bg-transparent pl-11 text-white placeholder:text-white/35" />
                 </label>
               </div>
-              <div className="mb-6 flex flex-wrap gap-2" role="group" aria-label="Start from a business goal">
+              <div className="mb-8 flex flex-wrap gap-2" role="group" aria-label="Start from a business goal">
                 <button
                   type="button"
-                  className={`h-10 rounded-full border px-4 text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A] ${
+                  className={`h-10 rounded-full px-4 text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A] ${
                     goal === "all"
-                      ? "border-[#D3126A] text-white"
-                      : "border-white/15 text-white/70 hover:bg-white/5"
+                      ? "border border-de-accent bg-transparent text-white"
+                      : "border border-white/12 text-white/65 hover:border-white/25 hover:text-white"
                   }`}
                   aria-pressed={goal === "all"}
                   onClick={() => setGoal("all")}
@@ -163,10 +159,10 @@ export default function BusinessNeedsIndex() {
                   <button
                     key={entry.id}
                     type="button"
-                    className={`h-10 rounded-full border px-4 text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A] ${
+                    className={`h-10 rounded-full px-4 text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A] ${
                       goal === entry.id
-                        ? "border-[#D3126A] text-white"
-                        : "border-white/15 text-white/70 hover:bg-white/5"
+                        ? "border border-de-accent bg-transparent text-white"
+                        : "border border-white/12 text-white/65 hover:border-white/25 hover:text-white"
                     }`}
                     aria-pressed={goal === entry.id}
                     onClick={() => setGoal(entry.id)}
@@ -178,33 +174,58 @@ export default function BusinessNeedsIndex() {
               </div>
 
               {families.length ? (
-                <ul className="grid gap-5 sm:grid-cols-2 xl:grid-cols-3" data-testid="business-needs-families">
+                <ul className="grid gap-6 sm:grid-cols-2 xl:grid-cols-3" data-testid="business-needs-families">
                   {families.map((family) => {
                     const Icon = FAMILY_ICONS[family.id];
+                    const included = draft.needs.some((need) => need.familyId === family.id);
+                    const leadOutcome = family.offers[0]?.outcomes[0];
                     return (
                       <li key={family.id}>
-                        <article className="group flex h-full min-h-[19rem] flex-col overflow-hidden rounded-2xl border border-black/10 bg-[#FAF9F6] text-[#1A1228] transition-all duration-300 hover:-translate-y-1.5 hover:border-de-accent/50 hover:bg-white hover:shadow-[0_20px_50px_rgba(0,0,0,0.25)] sm:min-h-[20rem]" data-testid={`family-card-${family.id}`}>
-                          <Link href={familyPath(family.id)} className="relative flex min-h-[6.75rem] items-center overflow-hidden border-b border-black/10 bg-[#181520] p-4 sm:min-h-[7.5rem] sm:p-5">
-                            <div className="absolute inset-0 bg-[radial-gradient(circle_at_78%_18%,rgba(29,111,242,0.30),transparent_52%)]" aria-hidden="true" />
-                            <div className="relative flex w-full items-center gap-3.5">
-                              <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-de-accent/30 bg-de-accent/10 sm:h-12 sm:w-12">
-                                <Icon className={`h-5 w-5 sm:h-6 sm:w-6 ${FAMILY_ACCENTS[family.id]}`} aria-hidden="true" />
+                        <article
+                          className={`group flex h-full flex-col overflow-hidden rounded-2xl bg-[#F7F5F2] text-[#1A1228] transition-transform duration-300 hover:-translate-y-1 ${
+                            included ? "ring-1 ring-de-accent" : "ring-1 ring-black/10"
+                          }`}
+                          data-testid={`family-card-${family.id}`}
+                        >
+                          <Link href={familyPath(family.id)} className="relative overflow-hidden bg-[#0c0c10] px-5 pb-6 pt-5">
+                            <div className="absolute inset-0 bg-[radial-gradient(circle_at_88%_0%,rgba(29,111,242,0.28),transparent_58%)]" aria-hidden="true" />
+                            <div className="relative">
+                              <span className="flex h-10 w-10 items-center justify-center rounded-lg border border-white/10 bg-black/30">
+                                <Icon className={`h-5 w-5 ${FAMILY_ACCENTS[family.id]}`} aria-hidden="true" />
                               </span>
-                              <div className="min-w-0">
-                                <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-white/45">Business need</p>
-                                <h3 className="mt-1 text-base font-bold leading-tight text-white sm:text-lg">{family.label}</h3>
-                              </div>
-                              <ArrowRight className="ml-auto h-4 w-4 shrink-0 text-white/35 transition-transform group-hover:translate-x-1 group-hover:text-de-accent-ink" aria-hidden="true" />
+                              <h3 className="mt-5 text-xl font-semibold leading-snug tracking-tight text-white">{family.label}</h3>
                             </div>
                           </Link>
-                          <div className="flex flex-1 flex-col p-4 sm:p-5">
-                            <p className="text-sm font-medium leading-relaxed text-[#4A4556]">{family.description}</p>
-                            <ul className="mt-4 space-y-2.5">
-                              {(family.offers[0]?.outcomes ?? []).slice(0, 2).map((outcome) => <li key={outcome} className="flex gap-2 text-xs leading-relaxed text-[#4A4556]"><CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0 text-de-accent" aria-hidden="true" />{outcome}</li>)}
-                            </ul>
-                            <div className="mt-auto grid grid-cols-2 gap-2 border-t border-black/10 pt-4">
-                              <Button asChild variant="outline" size="sm" className="h-10 min-w-0 border-black/15 bg-white px-2 text-xs font-semibold text-[#1A1228] hover:bg-black/5 sm:px-3"><Link href={familyPath(family.id)}><Eye className="mr-1 h-3.5 w-3.5" />Explore</Link></Button>
-                              <Button size="sm" className="h-10 min-w-0 bg-de-accent px-2 text-xs font-bold text-white hover:bg-[#6548ff] sm:px-3" aria-pressed={draft.needs.some((need) => need.familyId === family.id)} onClick={() => { const next = toggleDraftNeed(family.id); const included = next.needs.some((need) => need.familyId === family.id); toast({ title: included ? "Added to Your Solution" : "Removed from Your Solution", description: included ? `${family.label} is in Your Solution.` : `${family.label} was removed.` }); }}>{draft.needs.some((need) => need.familyId === family.id) ? "Included" : "Include"}</Button>
+                          <div className="flex flex-1 flex-col px-5 pb-5 pt-4">
+                            <p className="text-[15px] leading-relaxed text-[#4A4556]">{family.description}</p>
+                            {leadOutcome ? (
+                              <p className="mt-4 text-sm leading-relaxed text-[#1A1228]">
+                                <span className="text-de-accent">/</span> {leadOutcome}
+                              </p>
+                            ) : null}
+                            <div className="mt-auto flex items-center justify-between gap-3 pt-6">
+                              <Link
+                                href={familyPath(family.id)}
+                                className="inline-flex h-11 items-center text-sm font-semibold text-[#1A1228] underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A]"
+                              >
+                                Explore
+                                <ArrowRight className="ml-1.5 h-3.5 w-3.5" aria-hidden="true" />
+                              </Link>
+                              <Button
+                                size="sm"
+                                className="h-11 min-w-[6.5rem] bg-de-accent px-4 text-sm font-semibold text-white hover:bg-de-accent/90"
+                                aria-pressed={included}
+                                onClick={() => {
+                                  const next = toggleDraftNeed(family.id);
+                                  const nowIncluded = next.needs.some((need) => need.familyId === family.id);
+                                  toast({
+                                    title: nowIncluded ? "Added to Your Solution" : "Removed from Your Solution",
+                                    description: nowIncluded ? `${family.label} is in Your Solution.` : `${family.label} was removed.`,
+                                  });
+                                }}
+                              >
+                                {included ? "Included" : "Include"}
+                              </Button>
                             </div>
                           </div>
                         </article>
@@ -213,7 +234,7 @@ export default function BusinessNeedsIndex() {
                   })}
                 </ul>
               ) : (
-                <div className="rounded-2xl border border-white/10 bg-[#121212] px-6 py-14 text-center" role="status">
+                <div className="rounded-2xl border border-white/10 px-6 py-14 text-center" role="status">
                   <Search className="mx-auto h-8 w-8 text-white/30" aria-hidden="true" /><h3 className="mt-4 text-xl font-semibold text-white">No matching solution</h3><Button variant="outline" className="mt-5 border-white/20 text-white" onClick={() => setQuery("")}>Clear search</Button>
                 </div>
               )}

--- a/client/src/pages/solutions/SolutionRequest.tsx
+++ b/client/src/pages/solutions/SolutionRequest.tsx
@@ -10,25 +10,35 @@ import { useSEO } from "@/hooks/useSEO";
 import {
   BUSINESS_NEEDS_INDEX_PATH,
   familyPath,
+  getFamilyById,
   getFamilyBySlug,
   offerForDelivery,
-  parseDeliveryModel,
-  type CuratedDeliveryModel,
+  parseDeliveryPreference,
+  SOLUTION_WORKSPACE_PATH,
 } from "@/lib/businessNeeds";
 import { DOOR_2_ELIGIBILITY } from "@shared/checkoutEligibility";
+import {
+  addDraftNeed,
+  emptyDraft,
+  patchSolutionDraft,
+  readSolutionDraft,
+  recommendedCtaLabel,
+  recommendedIntent,
+  toRequestNeeds,
+  type SolutionDraft,
+  type SolutionRequestIntent,
+} from "@/lib/solutionDraft";
 
-type Intent = "request" | "quote" | "assessment" | "consultation";
-
-const INTENT_LABEL: Record<Intent, string> = {
-  request: "Request this solution",
+const INTENT_LABEL: Record<SolutionRequestIntent, string> = {
+  request: "Submit this solution",
   quote: "Request a quote",
-  assessment: "Start an assessment",
+  assessment: "Start a Cyber Risk Assessment",
   consultation: "Schedule a consultation",
 };
 
-function parseIntent(value: string | null): Intent {
-  if (value === "quote" || value === "assessment" || value === "consultation") return value;
-  return "request";
+function parseIntent(value: string | null): SolutionRequestIntent {
+  if (value === "quote" || value === "assessment" || value === "consultation" || value === "request") return value;
+  return "assessment";
 }
 
 type FormState = {
@@ -42,10 +52,31 @@ type FormState = {
 export default function SolutionRequest() {
   const search = useSearch();
   const params = useMemo(() => new URLSearchParams(search), [search]);
-  const family = getFamilyBySlug(params.get("family") || "");
-  const delivery: CuratedDeliveryModel = parseDeliveryModel(params.get("delivery"));
-  const intent = parseIntent(params.get("intent"));
-  const offer = family ? offerForDelivery(family, delivery) : null;
+  const [draft, setDraft] = useState<SolutionDraft>(emptyDraft);
+
+  useEffect(() => {
+    const current = readSolutionDraft();
+    const family = getFamilyBySlug(params.get("family") || "");
+    const delivery = parseDeliveryPreference(params.get("delivery"));
+    const intent = parseIntent(params.get("intent"));
+    let next = current;
+    if (family) {
+      next = addDraftNeed({
+        familyId: family.id,
+        ...(delivery ? { delivery } : {}),
+      });
+    }
+    if (delivery && !next.deliveryPreference) {
+      next = patchSolutionDraft({ deliveryPreference: delivery });
+    }
+    if (intent) {
+      next = patchSolutionDraft({ intent });
+    }
+    setDraft(next);
+  }, [params]);
+
+  const intent = parseIntent(params.get("intent")) || recommendedIntent(draft);
+  const needs = toRequestNeeds(draft);
 
   const [form, setForm] = useState<FormState>({
     organizationName: "",
@@ -59,7 +90,6 @@ export default function SolutionRequest() {
   const [error, setError] = useState("");
   const [result, setResult] = useState<{
     correlationId: string;
-    crm: string;
     message: string;
   } | null>(null);
 
@@ -98,12 +128,12 @@ export default function SolutionRequest() {
     event.preventDefault();
     setError("");
     setResult(null);
-    if (!family || !offer) {
-      setError("Select a solution family before submitting this Solution Request.");
+    if (needs.length === 0) {
+      setError("Select at least one business need before submitting this solution.");
       return;
     }
     if (form.contactName.trim().length < 2 || !form.contactEmail.includes("@")) {
-      setError("A name and email are required to submit or save this Solution Request.");
+      setError("A name and email are required to submit this solution.");
       return;
     }
 
@@ -115,34 +145,43 @@ export default function SolutionRequest() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           id: requestId,
-          familyId: family.id,
-          offerId: offer.id,
-          deliveryModel: delivery,
+          familyId: needs[0]?.familyId,
+          offerId: needs[0]?.offerId,
+          deliveryModel: needs[0]?.deliveryModel,
+          deliveryPreference: draft.deliveryPreference || "unsure",
+          selectedNeeds: needs,
+          environment: draft.environment,
           intent,
           organizationName: form.organizationName,
           contactName: form.contactName,
           contactEmail: form.contactEmail,
           contactPhone: form.contactPhone,
           notes: form.notes,
-          idempotencyKey: `${form.contactEmail.trim().toLowerCase()}|${offer.id}|${delivery}|${intent}`,
+          idempotencyKey: `${form.contactEmail.trim().toLowerCase()}|${needs
+            .map((need) => need.familyId)
+            .sort()
+            .join(",")}|${draft.deliveryPreference || "unsure"}|${intent}`,
         }),
       });
       const data = await response.json().catch(() => ({}));
       if (!response.ok) {
-        setError(typeof data.error === "string" ? data.error : "We could not save your Solution Request. Please try again.");
+        setError(typeof data.error === "string" ? data.error : "We could not save your solution request. Please try again.");
         return;
       }
       setResult({
         correlationId: data.correlationId,
-        crm: data.crm,
         message: data.message,
       });
     } catch {
-      setError("We could not save your Solution Request. Please try again.");
+      setError("We could not save your solution request. Please try again.");
     } finally {
       setSubmitting(false);
     }
   };
+
+  const backHref = needs[0]?.familyId
+    ? familyPath(needs[0].familyId as Parameters<typeof familyPath>[0])
+    : SOLUTION_WORKSPACE_PATH;
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-de-bg">
@@ -150,7 +189,7 @@ export default function SolutionRequest() {
         <MegaMenu />
         <main className="de-nav-clear mx-auto max-w-3xl px-4 pb-40 sm:px-6 lg:px-8">
           <Link
-            href={family ? familyPath(family.id) : BUSINESS_NEEDS_INDEX_PATH}
+            href={backHref}
             className="mb-8 inline-flex h-11 items-center text-sm text-white/65 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A] focus-visible:ring-offset-2 focus-visible:ring-offset-[#050312]"
           >
             <ArrowLeft className="mr-2 h-4 w-4" aria-hidden="true" />
@@ -164,20 +203,36 @@ export default function SolutionRequest() {
             {INTENT_LABEL[intent]}
           </h1>
           <p className="mb-8 text-white/70">
-            This is a Solution Request, not a cart. You are asking Digerati Experts to follow up —
-            not paying online.
+            No payment is required. We'll confirm fit, scope, and pricing before you commit.
           </p>
 
           <section className="mb-8 rounded-2xl border border-de-hairline bg-de-raised p-6" data-testid="request-selection">
-            {family && offer ? (
+            {needs.length ? (
               <>
-                <p className="text-sm text-white/50">Selected solution</p>
-                <h2 className="mt-1 text-xl font-semibold text-white">{offer.name}</h2>
-                <p className="mt-2 text-sm text-white/65">
-                  {family.label} · {delivery === "co_managed" ? "Co-managed" : "Standalone"}
-                </p>
-                <p className="mt-4 text-sm leading-relaxed text-white/75">{offer.summary}</p>
-                <p className="mt-4 text-sm text-white/55">Next step: {offer.nextStep}</p>
+                <p className="text-sm text-white/50">Your Solution</p>
+                <ul className="mt-3 space-y-3">
+                  {needs.map((need) => {
+                    const family = getFamilyById(need.familyId);
+                    if (!family) return null;
+                    const offer =
+                      need.deliveryModel === "co_managed" || need.deliveryModel === "standalone"
+                        ? offerForDelivery(family, need.deliveryModel)
+                        : null;
+                    return (
+                      <li key={need.familyId}>
+                        <h2 className="text-xl font-semibold text-white">{family.label}</h2>
+                        <p className="mt-1 text-sm text-white/65">
+                          {need.deliveryModel === "co_managed"
+                            ? "Work with your IT team"
+                            : need.deliveryModel === "standalone"
+                              ? "DE managed"
+                              : "We'll help you decide how DE is involved"}
+                        </p>
+                        {offer ? <p className="mt-2 text-sm leading-relaxed text-white/75">{offer.summary}</p> : null}
+                      </li>
+                    );
+                  })}
+                </ul>
               </>
             ) : (
               <p className="text-sm text-white/70">
@@ -197,10 +252,7 @@ export default function SolutionRequest() {
             >
               <h2 className="text-xl font-semibold text-white">Request saved</h2>
               <p className="mt-3 text-white/75">{result.message}</p>
-              <p className="mt-3 text-sm text-white/55">
-                Reference: {result.correlationId}
-                {result.crm === "pending" ? " · Follow-up is pending" : ""}
-              </p>
+              <p className="mt-3 text-sm text-white/55">Reference: {result.correlationId}</p>
               <Button asChild variant="outline" className="mt-6 h-11 border-white/20 text-white hover:bg-white/10">
                 <Link href={BUSINESS_NEEDS_INDEX_PATH}>Browse another family</Link>
               </Button>
@@ -280,11 +332,10 @@ export default function SolutionRequest() {
               </div>
 
               <Button type="submit" variant="brand" className="h-11 w-full sm:w-auto" disabled={submitting}>
-                {submitting ? "Saving…" : INTENT_LABEL[intent]}
+                {submitting ? "Saving…" : recommendedCtaLabel(intent)}
               </Button>
               <p className="text-xs text-white/45">
-                Contact details are used only to save this Solution Request. We will not claim a CRM
-                handoff succeeded unless the request is stored first.
+                Contact details are used only to follow up on this solution. No payment is required.
               </p>
             </form>
           )}

--- a/client/src/pages/solutions/door2Leakage.test.ts
+++ b/client/src/pages/solutions/door2Leakage.test.ts
@@ -2,15 +2,19 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { curatedSolutionFamilies } from "@/data/curatedSolutions";
+import { BUSINESS_GOALS } from "@/lib/businessNeeds";
 
 const root = path.resolve(import.meta.dirname, "../../../..");
 
 const door2Files = [
   "client/src/lib/businessNeeds.ts",
   "client/src/lib/isDoor2Path.ts",
+  "client/src/lib/solutionDraft.ts",
   "client/src/pages/solutions/BusinessNeedsIndex.tsx",
   "client/src/pages/solutions/BusinessNeedsFamily.tsx",
   "client/src/pages/solutions/SolutionRequest.tsx",
+  "client/src/pages/store/PublicStoreCheckout.tsx",
+  "client/src/components/store/PublicSolutionCart.tsx",
   "server/publicSolutionRoutes.ts",
   "server/publicSolutionRequestStore.ts",
   "server/publicSolutionRequestCrm.ts",
@@ -60,22 +64,39 @@ describe("Door 2 public leakage", () => {
     }
   });
 
-  it("covers 13 families with both delivery models and no email gate copy", () => {
+  it("covers 13 families with a goal layer and no email gate copy", () => {
     expect(curatedSolutionFamilies).toHaveLength(13);
+    expect(BUSINESS_GOALS).toHaveLength(5);
+    expect(new Set(BUSINESS_GOALS.flatMap((goal) => goal.familyIds)).size).toBe(13);
     const index = readFileSync(path.join(root, "client/src/pages/solutions/BusinessNeedsIndex.tsx"), "utf8");
     const familyPage = readFileSync(path.join(root, "client/src/pages/solutions/BusinessNeedsFamily.tsx"), "utf8");
+    const requestPage = readFileSync(path.join(root, "client/src/pages/solutions/SolutionRequest.tsx"), "utf8");
+    const workspace = readFileSync(path.join(root, "client/src/pages/store/PublicStoreCheckout.tsx"), "utf8");
     expect(index).toContain("without an email address");
     expect(index).not.toContain("type=\"email\"");
+    expect(index).toContain("Explore");
+    expect(index).toContain("Include");
+    expect(index).not.toContain('delivery: "standalone"');
+    expect(index).not.toContain("ShoppingCart");
     expect(familyPage).toContain("data-testid={`delivery-${value}`}");
-    expect(familyPage).toContain('["standalone", "DE owns this solution"]');
-    expect(familyPage).toContain('["co_managed", "Work with your IT team"]');
-    expect(familyPage).toContain("Add to Your Solution");
-    expect(familyPage).toContain("Request a quote");
-    expect(familyPage).toContain("Start an assessment");
-    expect(familyPage).toContain("Schedule a consultation");
+    expect(familyPage).toContain("DE manages this");
+    expect(familyPage).toContain("Work with our IT team");
+    expect(familyPage).toContain("Not sure — help me decide");
+    expect(familyPage).toContain("Continue building");
     expect(familyPage).toContain("Ask DE about this solution");
+    expect(familyPage).not.toContain("Add to Your Solution");
+    expect(familyPage).not.toContain("Request a quote");
+    expect(familyPage).not.toContain("Start an assessment");
+    expect(familyPage).not.toContain("Schedule a consultation");
     expect(familyPage).not.toContain("Pay Now");
     expect(familyPage).not.toContain("computeCoverageScore");
     expect(familyPage).not.toContain("@/contexts/CartContext");
+    expect(requestPage).not.toContain("not a cart");
+    expect(requestPage).not.toContain("CRM handoff");
+    expect(workspace).not.toContain("Continue this solution");
+    expect(workspace).not.toContain("checkout path");
+    expect(workspace).not.toContain("misleading");
+    expect(workspace).toContain("recommendedCtaLabel");
+    expect(workspace).toContain("Recommended next step");
   });
 });

--- a/client/src/pages/store/PublicStoreCheckout.tsx
+++ b/client/src/pages/store/PublicStoreCheckout.tsx
@@ -94,15 +94,15 @@ export default function PublicStoreCheckout() {
       <div className="relative z-10">
         <MegaMenu />
         <main className="de-nav-clear mx-auto max-w-6xl px-4 pb-28 sm:px-6 lg:px-8">
-          <Link href="/store" className="mb-7 inline-flex min-h-11 items-center text-sm text-white/65 hover:text-white">
+          <Link href="/store" className="mb-10 inline-flex min-h-11 items-center text-sm text-white/55 hover:text-white">
             <ArrowLeft className="mr-2 h-4 w-4" />
             Continue browsing
           </Link>
-          <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_22rem]">
+          <div className="grid gap-10 lg:grid-cols-[minmax(0,1fr)_22rem]">
             <section>
-              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-de-accent-ink">Your Solution</p>
-              <h1 className="mt-2 text-4xl font-bold text-white md:text-5xl">Review Your Solution</h1>
-              <p className="mt-3 max-w-2xl text-lg text-white/65">
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-de-accent-ink">Your Solution</p>
+              <h1 className="mt-4 text-[clamp(2.25rem,5vw,3.75rem)] font-bold leading-[1.08] tracking-[-0.035em] text-white">Review Your Solution</h1>
+              <p className="mt-5 max-w-xl text-lg leading-relaxed text-white/65">
                 These business needs will be scoped together. No payment is required. We'll confirm fit, scope, and pricing before you commit.
               </p>
 

--- a/client/src/pages/store/PublicStoreCheckout.tsx
+++ b/client/src/pages/store/PublicStoreCheckout.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link } from "wouter";
-import { ArrowLeft, CheckCircle2, ClipboardCheck, Layers, Trash2 } from "lucide-react";
+import { ArrowLeft, ClipboardCheck, Layers, Trash2 } from "lucide-react";
 import { MegaMenu } from "@/components/MegaMenu";
 import { DigeratiEnhancedFooterSection } from "@/pages/sections/DigeratiEnhancedFooterSection";
 import { StorePageAtmosphere } from "@/components/store/StorePageAtmosphere";
@@ -55,7 +55,7 @@ function deliveryLabel(value: string): string {
   if (value === "co_managed") return "Work with your IT team";
   if (value === "standalone") return "Managed by DE";
   if (value === "unsure") return "Help me decide";
-  return "Choose how DE is involved";
+  return "";
 }
 
 export default function PublicStoreCheckout() {
@@ -120,8 +120,8 @@ export default function PublicStoreCheckout() {
                     type="button"
                     role="tab"
                     aria-selected={draft.deliveryPreference === value}
-                    className={`h-11 rounded-lg px-3 text-sm font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A] ${
-                      draft.deliveryPreference === value ? "bg-[#D3126A] text-white" : "text-white/70 hover:bg-white/5"
+                    className={`h-11 rounded-lg px-3 text-left text-sm font-semibold sm:text-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A] ${
+                      draft.deliveryPreference === value ? "bg-[#D3126A] text-white" : "bg-white/5 text-white/70 hover:bg-white/10"
                     }`}
                     onClick={() => setDraft(patchSolutionDraft({ deliveryPreference: value }))}
                   >
@@ -142,8 +142,10 @@ export default function PublicStoreCheckout() {
                       <article key={item.familyId} className="rounded-2xl border border-white/10 bg-[#121212] p-5 sm:p-6">
                         <div className="flex items-start justify-between gap-4">
                           <div>
-                            <p className="text-xs uppercase tracking-wide text-de-accent-ink">{deliveryLabel(delivery)}</p>
-                            <h2 className="mt-2 text-xl font-semibold text-white">{family.label}</h2>
+                            {deliveryLabel(delivery) ? (
+                              <p className="text-xs uppercase tracking-wide text-de-accent-ink">{deliveryLabel(delivery)}</p>
+                            ) : null}
+                            <h2 className={`text-xl font-semibold text-white ${deliveryLabel(delivery) ? "mt-2" : ""}`}>{family.label}</h2>
                             <p className="mt-2 text-sm leading-relaxed text-white/60">{offer?.summary ?? family.description}</p>
                           </div>
                           <button
@@ -194,7 +196,7 @@ export default function PublicStoreCheckout() {
                             key={value}
                             type="button"
                             className={`h-11 rounded-lg text-sm font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A] ${
-                              draft.environment.deviceOwnership === value ? "bg-[#D3126A] text-white" : "text-white/70 hover:bg-white/5"
+                              draft.environment.deviceOwnership === value ? "bg-[#D3126A] text-white" : "bg-white/5 text-white/70 hover:bg-white/10"
                             }`}
                             onClick={() => setEnv("deviceOwnership", value)}
                           >
@@ -215,7 +217,7 @@ export default function PublicStoreCheckout() {
                             key={value}
                             type="button"
                             className={`h-11 rounded-lg text-sm font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A] ${
-                              draft.environment.internalIt === value ? "bg-[#D3126A] text-white" : "text-white/70 hover:bg-white/5"
+                              draft.environment.internalIt === value ? "bg-[#D3126A] text-white" : "bg-white/5 text-white/70 hover:bg-white/10"
                             }`}
                             onClick={() => setEnv("internalIt", value)}
                           >
@@ -276,10 +278,6 @@ export default function PublicStoreCheckout() {
               >
                 Ask DE
               </Button>
-              <p className="mt-5 flex items-start gap-2 text-sm text-white/55">
-                <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-de-accent-ink" />
-                No payment is required. We'll confirm fit, scope, and pricing before you commit.
-              </p>
               <Link href={BUSINESS_NEEDS_INDEX_PATH} className="mt-4 inline-flex min-h-11 items-center text-sm text-white/55 hover:text-white">
                 Add another business need
               </Link>

--- a/client/src/pages/store/PublicStoreCheckout.tsx
+++ b/client/src/pages/store/PublicStoreCheckout.tsx
@@ -1,52 +1,293 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link } from "wouter";
-import { ArrowLeft, ArrowRight, CheckCircle2, ClipboardCheck, ShieldCheck, Trash2 } from "lucide-react";
+import { ArrowLeft, CheckCircle2, ClipboardCheck, Layers, Trash2 } from "lucide-react";
 import { MegaMenu } from "@/components/MegaMenu";
 import { DigeratiEnhancedFooterSection } from "@/pages/sections/DigeratiEnhancedFooterSection";
 import { StorePageAtmosphere } from "@/components/store/StorePageAtmosphere";
 import { Button } from "@/components/ui/button";
-import { getFamilyById, offerForDelivery, requestPath } from "@/lib/businessNeeds";
-import { readSolutionCart, removeSolutionCartItem, SOLUTION_CART_EVENT, type PublicSolutionCartItem } from "@/lib/publicSolutionCart";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  BUSINESS_NEEDS_INDEX_PATH,
+  getFamilyById,
+  offerForDelivery,
+  requestPath,
+} from "@/lib/businessNeeds";
+import { openMspAdvisor } from "@/lib/openMspAdvisor";
+import {
+  emptyDraft,
+  patchEnvironment,
+  patchSolutionDraft,
+  readSolutionDraft,
+  recommendedCtaLabel,
+  recommendedIntent,
+  removeDraftNeed,
+  resolvedNeedDelivery,
+  SOLUTION_DRAFT_EVENT,
+  writeSolutionDraft,
+  type DeliveryPreference,
+  type DeviceOwnership,
+  type InternalItStatus,
+  type SolutionDraft,
+  type SolutionEnvironment,
+} from "@/lib/solutionDraft";
 import { useSEO } from "@/hooks/useSEO";
 
+const DELIVERY_OPTIONS: Array<[DeliveryPreference, string]> = [
+  ["standalone", "DE manages this"],
+  ["co_managed", "Work with our IT team"],
+  ["unsure", "Not sure — help me decide"],
+];
+
+const OWNERSHIP_OPTIONS: Array<[Exclude<DeviceOwnership, "">, string]> = [
+  ["company", "Company-owned"],
+  ["byod", "BYOD"],
+  ["hybrid", "Hybrid"],
+];
+
+const INTERNAL_IT_OPTIONS: Array<[Exclude<InternalItStatus, "">, string]> = [
+  ["yes", "Yes"],
+  ["no", "No"],
+  ["unsure", "Not sure"],
+];
+
+function deliveryLabel(value: string): string {
+  if (value === "co_managed") return "Work with your IT team";
+  if (value === "standalone") return "Managed by DE";
+  if (value === "unsure") return "Help me decide";
+  return "Choose how DE is involved";
+}
+
 export default function PublicStoreCheckout() {
-  const [items, setItems] = useState<PublicSolutionCartItem[]>([]);
-  useSEO({ title: "Review Your Solution | Digerati Experts", description: "Review curated Digerati Experts solutions and continue to the correct quote, assessment, or checkout path.", canonical: "/store/checkout", noIndex: true });
+  const [draft, setDraft] = useState<SolutionDraft>(emptyDraft);
+  useSEO({
+    title: "Your Solution | Digerati Experts",
+    description: "Review the Digerati Experts solution you are building and continue to the recommended next step.",
+    canonical: "/store/solution",
+    noIndex: true,
+  });
 
   useEffect(() => {
-    const refresh = () => setItems(readSolutionCart());
+    const refresh = () => setDraft(readSolutionDraft());
     refresh();
-    window.addEventListener(SOLUTION_CART_EVENT, refresh);
-    return () => window.removeEventListener(SOLUTION_CART_EVENT, refresh);
+    window.addEventListener(SOLUTION_DRAFT_EVENT, refresh);
+    return () => window.removeEventListener(SOLUTION_DRAFT_EVENT, refresh);
   }, []);
 
-  const rows = useMemo(() => items.flatMap((item) => {
-    const family = getFamilyById(item.familyId);
-    return family ? [{ item, family, offer: offerForDelivery(family, item.delivery) }] : [];
-  }), [items]);
+  const rows = useMemo(
+    () =>
+      draft.needs.flatMap((item) => {
+        const family = getFamilyById(item.familyId);
+        return family ? [{ item, family }] : [];
+      }),
+    [draft.needs],
+  );
 
-  return <div className="relative min-h-screen overflow-hidden bg-[#0a0a0a]">
-    <StorePageAtmosphere />
-    <div className="relative z-10"><MegaMenu />
-      <main className="de-nav-clear mx-auto max-w-6xl px-4 pb-28 sm:px-6 lg:px-8">
-        <Link href="/store" className="mb-7 inline-flex min-h-11 items-center text-sm text-white/65 hover:text-white"><ArrowLeft className="mr-2 h-4 w-4" />Continue browsing</Link>
-        <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_22rem]">
-          <section>
-            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-de-accent-ink">Your Solution</p>
-            <h1 className="mt-2 text-4xl font-bold text-white md:text-5xl">Review and continue</h1>
-            <p className="mt-3 max-w-2xl text-lg text-white/65">This checkout keeps the useful cart and review flow without exposing DE’s private vendor catalog.</p>
-            <div className="mt-8 space-y-4">
-              {rows.length ? rows.map(({ item, family, offer }) => <article key={item.familyId} className="rounded-2xl border border-white/10 bg-[#121212] p-5 sm:p-6">
-                <div className="flex items-start justify-between gap-4"><div><p className="text-xs uppercase tracking-wide text-de-accent-ink">{item.delivery === "co_managed" ? "Works with internal IT" : "Managed by DE"}</p><h2 className="mt-2 text-xl font-semibold text-white">{family.label}</h2><p className="mt-2 text-sm leading-relaxed text-white/60">{offer.summary}</p></div><button type="button" onClick={() => removeSolutionCartItem(item.familyId)} className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg text-white/45 hover:bg-white/5 hover:text-white" aria-label={`Remove ${family.label}`}><Trash2 className="h-4 w-4" /></button></div>
-                <Button asChild variant="outline" className="mt-5 h-11 border-de-accent/35 text-de-accent-ink hover:bg-de-accent/10"><Link href={requestPath({ family: family.id, delivery: item.delivery, intent: "request" })}>Continue this solution<ArrowRight className="ml-2 h-4 w-4" /></Link></Button>
-              </article>) : <div className="rounded-2xl border border-dashed border-white/15 bg-[#121212] px-6 py-14 text-center"><ClipboardCheck className="mx-auto h-8 w-8 text-white/30" /><h2 className="mt-4 text-xl font-semibold text-white">Your Solution is empty</h2><Button asChild className="mt-5 bg-de-accent text-white"><Link href="/store">Browse solutions</Link></Button></div>}
-            </div>
-          </section>
-          <aside className="h-fit rounded-2xl border border-white/10 bg-[#121212] p-6 lg:sticky lg:top-28">
-            <ShieldCheck className="h-8 w-8 text-de-accent-ink" /><h2 className="mt-4 text-xl font-semibold text-white">The correct checkout path</h2><p className="mt-2 text-sm leading-relaxed text-white/55">Managed, security, and compliance work stays quote or assessment-first. Approved fixed-price products can use payment checkout when DE publishes them.</p>
-            <ul className="mt-5 space-y-3 text-sm text-white/65">{["No public vendor or SKU exposure", "No misleading $0 pricing", "No Pay Now before eligibility is confirmed"].map((text) => <li key={text} className="flex gap-2"><CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-de-accent-ink" />{text}</li>)}</ul>
-          </aside>
-        </div>
-      </main><DigeratiEnhancedFooterSection /></div>
-  </div>;
+  const intent = recommendedIntent(draft);
+  const setEnv = <K extends keyof SolutionEnvironment>(key: K, value: SolutionEnvironment[K]) => {
+    setDraft(writeSolutionDraft(patchEnvironment(readSolutionDraft(), { [key]: value })));
+  };
+
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-[#0a0a0a]">
+      <StorePageAtmosphere />
+      <div className="relative z-10">
+        <MegaMenu />
+        <main className="de-nav-clear mx-auto max-w-6xl px-4 pb-28 sm:px-6 lg:px-8">
+          <Link href="/store" className="mb-7 inline-flex min-h-11 items-center text-sm text-white/65 hover:text-white">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Continue browsing
+          </Link>
+          <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_22rem]">
+            <section>
+              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-de-accent-ink">Your Solution</p>
+              <h1 className="mt-2 text-4xl font-bold text-white md:text-5xl">Review Your Solution</h1>
+              <p className="mt-3 max-w-2xl text-lg text-white/65">
+                These business needs will be scoped together. No payment is required. We'll confirm fit, scope, and pricing before you commit.
+              </p>
+
+              <h2 className="mt-8 mb-3 text-sm font-semibold uppercase tracking-wide text-white/55">
+                What fits your organization?
+              </h2>
+              <div
+                className="mb-8 grid grid-cols-1 gap-2 rounded-xl border border-white/10 bg-[#121212] p-2 sm:grid-cols-3"
+                role="tablist"
+                aria-label="What fits your organization?"
+              >
+                {DELIVERY_OPTIONS.map(([value, label]) => (
+                  <button
+                    key={value}
+                    type="button"
+                    role="tab"
+                    aria-selected={draft.deliveryPreference === value}
+                    className={`h-11 rounded-lg px-3 text-sm font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A] ${
+                      draft.deliveryPreference === value ? "bg-[#D3126A] text-white" : "text-white/70 hover:bg-white/5"
+                    }`}
+                    onClick={() => setDraft(patchSolutionDraft({ deliveryPreference: value }))}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+
+              <div className="space-y-4">
+                {rows.length ? (
+                  rows.map(({ item, family }) => {
+                    const delivery = resolvedNeedDelivery(item, draft.deliveryPreference);
+                    const offer =
+                      delivery === "co_managed" || delivery === "standalone"
+                        ? offerForDelivery(family, delivery)
+                        : null;
+                    return (
+                      <article key={item.familyId} className="rounded-2xl border border-white/10 bg-[#121212] p-5 sm:p-6">
+                        <div className="flex items-start justify-between gap-4">
+                          <div>
+                            <p className="text-xs uppercase tracking-wide text-de-accent-ink">{deliveryLabel(delivery)}</p>
+                            <h2 className="mt-2 text-xl font-semibold text-white">{family.label}</h2>
+                            <p className="mt-2 text-sm leading-relaxed text-white/60">{offer?.summary ?? family.description}</p>
+                          </div>
+                          <button
+                            type="button"
+                            onClick={() => removeDraftNeed(item.familyId)}
+                            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg text-white/45 hover:bg-white/5 hover:text-white"
+                            aria-label={`Remove ${family.label}`}
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </button>
+                        </div>
+                      </article>
+                    );
+                  })
+                ) : (
+                  <div className="rounded-2xl border border-dashed border-white/15 bg-[#121212] px-6 py-14 text-center">
+                    <ClipboardCheck className="mx-auto h-8 w-8 text-white/30" />
+                    <h2 className="mt-4 text-xl font-semibold text-white">Your Solution is empty</h2>
+                    <Button asChild className="mt-5 bg-de-accent text-white">
+                      <Link href="/store">Browse solutions</Link>
+                    </Button>
+                  </div>
+                )}
+              </div>
+
+              {rows.length > 0 && (
+                <section className="mt-8 rounded-2xl border border-white/10 bg-[#121212] p-5 sm:p-6" aria-labelledby="environment-heading">
+                  <h2 id="environment-heading" className="text-xl font-semibold text-white">
+                    Tell us about your environment
+                  </h2>
+                  <p className="mt-2 text-sm text-white/55">
+                    These facts help DE scope the work. You can leave anything blank if you are not sure.
+                  </p>
+                  <div className="mt-6 grid gap-5 sm:grid-cols-2">
+                    <div className="space-y-2">
+                      <Label htmlFor="sol-users" className="text-white/80">How many users?</Label>
+                      <Input id="sol-users" inputMode="numeric" value={draft.environment.userCount} onChange={(event) => setEnv("userCount", event.target.value)} className="h-11 border-white/15 bg-[#121212] text-white" />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="sol-sites" className="text-white/80">How many sites?</Label>
+                      <Input id="sol-sites" inputMode="numeric" value={draft.environment.siteCount} onChange={(event) => setEnv("siteCount", event.target.value)} className="h-11 border-white/15 bg-[#121212] text-white" />
+                    </div>
+                    <div className="space-y-2 sm:col-span-2">
+                      <p className="text-sm text-white/80">Company-owned, BYOD, or hybrid devices?</p>
+                      <div className="grid grid-cols-3 gap-2 rounded-xl border border-white/10 p-2">
+                        {OWNERSHIP_OPTIONS.map(([value, label]) => (
+                          <button
+                            key={value}
+                            type="button"
+                            className={`h-11 rounded-lg text-sm font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A] ${
+                              draft.environment.deviceOwnership === value ? "bg-[#D3126A] text-white" : "text-white/70 hover:bg-white/5"
+                            }`}
+                            onClick={() => setEnv("deviceOwnership", value)}
+                          >
+                            {label}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                    <div className="space-y-2 sm:col-span-2">
+                      <Label htmlFor="sol-mix" className="text-white/80">Laptop / desktop / mobile mix</Label>
+                      <Input id="sol-mix" value={draft.environment.deviceMix} onChange={(event) => setEnv("deviceMix", event.target.value)} className="h-11 border-white/15 bg-[#121212] text-white" placeholder="e.g. mostly laptops, some phones" />
+                    </div>
+                    <div className="space-y-2 sm:col-span-2">
+                      <p className="text-sm text-white/80">Any internal IT?</p>
+                      <div className="grid grid-cols-3 gap-2 rounded-xl border border-white/10 p-2">
+                        {INTERNAL_IT_OPTIONS.map(([value, label]) => (
+                          <button
+                            key={value}
+                            type="button"
+                            className={`h-11 rounded-lg text-sm font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#D3126A] ${
+                              draft.environment.internalIt === value ? "bg-[#D3126A] text-white" : "text-white/70 hover:bg-white/5"
+                            }`}
+                            onClick={() => setEnv("internalIt", value)}
+                          >
+                            {label}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="sol-compliance" className="text-white/80">Compliance requirements</Label>
+                      <Input id="sol-compliance" value={draft.environment.complianceNeeds} onChange={(event) => setEnv("complianceNeeds", event.target.value)} className="h-11 border-white/15 bg-[#121212] text-white" />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="sol-provider" className="text-white/80">Current provider</Label>
+                      <Input id="sol-provider" value={draft.environment.currentProvider} onChange={(event) => setEnv("currentProvider", event.target.value)} className="h-11 border-white/15 bg-[#121212] text-white" />
+                    </div>
+                    <div className="space-y-2 sm:col-span-2">
+                      <Label htmlFor="sol-urgency" className="text-white/80">Urgency / problem severity</Label>
+                      <Input id="sol-urgency" value={draft.environment.urgency} onChange={(event) => setEnv("urgency", event.target.value)} className="h-11 border-white/15 bg-[#121212] text-white" />
+                    </div>
+                  </div>
+                </section>
+              )}
+            </section>
+            <aside className="h-fit rounded-2xl border border-white/10 bg-[#121212] p-6 lg:sticky lg:top-28">
+              <Layers className="h-8 w-8 text-de-accent-ink" />
+              <h2 className="mt-4 text-xl font-semibold text-white">Recommended next step</h2>
+              <p className="mt-2 text-sm leading-relaxed text-white/55">
+                {rows.length
+                  ? "After we review this solution together, the next step is a Cyber Risk Assessment so scope and pricing stay honest."
+                  : "Add at least one business need to continue."}
+              </p>
+              {rows.length ? (
+                <Button asChild className="mt-5 h-11 w-full bg-[#D3126A] text-white hover:bg-[#b90f5d]">
+                  <Link
+                    href={requestPath({ intent })}
+                    onClick={() => patchSolutionDraft({ intent })}
+                    data-testid="recommended-next-step"
+                  >
+                    {recommendedCtaLabel(intent)}
+                  </Link>
+                </Button>
+              ) : (
+                <Button className="mt-5 h-11 w-full" disabled>
+                  {recommendedCtaLabel(intent)}
+                </Button>
+              )}
+              <Button
+                type="button"
+                variant="outline"
+                className="mt-3 h-11 w-full border-white/20 text-white hover:bg-white/10"
+                onClick={() =>
+                  openMspAdvisor({
+                    context: "other",
+                    seedMessage: "I am building a Digerati Experts solution and want to ask about fit, scope, and next steps.",
+                  })
+                }
+              >
+                Ask DE
+              </Button>
+              <p className="mt-5 flex items-start gap-2 text-sm text-white/55">
+                <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-de-accent-ink" />
+                No payment is required. We'll confirm fit, scope, and pricing before you commit.
+              </p>
+              <Link href={BUSINESS_NEEDS_INDEX_PATH} className="mt-4 inline-flex min-h-11 items-center text-sm text-white/55 hover:text-white">
+                Add another business need
+              </Link>
+            </aside>
+          </div>
+        </main>
+        <DigeratiEnhancedFooterSection />
+      </div>
+    </div>
+  );
 }

--- a/docs/PUBLIC-SOLUTION-BUILDER.md
+++ b/docs/PUBLIC-SOLUTION-BUILDER.md
@@ -1,0 +1,34 @@
+# Public Solution Builder (Door 2)
+
+Public `/store` is a **Business Solution Builder**, not a storefront cart.
+
+```text
+PUBLIC
+Business Solution Builder
+No vendor catalog
+No real shopping cart
+No Pay Now
+        ↓ qualified handoff
+CLIENT MARKETPLACE
+Authenticated cart / checkout
+        ↓ internal mappings
+DE DIGITAL WAREHOUSE
+Staff only
+```
+
+## Buyer journey
+
+1. What are you trying to improve? Pick one or several business needs (13 canonical families, with an optional 5-goal entry layer).
+2. How should DE be involved? DE managed / work with internal IT / help me decide.
+3. Environment facts: users, sites, device ownership, mix, internal IT, compliance, current provider, urgency.
+4. Your Solution: one composed draft.
+5. One recommended next step (today: Cyber Risk Assessment). Ask DE remains available.
+
+## Persistence
+
+- Browser: `de-solution-draft-v1` (`client/src/lib/solutionDraft.ts`)
+- Server: `/api/public/solutions/request` accepts `selectedNeeds[]` + `environment` as **one** request / one CRM opportunity
+- `/store/checkout` is an alias of `/store/solution` so old links do not reopen a grocery checkout
+
+Do not put vendor names, SKUs, costs, margins, or CRM-implementation commentary on these pages.
+Customer language is: **No payment is required. We'll confirm fit, scope, and pricing before you commit.**

--- a/docs/STORE-SOLUTION-ENGINE.md
+++ b/docs/STORE-SOLUTION-ENGINE.md
@@ -2,6 +2,10 @@
 
 **Decision:** The DE Solution is the canonical commerce object. Zoho Payments remains the money path. Portal auth remains the identity path. Stripe, Typesense, Redis, and a second customer identity system are **not** introduced in this slice.
 
+Public Door 2 is **not** this engine. Prospects use a Solution Draft / Solution Builder (`docs/PUBLIC-SOLUTION-BUILDER.md`) with no cart, no checkout, and no Pay Now. Real cart/checkout belongs to the authenticated Client Marketplace and the staff warehouse.
+
+## Why this exists
+
 ## Why this exists
 
 The storefront already had a client-side “Your Solution” cart (`localStorage`) plus Zoho checkout. That cart died across devices and was not recalculated server-side except at payment time.

--- a/docs/STORE-WAREHOUSE.md
+++ b/docs/STORE-WAREHOUSE.md
@@ -11,7 +11,7 @@ The former public `/store` workshop (SKU catalog, vendor marks, coverage heurist
 | Surface | Route | Auth |
 | --- | --- | --- |
 | Warehouse | `/internal/warehouse` and product/checkout subroutes | Live `admin` at route **and** catalog API |
-| Public curated Store | `/store`, `/store/solutions/:family`, `/store/checkout` | Public-safe DE solution data only |
+| Public curated Store | `/store`, `/store/solutions/:family`, `/store/solution` (`/store/checkout` alias) | Public Solution Builder — no vendor catalog, no Pay Now |
 | Legacy catalog paths | `/store/managed`, `/store/co-managed` | 301 to the appropriate public solution path |
 | Staff-only SKU URLs | `/store/product/:sku` except four ProActive models | Generic 404 — same body as unknown, no `Location` |
 | Client Marketplace | `/portal/marketplace` | Authenticated client; fail-safe Request Approval (no Hub catalog) |

--- a/scripts/door2-browser-smoke.mjs
+++ b/scripts/door2-browser-smoke.mjs
@@ -25,25 +25,32 @@ for (const viewport of viewports) {
   const emailInputs = await page.locator("main input[type='email']").count();
   const payNow = await page.getByText("Pay Now", { exact: false }).count();
   const obsoleteCardBadges = await page.getByText("Curated DE solution", { exact: true }).count();
+  const addButtons = await page.getByRole("button", { name: "Add", exact: true }).count();
   const indexOverflow = await hasHorizontalOverflow(page);
 
-  // Exercise the actual public cart/drawer and verify the sitewide bottom dock
-  // participates in the same shared overlay lock as the legacy Store drawers.
-  await page.locator("[data-testid='family-card-identity_access']").getByRole("button", { name: "Add" }).click();
+  await page.locator("[data-testid='family-card-identity_access']").getByRole("button", { name: "Include" }).click();
   await page.locator("[data-testid='public-solution-cart']").click();
   const dockHiddenWhileCartOpen = await page.evaluate(() => document.documentElement.dataset.dockHidden === "true");
   await page.keyboard.press("Escape");
   await page.screenshot({ path: `${outDir}/index-${viewport.name}.png`, fullPage: true });
 
-  await page.locator("[data-testid='family-card-identity_access']").getByRole("link", { name: /Identity|Details/i }).first().click();
+  await page.locator("[data-testid='family-card-identity_access']").getByRole("link", { name: /Identity|Explore/i }).first().click();
   await page.waitForSelector("[data-testid='heading-family']");
   const heading = await page.locator("[data-testid='heading-family']").innerText();
   await page.locator("[data-testid='delivery-co_managed']").click();
   const offer = await page.locator("[data-testid='offer-panel']").innerText();
+  const competingCtas = await page.getByRole("link", { name: /Request a quote|Start an assessment|Schedule a consultation/i }).count();
+  await page.locator("[data-testid='continue-building']").click();
   const familyOverflow = await hasHorizontalOverflow(page);
   await page.screenshot({ path: `${outDir}/family-${viewport.name}.png`, fullPage: true });
 
-  await page.getByRole("link", { name: "Request a quote" }).click();
+  await page.locator("[data-testid='public-solution-cart']").click();
+  await page.getByRole("link", { name: "Review Your Solution" }).click();
+  await page.waitForSelector("h1");
+  const workspaceOverflow = await hasHorizontalOverflow(page);
+  await page.screenshot({ path: `${outDir}/workspace-${viewport.name}.png`, fullPage: true });
+
+  await page.locator("[data-testid='recommended-next-step']").click();
   await page.waitForSelector("[data-testid='heading-solution-request']");
   const requestOverflow = await hasHorizontalOverflow(page);
   await page.screenshot({ path: `${outDir}/request-${viewport.name}.png`, fullPage: true });
@@ -58,13 +65,16 @@ for (const viewport of viewports) {
     emailInputs,
     payNow,
     obsoleteCardBadges,
+    addButtons,
     dockHiddenWhileCartOpen,
     heading,
     offerHasCoManaged: /co-managed/i.test(offer),
+    competingCtas,
     notFound,
     overflow: {
       index: indexOverflow,
       family: familyOverflow,
+      workspace: workspaceOverflow,
       request: requestOverflow,
       notFound: notFoundOverflow,
     },
@@ -80,6 +90,8 @@ const failed = results.some((row) =>
   row.emailInputs > 0 ||
   row.payNow > 0 ||
   row.obsoleteCardBadges > 0 ||
+  row.addButtons > 0 ||
+  row.competingCtas > 0 ||
   !row.dockHiddenWhileCartOpen ||
   row.notFound < 1 ||
   Object.values(row.overflow).some(Boolean),

--- a/server/middleware/security.ts
+++ b/server/middleware/security.ts
@@ -387,6 +387,7 @@ export function setSecurityHeaders(req: Request, res: Response, next: NextFuncti
     p === "/login" ||
     p === "/signup" ||
     p.startsWith("/store/checkout") ||
+    p.startsWith("/store/solution") ||
     p.startsWith("/store/cart") ||
     p.startsWith("/store/order-confirmation") ||
     p.startsWith("/store/quote-confirmation") ||

--- a/server/publicSolutionRequestCrm.ts
+++ b/server/publicSolutionRequestCrm.ts
@@ -10,17 +10,49 @@ function splitName(fullName: string): { first: string; last: string } {
   return { first: parts[0], last: parts.slice(1).join(" ") };
 }
 
+function deliveryLabel(value: string): string {
+  if (value === "co_managed") return "Work with internal IT";
+  if (value === "standalone") return "DE managed";
+  if (value === "unsure") return "Help me decide";
+  return value;
+}
+
 export function buildPublicSolutionRequestDescription(record: PublicSolutionRequest): string {
-  const family = record.familyId
-    ? curatedSolutionFamilies.find((entry) => entry.id === record.familyId)
-    : null;
-  const offer = family?.offers.find((item) => item.id === record.offerId);
+  const needs = record.selectedNeeds.length
+    ? record.selectedNeeds
+    : record.familyId
+      ? [
+          {
+            familyId: record.familyId,
+            offerId: record.offerId,
+            deliveryModel: record.deliveryModel,
+          },
+        ]
+      : [];
+  const needLines = needs.flatMap((need) => {
+    const family = curatedSolutionFamilies.find((entry) => entry.id === need.familyId);
+    const offer =
+      need.offerId && family ? family.offers.find((item) => item.id === need.offerId) : null;
+    return [
+      family ? `- ${family.label} (${deliveryLabel(need.deliveryModel)})` : "",
+      offer ? `  Offer: ${offer.name}` : "",
+    ];
+  });
+  const env = record.environment;
   return [
     `Solution Request ${record.correlationId}`,
     `Intent: ${record.intent}`,
-    family ? `Family: ${family.label}` : "",
-    offer ? `Offer: ${offer.name}` : "",
-    `Delivery: ${record.deliveryModel === "co_managed" ? "Co-managed" : "Standalone"}`,
+    record.deliveryPreference ? `Delivery preference: ${deliveryLabel(record.deliveryPreference)}` : "",
+    needs.length ? "Selected needs:" : "",
+    ...needLines,
+    env.userCount ? `Users: ${env.userCount}` : "",
+    env.siteCount ? `Sites: ${env.siteCount}` : "",
+    env.deviceOwnership ? `Device ownership: ${env.deviceOwnership}` : "",
+    env.deviceMix ? `Device mix: ${env.deviceMix}` : "",
+    env.internalIt ? `Internal IT: ${env.internalIt}` : "",
+    env.complianceNeeds ? `Compliance: ${env.complianceNeeds}` : "",
+    env.currentProvider ? `Current provider: ${env.currentProvider}` : "",
+    env.urgency ? `Urgency: ${env.urgency}` : "",
     record.organizationName ? `Organization: ${record.organizationName}` : "",
     record.notes ? `Notes: ${record.notes.slice(0, 500)}` : "",
   ]

--- a/server/publicSolutionRequestStore.ts
+++ b/server/publicSolutionRequestStore.ts
@@ -1,11 +1,26 @@
 import { randomUUID } from "crypto";
-import {
-  curatedSolutionFamilies,
-  type CuratedDeliveryModel,
-} from "../client/src/data/curatedSolutions";
+import { curatedSolutionFamilies, type CuratedDeliveryModel } from "../client/src/data/curatedSolutions";
 
 export type SolutionRequestIntent = "request" | "quote" | "assessment" | "consultation";
 export type SolutionRequestStatus = "draft" | "submitted";
+export type DeliveryPreference = CuratedDeliveryModel | "unsure";
+
+export type PublicSolutionNeed = {
+  familyId: string;
+  offerId: string | null;
+  deliveryModel: DeliveryPreference;
+};
+
+export type PublicSolutionEnvironment = {
+  userCount: string;
+  siteCount: string;
+  deviceOwnership: string;
+  deviceMix: string;
+  internalIt: string;
+  complianceNeeds: string;
+  currentProvider: string;
+  urgency: string;
+};
 
 export type PublicSolutionRequest = {
   id: string;
@@ -13,7 +28,10 @@ export type PublicSolutionRequest = {
   correlationId: string;
   familyId: string | null;
   offerId: string | null;
-  deliveryModel: CuratedDeliveryModel;
+  deliveryModel: DeliveryPreference;
+  deliveryPreference: DeliveryPreference | "";
+  selectedNeeds: PublicSolutionNeed[];
+  environment: PublicSolutionEnvironment;
   intent: SolutionRequestIntent;
   organizationName: string;
   contactName: string;
@@ -34,9 +52,26 @@ export function publicFamilyExists(familyId: string): boolean {
   return curatedSolutionFamilies.some((family) => family.id === familyId);
 }
 
-export function publicOfferInFamily(familyId: string, offerId: string, delivery: CuratedDeliveryModel): boolean {
+export function publicOfferInFamily(
+  familyId: string,
+  offerId: string,
+  delivery: CuratedDeliveryModel,
+): boolean {
   const family = curatedSolutionFamilies.find((entry) => entry.id === familyId);
   return !!family?.offers.some((offer) => offer.id === offerId && offer.deliveryModel === delivery);
+}
+
+function emptyEnvironment(): PublicSolutionEnvironment {
+  return {
+    userCount: "",
+    siteCount: "",
+    deviceOwnership: "",
+    deviceMix: "",
+    internalIt: "",
+    complianceNeeds: "",
+    currentProvider: "",
+    urgency: "",
+  };
 }
 
 function expireDrafts() {
@@ -56,7 +91,10 @@ export function createPublicSolutionRequest(sessionId: string): PublicSolutionRe
     correlationId: randomUUID(),
     familyId: null,
     offerId: null,
-    deliveryModel: "standalone",
+    deliveryModel: "unsure",
+    deliveryPreference: "",
+    selectedNeeds: [],
+    environment: emptyEnvironment(),
     intent: "request",
     organizationName: "",
     contactName: "",
@@ -69,7 +107,7 @@ export function createPublicSolutionRequest(sessionId: string): PublicSolutionRe
     updatedAt: now,
   };
   records.set(record.id, record);
-  return { ...record };
+  return { ...record, selectedNeeds: [...record.selectedNeeds], environment: { ...record.environment } };
 }
 
 export function findPublicSolutionRequest(sessionId: string): PublicSolutionRequest | undefined {
@@ -77,12 +115,20 @@ export function findPublicSolutionRequest(sessionId: string): PublicSolutionRequ
   const matches = [...records.values()]
     .filter((record) => record.sessionId === sessionId)
     .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
-  return matches[0] ? { ...matches[0] } : undefined;
+  return matches[0] ? cloneRequest(matches[0]) : undefined;
 }
 
 export function getPublicSolutionRequest(id: string): PublicSolutionRequest | undefined {
   const record = records.get(id);
-  return record ? { ...record } : undefined;
+  return record ? cloneRequest(record) : undefined;
+}
+
+function cloneRequest(record: PublicSolutionRequest): PublicSolutionRequest {
+  return {
+    ...record,
+    selectedNeeds: record.selectedNeeds.map((need) => ({ ...need })),
+    environment: { ...record.environment },
+  };
 }
 
 function asIntent(value: unknown): SolutionRequestIntent {
@@ -92,12 +138,77 @@ function asIntent(value: unknown): SolutionRequestIntent {
   return "request";
 }
 
-function asDelivery(value: unknown): CuratedDeliveryModel {
-  return value === "co_managed" ? "co_managed" : "standalone";
+function asDelivery(value: unknown): DeliveryPreference | "" {
+  if (value === "co_managed" || value === "standalone" || value === "unsure") return value;
+  return "";
 }
 
 function clip(value: unknown, max: number): string {
   return typeof value === "string" ? value.trim().slice(0, max) : "";
+}
+
+function parseEnvironment(value: unknown, fallback: PublicSolutionEnvironment): PublicSolutionEnvironment {
+  const input = value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+  return {
+    userCount: clip(input.userCount ?? fallback.userCount, 12),
+    siteCount: clip(input.siteCount ?? fallback.siteCount, 12),
+    deviceOwnership: clip(input.deviceOwnership ?? fallback.deviceOwnership, 24),
+    deviceMix: clip(input.deviceMix ?? fallback.deviceMix, 200),
+    internalIt: clip(input.internalIt ?? fallback.internalIt, 24),
+    complianceNeeds: clip(input.complianceNeeds ?? fallback.complianceNeeds, 400),
+    currentProvider: clip(input.currentProvider ?? fallback.currentProvider, 200),
+    urgency: clip(input.urgency ?? fallback.urgency, 200),
+  };
+}
+
+function parseNeed(value: unknown): PublicSolutionNeed | null {
+  if (!value || typeof value !== "object") return null;
+  const input = value as Record<string, unknown>;
+  const familyId = clip(input.familyId, 80);
+  if (!publicFamilyExists(familyId)) return null;
+  const delivery = asDelivery(input.deliveryModel) || "unsure";
+  const offerId = clip(input.offerId, 80);
+  const offerOk =
+    offerId && (delivery === "standalone" || delivery === "co_managed")
+      ? publicOfferInFamily(familyId, offerId, delivery)
+      : false;
+  return {
+    familyId,
+    offerId: offerOk ? offerId : null,
+    deliveryModel: delivery || "unsure",
+  };
+}
+
+function parseSelectedNeeds(value: unknown, fallback: PublicSolutionNeed[]): PublicSolutionNeed[] {
+  if (!Array.isArray(value)) return fallback.map((need) => ({ ...need }));
+  const seen = new Set<string>();
+  const needs: PublicSolutionNeed[] = [];
+  for (const entry of value.slice(0, 13)) {
+    const need = parseNeed(entry);
+    if (!need || seen.has(need.familyId)) continue;
+    seen.add(need.familyId);
+    needs.push(need);
+  }
+  return needs;
+}
+
+function synthesizeNeed(
+  familyId: string | null,
+  offerId: string | null,
+  deliveryModel: DeliveryPreference,
+): PublicSolutionNeed[] {
+  if (!familyId || !publicFamilyExists(familyId)) return [];
+  const offerOk =
+    offerId && (deliveryModel === "standalone" || deliveryModel === "co_managed")
+      ? publicOfferInFamily(familyId, offerId, deliveryModel)
+      : false;
+  return [
+    {
+      familyId,
+      offerId: offerOk ? offerId : null,
+      deliveryModel,
+    },
+  ];
 }
 
 export function upsertPublicSolutionRequest(input: {
@@ -106,6 +217,9 @@ export function upsertPublicSolutionRequest(input: {
   familyId?: string | null;
   offerId?: string | null;
   deliveryModel?: unknown;
+  deliveryPreference?: unknown;
+  selectedNeeds?: unknown;
+  environment?: unknown;
   intent?: unknown;
   organizationName?: unknown;
   contactName?: unknown;
@@ -118,16 +232,34 @@ export function upsertPublicSolutionRequest(input: {
     (input.id ? records.get(input.id) : undefined) ??
     [...records.values()].find((record) => record.sessionId === input.sessionId && record.status === "draft");
   const base = existing ?? createPublicSolutionRequest(input.sessionId);
-  const familyId = clip(input.familyId, 80) || base.familyId;
-  const deliveryModel = asDelivery(input.deliveryModel ?? base.deliveryModel);
-  const offerId = clip(input.offerId, 80) || base.offerId;
+  const deliveryPreference =
+    asDelivery(input.deliveryPreference) || asDelivery(input.deliveryModel) || base.deliveryPreference;
+  const selectedNeeds = parseSelectedNeeds(input.selectedNeeds, base.selectedNeeds);
+  const familyId = clip(input.familyId, 80) || selectedNeeds[0]?.familyId || base.familyId;
+  const deliveryModel =
+    asDelivery(input.deliveryModel) ||
+    selectedNeeds[0]?.deliveryModel ||
+    deliveryPreference ||
+    base.deliveryModel ||
+    "unsure";
+  const offerId = clip(input.offerId, 80) || selectedNeeds[0]?.offerId || base.offerId;
+  const nextNeeds =
+    selectedNeeds.length > 0
+      ? selectedNeeds
+      : synthesizeNeed(
+          familyId && publicFamilyExists(familyId) ? familyId : null,
+          offerId,
+          deliveryModel || "unsure",
+        );
   const next: PublicSolutionRequest = {
     ...base,
     sessionId: input.sessionId,
-    familyId: familyId && publicFamilyExists(familyId) ? familyId : null,
-    offerId:
-      familyId && offerId && publicOfferInFamily(familyId, offerId, deliveryModel) ? offerId : null,
-    deliveryModel,
+    familyId: nextNeeds[0]?.familyId ?? null,
+    offerId: nextNeeds[0]?.offerId ?? null,
+    deliveryModel: nextNeeds[0]?.deliveryModel || deliveryModel || "unsure",
+    deliveryPreference,
+    selectedNeeds: nextNeeds,
+    environment: parseEnvironment(input.environment, base.environment),
     intent: asIntent(input.intent ?? base.intent),
     organizationName: clip(input.organizationName ?? base.organizationName, 200),
     contactName: clip(input.contactName ?? base.contactName, 120),
@@ -137,7 +269,7 @@ export function upsertPublicSolutionRequest(input: {
     updatedAt: new Date().toISOString(),
   };
   records.set(next.id, next);
-  return { ...next };
+  return cloneRequest(next);
 }
 
 export function submitPublicSolutionRequest(
@@ -145,13 +277,17 @@ export function submitPublicSolutionRequest(
   contact: { name: string; email: string; phone?: string; organizationName?: string },
   idempotencyKey?: string,
 ): { record: PublicSolutionRequest; replayed: boolean } {
+  const composedKey = record.selectedNeeds
+    .map((need) => need.familyId)
+    .sort()
+    .join(",");
   const key =
-    idempotencyKey?.trim().slice(0, 120) ||
-    `${contact.email.trim().toLowerCase()}|${record.familyId || ""}|${record.offerId || ""}|${record.deliveryModel}|${record.intent}`;
+    idempotencyKey?.trim().slice(0, 200) ||
+    `${contact.email.trim().toLowerCase()}|${composedKey || record.familyId || ""}|${record.deliveryPreference || record.deliveryModel}|${record.intent}`;
   const existingId = idempotency.get(key);
   if (existingId) {
     const prior = records.get(existingId);
-    if (prior) return { record: { ...prior }, replayed: true };
+    if (prior) return { record: cloneRequest(prior), replayed: true };
   }
 
   const submitted: PublicSolutionRequest = {
@@ -166,7 +302,7 @@ export function submitPublicSolutionRequest(
   };
   records.set(submitted.id, submitted);
   idempotency.set(key, submitted.id);
-  return { record: { ...submitted }, replayed: false };
+  return { record: cloneRequest(submitted), replayed: false };
 }
 
 export function markPublicSolutionRequestCrm(
@@ -177,7 +313,7 @@ export function markPublicSolutionRequestCrm(
   if (!record) return undefined;
   const next = { ...record, crmStatus, updatedAt: new Date().toISOString() };
   records.set(id, next);
-  return { ...next };
+  return cloneRequest(next);
 }
 
 export function publicSolutionRequestView(record: PublicSolutionRequest) {
@@ -187,6 +323,9 @@ export function publicSolutionRequestView(record: PublicSolutionRequest) {
     familyId: record.familyId,
     offerId: record.offerId,
     deliveryModel: record.deliveryModel,
+    deliveryPreference: record.deliveryPreference,
+    selectedNeeds: record.selectedNeeds,
+    environment: record.environment,
     intent: record.intent,
     organizationName: record.organizationName,
     contactName: record.contactName,

--- a/server/publicSolutionRoutes.test.ts
+++ b/server/publicSolutionRoutes.test.ts
@@ -73,6 +73,39 @@ describe("public solution Door 2 API", () => {
     expect(JSON.stringify(body).toLowerCase()).not.toContain("sku");
   });
 
+  it("lets a guest submit several families as one Solution Request", async () => {
+    const response = await fetch(`${baseUrl}/api/public/solutions/request`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        selectedNeeds: [
+          { familyId: "identity_access", deliveryModel: "unsure" },
+          { familyId: "backup_continuity", deliveryModel: "unsure" },
+          { familyId: "email_collaboration", deliveryModel: "co_managed" },
+        ],
+        deliveryPreference: "unsure",
+        intent: "assessment",
+        contactName: "Jordan Buyer",
+        contactEmail: "jordan@example.com",
+        organizationName: "Example Medical",
+        environment: { userCount: "42", deviceOwnership: "hybrid", internalIt: "yes" },
+      }),
+    });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.request.status).toBe("submitted");
+    expect(body.request.selectedNeeds).toHaveLength(3);
+    expect(body.request.selectedNeeds.map((need: { familyId: string }) => need.familyId)).toEqual([
+      "identity_access",
+      "backup_continuity",
+      "email_collaboration",
+    ]);
+    expect(body.request.environment.userCount).toBe("42");
+    expect(body.request.environment.deviceOwnership).toBe("hybrid");
+    expect(body.message).toContain("saved");
+    expect(JSON.stringify(body).toLowerCase()).not.toContain("sku");
+  });
+
   it("lets a guest submit a Solution Request without portal login", async () => {
     const response = await fetch(`${baseUrl}/api/public/solutions/request`, {
       method: "POST",

--- a/server/publicSolutionRoutes.ts
+++ b/server/publicSolutionRoutes.ts
@@ -81,6 +81,9 @@ export function registerPublicSolutionRoutes(app: Express): void {
       familyId: req.body?.familyId,
       offerId: req.body?.offerId,
       deliveryModel: req.body?.deliveryModel,
+      deliveryPreference: req.body?.deliveryPreference,
+      selectedNeeds: req.body?.selectedNeeds,
+      environment: req.body?.environment,
       intent: req.body?.intent,
       organizationName: req.body?.organizationName,
       contactName: req.body?.contactName,
@@ -107,6 +110,9 @@ export function registerPublicSolutionRoutes(app: Express): void {
       familyId: req.body?.familyId,
       offerId: req.body?.offerId,
       deliveryModel: req.body?.deliveryModel,
+      deliveryPreference: req.body?.deliveryPreference,
+      selectedNeeds: req.body?.selectedNeeds,
+      environment: req.body?.environment,
       intent: req.body?.intent,
       organizationName: req.body?.organizationName,
       contactName,
@@ -115,7 +121,7 @@ export function registerPublicSolutionRoutes(app: Express): void {
       notes: req.body?.notes,
     });
 
-    if (!draft.familyId) {
+    if (!draft.familyId && draft.selectedNeeds.length === 0) {
       return res.status(400).json({ error: "Select a solution family before submitting." });
     }
 
@@ -144,6 +150,8 @@ export function registerPublicSolutionRoutes(app: Express): void {
         familyId: submitted.record.familyId,
         offerId: submitted.record.offerId,
         deliveryModel: submitted.record.deliveryModel,
+        deliveryPreference: submitted.record.deliveryPreference,
+        selectedNeeds: submitted.record.selectedNeeds.map((need) => need.familyId),
         intent: submitted.record.intent,
       });
       void syncPublicSolutionRequestToCrm(submitted.record)
@@ -160,10 +168,7 @@ export function registerPublicSolutionRoutes(app: Express): void {
       correlationId: view.correlationId,
       crm: view.crmStatus,
       replayed: submitted.replayed,
-      message:
-        view.crmStatus === "recorded"
-          ? "Your Solution Request was saved."
-          : "Your Solution Request was saved. Follow-up is pending.",
+      message: "Your solution request was saved. We'll confirm fit, scope, and pricing before you commit.",
     });
   });
 }

--- a/server/storeLegacyRedirects.test.ts
+++ b/server/storeLegacyRedirects.test.ts
@@ -5,6 +5,7 @@ describe("legacy /store destage", () => {
   it("sends public workshop URLs to Door 1 or Door 2", () => {
     expect(classifyLegacyStorePath("/store")).toEqual({ kind: "public_store" });
     expect(classifyLegacyStorePath("/store/checkout")).toEqual({ kind: "public_store" });
+    expect(classifyLegacyStorePath("/store/solution")).toEqual({ kind: "public_store" });
     expect(classifyLegacyStorePath("/store/solutions/identity-access")).toEqual({ kind: "public_store" });
     expect(classifyLegacyStorePath("/store/managed")).toEqual({
       kind: "public_redirect",

--- a/server/storeLegacyRedirects.ts
+++ b/server/storeLegacyRedirects.ts
@@ -43,7 +43,7 @@ export function classifyLegacyStorePath(pathname: string): LegacyStoreClassifica
     if (dest) return { kind: "public_redirect", to: dest };
     return { kind: "generic_deny" };
   }
-  if (path === "/store" || path === "/store/checkout" || path.startsWith("/store/solutions/")) {
+  if (path === "/store" || path === "/store/checkout" || path === "/store/solution" || path.startsWith("/store/solutions/")) {
     return { kind: "public_store" };
   }
   if (path.startsWith("/store/")) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Public Door 2 still used grocery-cart UX (`Add`, shopping-cart icon, `/store/checkout`, per-item “Continue this solution”) while telling people it was not a cart. This PR changes the **buyer journey scaffold** and keeps the existing Store visual language: same family cards, atmosphere, type, electric accent, and raised graphite panels.

Prospects now:

1. Pick one or several business needs (optional 5-goal layer over the 13 families)
2. Choose how DE should be involved (DE managed / work with IT / not sure) — **Include no longer silently stores `standalone`**
3. Add environment facts on **Your Solution**
4. Submit **one composed request** (multiple families → one CRM opportunity)
5. See **one recommended next step** (Cyber Risk Assessment) plus Ask DE

Cart/checkout vocabulary stays with the authenticated Client Marketplace and the staff warehouse. `/store/checkout` is an alias of `/store/solution` so old links do not reopen a payment checkout.

This is not a Store restyle and does not touch Blog/Journal colors, Desk, or VIS-011 product media.

## Completion report

1. **What changed:** Solution Draft model, composed public request API, Explore/Include on family cards, delivery choice before the workspace, environment step, collapsed CTAs, customer copy cleaned of SKU/vendor/CRM commentary.
2. **Why:** The architecture (solutions → marketplace → warehouse) was right; Door 2 was still wearing Door 3 ecommerce UX.
3. **Files:** `client/src/lib/solutionDraft.ts`, Door 2 pages/components, `server/publicSolutionRequest*`, routes/legacy redirects, `docs/PUBLIC-SOLUTION-BUILDER.md`.
4. **Functionality preserved:** 13 families, standalone + co-managed offers, search without email, Client Marketplace sign-in aside, Ask DE, public-safe data contract, warehouse isolation. Existing card chrome, type scale, and electric accent were kept; unselected delivery tabs were given the same raised segment fill so they still look like the original control when nothing is selected yet.
5. **Tests:** `tsc` clean. Vitest: solution draft, Door 2 leakage, public solution routes (including 3-family composed submit), legacy redirects, `isDoor2Path`. Playwright Door 2 smoke passed at 390 / 768 / 1440 (13 families, no Add, no Pay Now, no competing quote/assessment/consult CTAs, no overflow).
6. **Browser verification:** Exercised Include → Your Solution drawer → family delivery → Continue building → `/store/solution` → recommended assessment request. Viewport screenshots below.
7. **Remaining issues:** Google stale `/store/product/...` snippets need Search Console removals (P2). Ask DE / cookie / Your Solution stacking on short mobile viewports is pre-existing Desk chrome — not restyled here. Hub still owns qualification/pricing rules; the website only collects facts.
8. **Human inputs:** Confirm the 5 business-goal labels. Search Console URL removals.

[Store index at 1440](https://cursor.com/agents/bc-2eccd163-9841-47a8-8688-359b7605cfd2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Findex-1440-fold.png)
[Family page with co-managed selected at 1440](https://cursor.com/agents/bc-2eccd163-9841-47a8-8688-359b7605cfd2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ffamily-1440-selected.png)
[Your Solution workspace at 1440](https://cursor.com/agents/bc-2eccd163-9841-47a8-8688-359b7605cfd2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fworkspace-1440-fold.png)
[Store index at 390](https://cursor.com/agents/bc-2eccd163-9841-47a8-8688-359b7605cfd2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Findex-390-fold.png)
[Family page at 390](https://cursor.com/agents/bc-2eccd163-9841-47a8-8688-359b7605cfd2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ffamily-390-fold.png)
[Your Solution workspace at 390](https://cursor.com/agents/bc-2eccd163-9841-47a8-8688-359b7605cfd2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fworkspace-390-fold.png)

## CONCURRENCY AUDIT

```
CONCURRENCY AUDIT
Branch base: 3518111a99eaa7e8025f5690f80f2ef6002747f4
Current origin/main: 3518111a99eaa7e8025f5690f80f2ef6002747f4
Commits landed on main since branch creation:
none
Overlapping files:
- none
Reconciliation performed:
- none needed; branched from current origin/main
Newer-main work preserved:
YES
Whole-file replacements reviewed:
YES — none used
Tests:
npm run check (tsc) pass
vitest: solutionDraft, door2Leakage, publicSolutionRoutes, storeLegacyRedirects, isDoor2Path, curatedSolutions
DOOR2_BASE=http://127.0.0.1:3300 npm run smoke:door2 pass (390/768/1440)
Visual QA:
390: family cards stack; delivery options are h-11 segments; workspace is single column then aside; no horizontal overflow
768: goal chips wrap; 3-step how-it-works stays in the existing raised box
1440: 3-column family grid preserved; workspace keeps the previous checkout 2-column shell
Screenshots captured:
YES
```

## Visual System v2

Scaffold/interaction only. Existing Store cards, tokens, and electric accent are unchanged. No new HUD/evidence primitives. VIS-011 (Store product-media restyle) is not this PR.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2eccd163-9841-47a8-8688-359b7605cfd2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2eccd163-9841-47a8-8688-359b7605cfd2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

