### PR TITLE
Store: add jelly motion to solution cards

### DIFF
--- a/client/src/components/store/PublicSolutionCart.tsx
+++ b/client/src/components/store/PublicSolutionCart.tsx
@@ -79,13 +79,13 @@ export function PublicSolutionCart() {
           {needs.length > 0 && <span className="ml-2 rounded-full bg-de-accent px-2 py-0.5 text-xs font-bold text-white">{needs.length}</span>}
         </Button>
       </SheetTrigger>
-      <SheetContent className="w-[min(92vw,28rem)] border-white/10 bg-[#0d0d0d] text-white sm:max-w-md">
+      <SheetContent className="de-store-jelly-sheet w-[min(92vw,28rem)] border-white/10 bg-[#0d0d0d] text-white sm:max-w-md">
         <SheetHeader>
           <SheetTitle className="text-2xl text-white">Your Solution</SheetTitle>
           <SheetDescription className="text-white/55">One profile, one set of business needs, one composed solution.</SheetDescription>
         </SheetHeader>
 
-        <div className="mt-6 rounded-xl border border-white/10 bg-[#151515] p-4">
+        <div data-de-jelly-surface className="mt-6 rounded-xl border border-white/10 bg-[#151515] p-4">
           <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-de-accent-ink">Profile</p>
           <p className="mt-2 text-sm leading-relaxed text-white/65">{profileSummary(draft.environment)}</p>
           <p className={`mt-2 text-xs ${profileReady ? "text-emerald-300" : "text-amber-200"}`}>
@@ -97,7 +97,7 @@ export function PublicSolutionCart() {
           {needs.length ? needs.map((item) => {
             const family = getFamilyById(item.familyId);
             if (!family) return null;
-            return <div key={item.familyId} className="rounded-xl border border-white/10 bg-[#151515] p-4">
+            return <div key={item.familyId} data-de-jelly-surface className="rounded-xl border border-white/10 bg-[#151515] p-4">
               <div className="flex items-start justify-between gap-3">
                 <div>
                   <h3 className="font-semibold text-white">{family.label}</h3>
@@ -108,7 +108,7 @@ export function PublicSolutionCart() {
                 </button>
               </div>
             </div>;
-          }) : <div className="rounded-xl border border-dashed border-white/15 p-8 text-center"><Layers className="mx-auto h-7 w-7 text-white/30" /><p className="mt-3 text-white/60">No business needs selected yet.</p></div>}
+          }) : <div data-de-jelly-surface className="rounded-xl border border-dashed border-white/15 p-8 text-center"><Layers className="mx-auto h-7 w-7 text-white/30" /><p className="mt-3 text-white/60">No business needs selected yet.</p></div>}
         </div>
         {needs.length ? (
           <Button asChild className="mt-6 h-12 w-full bg-[#D3126A] text-white hover:bg-[#b90f5d]">

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,6 +1,7 @@
 import { createRoot } from "react-dom/client";
 import App from "./App";
 import "./index.css";
+import "./styles/store-jelly.css";
 import { initAnalytics } from "./lib/analytics";
 
 initAnalytics();

--- a/client/src/styles/store-jelly.css
+++ b/client/src/styles/store-jelly.css
@@ -1,0 +1,172 @@
+/*
+ * Store jelly motion
+ * Compiz-inspired elasticity for the public Solution Builder and its cart.
+ * Scoped to Store routes only via html.de-store-gesture-lock.
+ */
+
+:root {
+  --de-jelly-spring: cubic-bezier(0.18, 1.42, 0.34, 1);
+  --de-jelly-soft: cubic-bezier(0.22, 1.18, 0.36, 1);
+}
+
+@keyframes de-jelly-hover {
+  0% {
+    transform: translate3d(0, 0, 0) scale3d(1, 1, 1) rotate(0deg);
+  }
+  34% {
+    transform: translate3d(0, -4px, 0) scale3d(1.018, 0.985, 1) rotate(-0.12deg);
+  }
+  58% {
+    transform: translate3d(0, -1px, 0) scale3d(0.994, 1.008, 1) rotate(0.08deg);
+  }
+  78% {
+    transform: translate3d(0, -3px, 0) scale3d(1.006, 0.997, 1) rotate(-0.04deg);
+  }
+  100% {
+    transform: translate3d(0, -2px, 0) scale3d(1, 1, 1) rotate(0deg);
+  }
+}
+
+@keyframes de-jelly-select {
+  0% {
+    transform: translate3d(0, 0, 0) scale3d(1, 1, 1);
+  }
+  38% {
+    transform: translate3d(0, 1px, 0) scale3d(0.975, 1.025, 1);
+  }
+  64% {
+    transform: translate3d(0, -1px, 0) scale3d(1.012, 0.992, 1);
+  }
+  82% {
+    transform: translate3d(0, 0, 0) scale3d(0.997, 1.004, 1);
+  }
+  100% {
+    transform: translate3d(0, 0, 0) scale3d(1, 1, 1);
+  }
+}
+
+@keyframes de-jelly-sheet-in {
+  0% {
+    transform: translate3d(102%, 0, 0) skewX(-1.8deg) scaleX(0.985);
+  }
+  68% {
+    transform: translate3d(-7px, 0, 0) skewX(0.35deg) scaleX(1.006);
+  }
+  84% {
+    transform: translate3d(3px, 0, 0) skewX(-0.14deg) scaleX(0.998);
+  }
+  100% {
+    transform: translate3d(0, 0, 0) skewX(0deg) scaleX(1);
+  }
+}
+
+/* Workspace panes and nested cards. Keep geometry stable; only the paint layer moves. */
+html.de-store-gesture-lock main section[class~="rounded-2xl"][class~="border-white/10"],
+html.de-store-gesture-lock main aside[class~="rounded-2xl"][class~="border-white/10"],
+html.de-store-gesture-lock main [class~="rounded-xl"][class~="border-white/10"],
+html.de-store-gesture-lock [data-de-jelly-surface] {
+  transform: translate3d(0, 0, 0);
+  transform-origin: 50% 78%;
+  backface-visibility: hidden;
+  transition:
+    transform 440ms var(--de-jelly-spring),
+    border-color 220ms ease,
+    background-color 220ms ease,
+    box-shadow 280ms ease;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  html.de-store-gesture-lock main section[class~="rounded-2xl"][class~="border-white/10"]:hover,
+  html.de-store-gesture-lock main aside[class~="rounded-2xl"][class~="border-white/10"]:hover,
+  html.de-store-gesture-lock main [class~="rounded-xl"][class~="border-white/10"]:hover,
+  html.de-store-gesture-lock [data-de-jelly-surface]:hover {
+    animation: de-jelly-hover 520ms var(--de-jelly-soft) both;
+    border-color: rgba(255, 255, 255, 0.16);
+    box-shadow: 0 18px 46px rgba(0, 0, 0, 0.22);
+  }
+}
+
+/* Choice tiles get the stronger squish. */
+html.de-store-gesture-lock main [role="radio"],
+html.de-store-gesture-lock main button[aria-pressed],
+html.de-store-gesture-lock [data-de-jelly-choice] {
+  transform: translate3d(0, 0, 0);
+  transform-origin: 50% 70%;
+  backface-visibility: hidden;
+  transition:
+    transform 360ms var(--de-jelly-spring),
+    border-color 180ms ease,
+    background-color 180ms ease,
+    box-shadow 220ms ease;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  html.de-store-gesture-lock main [role="radio"]:hover:not(:disabled),
+  html.de-store-gesture-lock main button[aria-pressed]:hover:not(:disabled),
+  html.de-store-gesture-lock [data-de-jelly-choice]:hover:not(:disabled) {
+    transform: translate3d(0, -2px, 0) scale3d(1.012, 0.992, 1);
+  }
+}
+
+html.de-store-gesture-lock main [role="radio"]:active:not(:disabled),
+html.de-store-gesture-lock main button[aria-pressed]:active:not(:disabled),
+html.de-store-gesture-lock [data-de-jelly-choice]:active:not(:disabled),
+html.de-store-gesture-lock [data-testid="public-solution-cart"]:active {
+  transform: translate3d(0, 1px, 0) scale3d(0.972, 1.025, 1);
+  transition-duration: 90ms;
+}
+
+html.de-store-gesture-lock main [role="radio"][aria-checked="true"],
+html.de-store-gesture-lock main button[aria-pressed="true"],
+html.de-store-gesture-lock [data-de-jelly-choice][aria-pressed="true"] {
+  animation: de-jelly-select 390ms var(--de-jelly-soft);
+}
+
+/* Floating Your Solution launcher: compact jelly, no distracting rotation. */
+html.de-store-gesture-lock [data-testid="public-solution-cart"] {
+  transform: translate3d(0, 0, 0);
+  transform-origin: 72% 100%;
+  transition:
+    transform 420ms var(--de-jelly-spring),
+    box-shadow 220ms ease,
+    background-color 180ms ease;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  html.de-store-gesture-lock [data-testid="public-solution-cart"]:hover {
+    transform: translate3d(0, -3px, 0) scale3d(1.018, 0.988, 1);
+    box-shadow: 0 20px 52px rgba(0, 0, 0, 0.34);
+  }
+}
+
+/* Radix Sheet has its own slide classes; this class replaces the open transform with a springy settle. */
+html.de-store-gesture-lock .de-store-jelly-sheet[data-state="open"] {
+  animation: de-jelly-sheet-in 560ms var(--de-jelly-soft) both;
+}
+
+html.de-store-gesture-lock .de-store-jelly-sheet [data-de-jelly-surface] {
+  transform-origin: 70% 50%;
+}
+
+/* Keyboard focus stays crisp even while transforms are active. */
+html.de-store-gesture-lock [data-de-jelly-surface]:focus-visible,
+html.de-store-gesture-lock [data-de-jelly-choice]:focus-visible {
+  outline: 2px solid #d3126a;
+  outline-offset: 3px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html.de-store-gesture-lock main section[class~="rounded-2xl"][class~="border-white/10"],
+  html.de-store-gesture-lock main aside[class~="rounded-2xl"][class~="border-white/10"],
+  html.de-store-gesture-lock main [class~="rounded-xl"][class~="border-white/10"],
+  html.de-store-gesture-lock main [role="radio"],
+  html.de-store-gesture-lock main button[aria-pressed],
+  html.de-store-gesture-lock [data-de-jelly-surface],
+  html.de-store-gesture-lock [data-de-jelly-choice],
+  html.de-store-gesture-lock [data-testid="public-solution-cart"],
+  html.de-store-gesture-lock .de-store-jelly-sheet[data-state="open"] {
+    animation: none !important;
+    transform: none !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## What changed
- Adds a Store-only Compiz-style jelly motion system for Solution Builder surfaces.
- Applies elastic hover/press/selection motion to configuration panes and choice tiles.
- Gives the `Your Solution` launcher a compact squish response.
- Gives the solution drawer a soft overshoot/settle entrance.
- Applies jelly behavior to profile and selected-need cards inside the drawer.

## Guardrails
- Scoped to Store routes only via `html.de-store-gesture-lock`.
- Transform/paint animation only; no layout reflow.
- `prefers-reduced-motion` disables all jelly animation.
- No changes to pricing, package logic, request persistence, marketplace, warehouse, or public/private data boundaries.

## Validation
Run the existing CI/typecheck/unit/build/browser Store smoke before merge.