### PR TITLE
Loop Client Marketplace login back to /portal/marketplace

### DIFF
--- a/client/src/hooks/useStoreAuth.ts
+++ b/client/src/hooks/useStoreAuth.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import type { ClientType } from "@/data/storeProducts";
-import { PORTAL_LOGIN } from "@/lib/portalUrls";
+import { portalLoginWithReturn } from "@/lib/portalUrls";
+import { marketplaceReturnTo } from "@shared/portalReturnTo";
 
 // Store role types for RBAC
 export type StoreRole = 'public' | 'prospect' | 'managed' | 'comanaged' | 'admin';
@@ -136,8 +137,7 @@ export function useStoreAuth(): StoreAuthState {
     const currentPath = window.location.pathname;
     localStorage.setItem("storeRedirectAfterLogin", currentPath);
     // Absolute portal host — apex /portal/login is mangled by Cloudflare to //login
-    const returnTo = `${window.location.origin}${currentPath}`;
-    window.location.href = `${PORTAL_LOGIN}?returnTo=${encodeURIComponent(returnTo)}`;
+    window.location.href = portalLoginWithReturn(marketplaceReturnTo(currentPath));
   }, []);
 
   const logout = useCallback(() => {

--- a/client/src/lib/portalApi.ts
+++ b/client/src/lib/portalApi.ts
@@ -1,7 +1,5 @@
 import { PORTAL_LOGIN } from "./portalUrls";
-
-/** Path-only login route for same-host pathname checks (never compare against absolute URL). */
-const PORTAL_LOGIN_PATH = "/portal/login";
+import { marketplaceReturnTo, PORTAL_DASHBOARD_PATH, PORTAL_LOGIN_PATH } from "@shared/portalReturnTo";
 
 function portalAuthHeaders(extra?: HeadersInit): Record<string, string> {
   const headers: Record<string, string> = {};
@@ -36,14 +34,8 @@ export function redirectToPortalLogin(returnTo?: string) {
   const path = window.location.pathname || "";
   if (path === PORTAL_LOGIN_PATH || path.startsWith(`${PORTAL_LOGIN_PATH}?`)) return;
 
-  const dest =
-    returnTo && returnTo.startsWith("/portal") && !returnTo.startsWith("//")
-      ? returnTo
-      : `${path}${window.location.search || ""}`;
-  const safeReturn =
-    dest.startsWith("/portal") && !dest.startsWith("//") && dest !== PORTAL_LOGIN_PATH
-      ? dest
-      : "/portal/dashboard";
+  const dest = marketplaceReturnTo(returnTo || `${path}${window.location.search || ""}`);
+  const safeReturn = dest === PORTAL_LOGIN_PATH ? PORTAL_DASHBOARD_PATH : dest;
 
   clearPortalLocalSession();
   const qs = new URLSearchParams({ returnTo: safeReturn });

--- a/client/src/lib/portalUrls.test.ts
+++ b/client/src/lib/portalUrls.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import {
+  PORTAL_LOGIN,
+  portalLoginWithReturn,
+  portalMarketplaceLoginUrl,
+} from "./portalUrls";
+import { PORTAL_MARKETPLACE_PATH } from "@shared/portalReturnTo";
+
+describe("portal marketplace login loop-back", () => {
+  it("sends marketplace login through the portal host with returnTo", () => {
+    const url = portalMarketplaceLoginUrl();
+    expect(url.startsWith(PORTAL_LOGIN)).toBe(true);
+    expect(url).not.toContain("//login");
+    expect(url).toContain(`returnTo=${encodeURIComponent(PORTAL_MARKETPLACE_PATH)}`);
+  });
+
+  it("maps public Store paths to Client Marketplace instead of portal home", () => {
+    const url = portalLoginWithReturn("/store");
+    expect(url).toContain(`returnTo=${encodeURIComponent(PORTAL_MARKETPLACE_PATH)}`);
+    expect(portalLoginWithReturn("https://digeratiexperts.com/store/checkout")).toContain(
+      encodeURIComponent(PORTAL_MARKETPLACE_PATH),
+    );
+  });
+
+  it("keeps generic portal login on dashboard when no return is given", () => {
+    expect(portalLoginWithReturn()).toBe(PORTAL_LOGIN);
+  });
+});

--- a/client/src/lib/portalUrls.ts
+++ b/client/src/lib/portalUrls.ts
@@ -8,16 +8,39 @@
  *
  * Canonical login: https://portal.digeratiexperts.com/portal/login
  */
+import {
+  PORTAL_DASHBOARD_PATH,
+  PORTAL_MARKETPLACE_PATH,
+  marketplaceReturnTo,
+} from "@shared/portalReturnTo";
+
 export const PORTAL_ORIGIN = "https://portal.digeratiexperts.com";
 export const PORTAL_LOGIN = `${PORTAL_ORIGIN}/portal/login`;
 export const PORTAL_HOME = `${PORTAL_ORIGIN}/portal`;
+export const PORTAL_MARKETPLACE = `${PORTAL_ORIGIN}${PORTAL_MARKETPLACE_PATH}`;
 export const PORTAL_TICKETS = `${PORTAL_ORIGIN}/portal/tickets`;
 export const PORTAL_FILES = `${PORTAL_ORIGIN}/portal/files`;
 export const PORTAL_CONTRACTS = `${PORTAL_ORIGIN}/portal/contracts`;
 export const REMOTE_SUPPORT_HREF = "https://assist.zoho.com/";
 
+export { PORTAL_MARKETPLACE_PATH };
+
 export function portalLoginWithReturn(returnTo?: string): string {
   if (!returnTo) return PORTAL_LOGIN;
-  const params = new URLSearchParams({ returnTo });
+  const safe = marketplaceReturnTo(returnTo);
+  const params = new URLSearchParams({ returnTo: safe });
   return `${PORTAL_LOGIN}?${params.toString()}`;
+}
+
+/** Existing clients leaving public Store should land in Client Marketplace, not portal home. */
+export function portalMarketplaceLoginUrl(): string {
+  const params = new URLSearchParams({ returnTo: PORTAL_MARKETPLACE_PATH });
+  return `${PORTAL_LOGIN}?${params.toString()}`;
+}
+
+export function portalReturnLabel(returnTo: string): string {
+  const safe = marketplaceReturnTo(returnTo);
+  if (safe === PORTAL_MARKETPLACE_PATH) return "Client Marketplace";
+  if (safe === PORTAL_DASHBOARD_PATH || safe === "/portal") return "Client Portal";
+  return "your destination";
 }

--- a/client/src/pages/portal/PortalLogin.tsx
+++ b/client/src/pages/portal/PortalLogin.tsx
@@ -7,6 +7,8 @@ import { useLocation } from "wouter";
 import logoImage from "@assets/DE-Logo-new_1762461524794.webp";
 import TurnstileWidget from "@/components/TurnstileWidget";
 import { useSEO } from "@/hooks/useSEO";
+import { portalReturnLabel } from "@/lib/portalUrls";
+import { marketplaceReturnTo } from "@shared/portalReturnTo";
 
 type LoginStep = "credentials" | "mfa";
 
@@ -50,7 +52,7 @@ export default function PortalLogin() {
     const zohoSso = readQueryParam("zoho_sso");
     const err = readQueryParam("error");
     const message = readQueryParam("message");
-    const returnTo = readQueryParam("returnTo") || "/portal/dashboard";
+    const returnTo = marketplaceReturnTo(readQueryParam("returnTo"));
 
     if (err) {
       setError(message || "Sign-in failed. Please try again.");
@@ -97,10 +99,7 @@ export default function PortalLogin() {
           } catch {
             /* navigate with token; capabilities refresh on next /me */
           }
-          const dest =
-            returnTo.startsWith("/portal") && !returnTo.startsWith("//")
-              ? returnTo
-              : "/portal/dashboard";
+          const dest = marketplaceReturnTo(returnTo);
           window.history.replaceState({}, "", "/portal/login");
           navigate(dest);
         } catch {
@@ -118,6 +117,30 @@ export default function PortalLogin() {
         if (!cancelled) setZohoConfigured(Boolean(data?.configured));
       } catch {
         if (!cancelled) setZohoConfigured(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [navigate]);
+
+  useEffect(() => {
+    if (readQueryParam("zoho_sso") === "1") return;
+    const token = localStorage.getItem("portalToken");
+    if (!token) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const meRes = await fetch("/api/portal/me", {
+          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
+        });
+        if (!meRes.ok || cancelled) return;
+        const meData = await meRes.json();
+        if (cancelled || !meData?.user) return;
+        navigate(marketplaceReturnTo(readQueryParam("returnTo")));
+      } catch {
+        /* stay on login when the stored token is stale */
       }
     })();
     return () => {
@@ -157,12 +180,7 @@ export default function PortalLogin() {
       localStorage.setItem("portalToken", data.token);
       localStorage.setItem("portalUserId", data.user?.id || "portal-user");
       localStorage.setItem("userEmail", email);
-      const returnTo = readQueryParam("returnTo");
-      const dest =
-        returnTo.startsWith("/portal") && !returnTo.startsWith("//")
-          ? returnTo
-          : "/portal/dashboard";
-      navigate(dest);
+      navigate(marketplaceReturnTo(readQueryParam("returnTo")));
     } catch (err) {
       setError("Connection error. Please try again.");
     } finally {
@@ -194,12 +212,7 @@ export default function PortalLogin() {
       localStorage.setItem("portalToken", data.token);
       localStorage.setItem("portalUserId", data.user?.id || "portal-user");
       localStorage.setItem("userEmail", email);
-      const returnTo = readQueryParam("returnTo");
-      const dest =
-        returnTo.startsWith("/portal") && !returnTo.startsWith("//")
-          ? returnTo
-          : "/portal/dashboard";
-      navigate(dest);
+      navigate(marketplaceReturnTo(readQueryParam("returnTo")));
     } catch (err) {
       setError("Connection error. Please try again.");
     } finally {
@@ -207,11 +220,9 @@ export default function PortalLogin() {
     }
   };
 
-  const returnToForZoho = (() => {
-    const r = readQueryParam("returnTo");
-    return r.startsWith("/portal") && !r.startsWith("//") ? r : "/portal/dashboard";
-  })();
+  const returnToForZoho = marketplaceReturnTo(readQueryParam("returnTo"));
   const zohoStartHref = `/api/portal/auth/zoho/start?returnTo=${encodeURIComponent(returnToForZoho)}`;
+  const returnLabel = portalReturnLabel(returnToForZoho);
   const showZoho = zohoConfigured !== false;
 
   return (
@@ -227,7 +238,9 @@ export default function PortalLogin() {
               <CardHeader className="space-y-2">
                 <CardTitle className="text-2xl text-white">Client Portal</CardTitle>
                 <CardDescription className="text-gray-300">
-                  Sign in to access your account and manage support
+                  {returnToForZoho === "/portal/marketplace"
+                    ? "Sign in to continue to the Client Marketplace."
+                    : `Sign in to continue to ${returnLabel}.`}
                 </CardDescription>
               </CardHeader>
 

--- a/client/src/pages/solutions/BusinessNeedsIndex.tsx
+++ b/client/src/pages/solutions/BusinessNeedsIndex.tsx
@@ -11,7 +11,7 @@ import { PublicSolutionCart } from "@/components/store/PublicSolutionCart";
 import { useSEO } from "@/hooks/useSEO";
 import { curatedSolutionFamilies, type CuratedSolutionFamily } from "@/data/curatedSolutions";
 import { BUSINESS_GOALS, familyPath, type BusinessGoalId } from "@/lib/businessNeeds";
-import { PORTAL_LOGIN } from "@/lib/portalUrls";
+import { portalMarketplaceLoginUrl } from "@/lib/portalUrls";
 import { emptyDraft, readSolutionDraft, SOLUTION_DRAFT_EVENT, toggleDraftNeed, type SolutionDraft } from "@/lib/solutionDraft";
 import { useToast } from "@/hooks/use-toast";
 
@@ -103,7 +103,11 @@ export default function BusinessNeedsIndex() {
                 </p>
                 <p className="mt-8 text-sm text-white/45">
                   Client or DE staff?{" "}
-                  <a href={PORTAL_LOGIN} className="font-medium text-de-accent-ink underline-offset-4 hover:underline">
+                  <a
+                    href={portalMarketplaceLoginUrl()}
+                    className="font-medium text-de-accent-ink underline-offset-4 hover:underline"
+                    data-testid="link-client-marketplace"
+                  >
                     Open Client Marketplace
                   </a>
                 </p>

--- a/client/src/pages/store/CoManagedStore.tsx
+++ b/client/src/pages/store/CoManagedStore.tsx
@@ -54,7 +54,7 @@ import {
 import { useToast } from "@/hooks/use-toast";
 import { useCart } from "@/contexts/CartContext";
 import { useStoreAuth } from "@/hooks/useStoreAuth";
-import { PORTAL_LOGIN } from "@/lib/portalUrls";
+import { portalMarketplaceLoginUrl } from "@/lib/portalUrls";
 import { openMspAdvisor } from "@/lib/openMspAdvisor";
 import {
   isGuidedFullCatalog,
@@ -877,9 +877,12 @@ const CoManagedStore = () => {
                     <h3 className="mb-2 font-semibold text-white">Client-only products</h3>
                     <p className="text-sm text-white/60">
                       Some products require an existing client relationship.{" "}
-                      <Link href={PORTAL_LOGIN} className="text-de-accent-ink hover:text-de-accent-ink">
-                        Log in to your portal
-                      </Link>{" "}
+                      <a
+                        href={portalMarketplaceLoginUrl()}
+                        className="text-de-accent-ink hover:text-de-accent-ink"
+                      >
+                        Log in to the Client Marketplace
+                      </a>{" "}
                       for exclusive pricing.
                     </p>
                   </div>

--- a/docs/PUBLIC-SOLUTION-BUILDER.md
+++ b/docs/PUBLIC-SOLUTION-BUILDER.md
@@ -30,5 +30,7 @@ Staff only
 - Server: `/api/public/solutions/request` accepts `selectedNeeds[]` + `environment` as **one** request / one CRM opportunity
 - `/store/checkout` is an alias of `/store/solution` so old links do not reopen a grocery checkout
 
+Client Marketplace is a **separate door**. The Store “Open Client Marketplace” link must send existing clients through `https://portal.digeratiexperts.com/portal/login?returnTo=/portal/marketplace`. After Zoho or email sign-in they continue to `/portal/marketplace`, not portal home. Do not drop `returnTo`. Never use apex `/portal/login` (Cloudflare can emit `//login`).
+
 Do not put vendor names, SKUs, costs, margins, or CRM-implementation commentary on these pages.
 Customer language is: **No payment is required. We'll confirm fit, scope, and pricing before you commit.**

--- a/server/portalZohoAuth.ts
+++ b/server/portalZohoAuth.ts
@@ -127,13 +127,9 @@ export function isMasterPortalEmail(email: string): boolean {
   return MASTER_EMAILS.has(email.trim().toLowerCase());
 }
 
-export function sanitizeReturnTo(raw: unknown): string {
-  if (typeof raw !== "string" || !raw.startsWith("/") || raw.startsWith("//")) {
-    return "/portal/dashboard";
-  }
-  if (!raw.startsWith("/portal")) return "/portal/dashboard";
-  return raw;
-}
+import { marketplaceReturnTo, sanitizeReturnTo } from "@shared/portalReturnTo";
+
+export { marketplaceReturnTo, sanitizeReturnTo };
 
 export function portalLoginErrorRedirect(code: string, message?: string): string {
   const params = new URLSearchParams({ error: code });
@@ -169,7 +165,7 @@ export function createZohoStartPayload(returnTo?: string): {
   const state = signState({
     v: 1,
     exp: Date.now() + 10 * 60 * 1000,
-    r: sanitizeReturnTo(returnTo),
+    r: marketplaceReturnTo(returnTo),
     n: b64url(randomBytes(16)),
   });
   return {
@@ -181,7 +177,7 @@ export function createZohoStartPayload(returnTo?: string): {
 export function verifyZohoOAuthState(state: string): { returnTo: string } | null {
   const parsed = verifyState(state);
   if (!parsed) return null;
-  return { returnTo: sanitizeReturnTo(parsed.r) };
+  return { returnTo: marketplaceReturnTo(parsed.r) };
 }
 
 export async function exchangeZohoAuthCode(opts: {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -23,7 +23,7 @@ import {
   isMasterPortalEmail,
   portalLoginErrorRedirect,
   readZohoPkceCookie,
-  sanitizeReturnTo,
+  marketplaceReturnTo,
   setZohoPkceCookie,
   verifyZohoOAuthState,
 } from "./portalZohoAuth";
@@ -2501,7 +2501,7 @@ export async function registerRoutes(app: Express) {
     const params = new URLSearchParams({
       zoho_sso: "1",
       token,
-      returnTo: sanitizeReturnTo(returnTo),
+      returnTo: marketplaceReturnTo(returnTo),
     });
     return res.redirect(`/portal/login?${params.toString()}`);
   }
@@ -2642,7 +2642,7 @@ export async function registerRoutes(app: Express) {
       userAgent: typeof req.headers?.["user-agent"] === "string" ? req.headers["user-agent"] : null,
       path: "/api/portal/auth/zoho/start",
     });
-    const returnTo = sanitizeReturnTo(req.query.returnTo);
+    const returnTo = marketplaceReturnTo(req.query.returnTo);
     const { authorizeUrl, codeVerifier } = createZohoStartPayload(returnTo);
     setZohoPkceCookie(res, codeVerifier);
     return res.redirect(authorizeUrl);

--- a/shared/portalReturnTo.test.ts
+++ b/shared/portalReturnTo.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  marketplaceReturnTo,
+  PORTAL_DASHBOARD_PATH,
+  PORTAL_MARKETPLACE_PATH,
+  sanitizeReturnTo,
+} from "./portalReturnTo";
+
+describe("sanitizeReturnTo", () => {
+  it("keeps Client Marketplace and other portal pages", () => {
+    expect(sanitizeReturnTo("/portal/marketplace")).toBe(PORTAL_MARKETPLACE_PATH);
+    expect(sanitizeReturnTo("/portal/dashboard")).toBe("/portal/dashboard");
+    expect(sanitizeReturnTo("/portal/tickets?id=1")).toBe("/portal/tickets?id=1");
+  });
+
+  it("rejects login loops, protocol-relative URLs, and off-site hosts", () => {
+    expect(sanitizeReturnTo("/portal/login")).toBe(PORTAL_DASHBOARD_PATH);
+    expect(sanitizeReturnTo("//login")).toBe(PORTAL_DASHBOARD_PATH);
+    expect(sanitizeReturnTo("https://evil.example/portal/marketplace")).toBe(PORTAL_DASHBOARD_PATH);
+    expect(sanitizeReturnTo("javascript:alert(1)")).toBe(PORTAL_DASHBOARD_PATH);
+  });
+
+  it("unwraps same-site absolute URLs to a path", () => {
+    expect(sanitizeReturnTo("https://portal.digeratiexperts.com/portal/marketplace")).toBe(
+      PORTAL_MARKETPLACE_PATH,
+    );
+    expect(sanitizeReturnTo("https://digeratiexperts.com/portal/tickets")).toBe("/portal/tickets");
+  });
+});
+
+describe("marketplaceReturnTo", () => {
+  it("sends Store and marketplace intents back to Client Marketplace", () => {
+    expect(marketplaceReturnTo("/store")).toBe(PORTAL_MARKETPLACE_PATH);
+    expect(marketplaceReturnTo("/store/checkout")).toBe(PORTAL_MARKETPLACE_PATH);
+    expect(marketplaceReturnTo("https://digeratiexperts.com/store")).toBe(PORTAL_MARKETPLACE_PATH);
+    expect(marketplaceReturnTo("/portal/marketplace")).toBe(PORTAL_MARKETPLACE_PATH);
+  });
+
+  it("does not hijack unrelated portal pages", () => {
+    expect(marketplaceReturnTo("/portal/tickets")).toBe("/portal/tickets");
+  });
+});

--- a/shared/portalReturnTo.ts
+++ b/shared/portalReturnTo.ts
@@ -1,0 +1,73 @@
+/**
+ * Safe post-login destinations for the Client Portal.
+ * Never allow protocol-relative //login or off-site hosts.
+ */
+
+export const PORTAL_DASHBOARD_PATH = "/portal/dashboard";
+export const PORTAL_MARKETPLACE_PATH = "/portal/marketplace";
+export const PORTAL_LOGIN_PATH = "/portal/login";
+
+const BLOCKED_PREFIXES = [
+  PORTAL_LOGIN_PATH,
+  "/portal/signup",
+  "/portal/forgot-password",
+  "/portal/reset-password",
+];
+
+const EXTRA_ALLOWED = ["/official-network-planner", "/de-ecosystem-matrix-offical"];
+
+const ALLOWED_HOSTS = new Set([
+  "portal.digeratiexperts.com",
+  "digeratiexperts.com",
+  "www.digeratiexperts.com",
+]);
+
+function extractReturnPath(raw: unknown): string | null {
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  if (!trimmed || trimmed.startsWith("//") || trimmed.includes("\\")) return null;
+  if (/^javascript:/i.test(trimmed) || /^data:/i.test(trimmed)) return null;
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    try {
+      const url = new URL(trimmed);
+      if (!ALLOWED_HOSTS.has(url.hostname.toLowerCase())) return null;
+      return `${url.pathname}${url.search}`;
+    } catch {
+      return null;
+    }
+  }
+
+  if (!trimmed.startsWith("/")) return null;
+  return trimmed.split("#")[0];
+}
+
+function isBlockedAuthPath(path: string): boolean {
+  const pathname = path.split("?")[0] || path;
+  return BLOCKED_PREFIXES.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));
+}
+
+function isAllowedPath(path: string): boolean {
+  const pathname = path.split("?")[0] || path;
+  if (pathname === "/portal" || pathname.startsWith("/portal/")) return true;
+  return EXTRA_ALLOWED.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));
+}
+
+/** Public Store is Door 2. Existing-client catalog lives at /portal/marketplace. */
+export function marketplaceReturnTo(raw: unknown): string {
+  const path = extractReturnPath(raw);
+  if (path) {
+    const pathname = path.split("?")[0] || path;
+    if (pathname === "/store" || pathname.startsWith("/store/") || pathname === PORTAL_MARKETPLACE_PATH) {
+      return PORTAL_MARKETPLACE_PATH;
+    }
+  }
+  return sanitizeReturnTo(raw);
+}
+
+export function sanitizeReturnTo(raw: unknown): string {
+  const path = extractReturnPath(raw);
+  if (!path || path.length > 200) return PORTAL_DASHBOARD_PATH;
+  if (isBlockedAuthPath(path) || !isAllowedPath(path)) return PORTAL_DASHBOARD_PATH;
+  return path;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Public Store “Open Client Marketplace” sent existing clients to portal login with **no `returnTo`**. After Zoho or email sign-in they landed on portal home instead of Client Marketplace.

This keeps the three doors distinct: public Solution Builder stays public; Client Marketplace stays authenticated; login now continues to `/portal/marketplace`.

## Completion report

1. **What changed**
   - Store marketplace CTA uses `https://portal.digeratiexperts.com/portal/login?returnTo=/portal/marketplace`
   - Login, MFA, and Zoho SSO honor a sanitized `returnTo` (including Store paths mapped to marketplace)
   - Already-signed-in visitors skip the form and go to that destination
   - Login copy says they are continuing to Client Marketplace when that is the destination
2. **Why it changed**
   - Authenticating for marketplace had no loop-back
3. **Files changed**
   - `shared/portalReturnTo.ts`, `client/src/lib/portalUrls.ts`, `PortalLogin.tsx`, `BusinessNeedsIndex.tsx`, Zoho start/callback, store auth redirect
4. **Functionality preserved**
   - Generic Client Portal nav still opens login without forcing marketplace
   - Unsafe `returnTo` values (`//login`, off-site hosts, login/signup loops) still fall back to dashboard
   - Canonical login host unchanged: `https://portal.digeratiexperts.com/portal/login`
5. **Tests performed**
   - `npx vitest run shared/portalReturnTo.test.ts client/src/lib/portalUrls.test.ts` — pass
   - `npx tsc --noEmit` — pass
6. **Browser verification performed**
   - Link and sanitizer covered by tests. Full Zoho SSO round-trip not exercised in this environment (no live portal session)
7. **Remaining issues**
   - Google cached `/store/product/...` snippets are still a Search Console P2
   - Anonymous form-situation continuity from the prior request is **not** in this commit (WIP files remain local)
8. **Human inputs still required**
   - Confirm live: Store → Open Client Marketplace → sign in → `/portal/marketplace`

```
CONCURRENCY AUDIT
Branch base: 825c88f (origin/main at branch creation)
Current origin/main: 825c88f
Commits landed on main since branch creation:
- none
Overlapping files:
- none
Reconciliation performed:
- fetched origin/main; merge-base equals origin/main
Newer-main work preserved:
YES
Whole-file replacements reviewed:
YES (no whole-file take)
Tests:
vitest portalReturnTo + portalUrls; tsc
Visual QA:
390: N/A for login redirect (behavior, not layout)
768: N/A
1440: N/A
Screenshots captured:
NO
```

Visual System v2: no HUD/evidence primitives added. Did not touch `ZohoASAPWidget.tsx`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2eccd163-9841-47a8-8688-359b7605cfd2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2eccd163-9841-47a8-8688-359b7605cfd2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

