### PR TITLE
Govern active work through GitHub-visible locks

### DIFF
--- a/.ai/ACTIVE_WORK.yaml
+++ b/.ai/ACTIVE_WORK.yaml
@@ -1,13 +1,23 @@
-# DE shared AI work registry.
-# Mandatory coordination source; governed by docs/AI-ENGINEERING-GOVERNANCE.md.
+# DE shared AI work registry mirror.
+# Governed by docs/AI-ENGINEERING-GOVERNANCE.md and docs/ACTIVE-WORK-COORDINATION.md.
 #
-# IMPORTANT: an empty registry does NOT prove there is no concurrent work.
-# Before claiming work, also inspect current open PRs/branches and docs/SITE-VISUAL-TASKS.md.
-# Add a claim before implementation and remove/close it when merged, abandoned, or superseded.
+# IMPORTANT: GitHub-visible open work is the authoritative concurrency lock.
+# Before changing code, every agent MUST inspect:
+#   1. open GitHub issues whose title/status marks ACTIVE/P0/IN PROGRESS;
+#   2. all open pull requests and their changed files;
+#   3. current remote branches relevant to the subsystem;
+#   4. this YAML mirror;
+#   5. docs/SITE-VISUAL-TASKS.md for visual work.
+#
+# A claim written only on an unmerged feature branch cannot protect other agents,
+# because they will not see it from origin/main. Therefore this file is a mirror,
+# never the sole source of truth. Create/update the GitHub issue first, then mirror
+# the claim here when useful. An empty `claims` list NEVER means the repo is idle.
 #
 # Example:
 # claims:
 #   - id: ask-de-launcher-svg
+#     issue: 123
 #     owner: claude
 #     subsystem: de-desk
 #     branch: claude/ask-de-launcher-svg
@@ -18,5 +28,5 @@
 #     status: active
 #     started: 2026-08-30
 
-version: 1
+version: 2
 claims: []

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,11 +2,11 @@
 
 ## AI engineering governance — mandatory
 
-Authoritative multi-agent policy: **`docs/AI-ENGINEERING-GOVERNANCE.md`**. Shared coordination registry: **`.ai/ACTIVE_WORK.yaml`**. This policy is mandatory for Claude Code, Cursor, Antigravity/Gemini, ChatGPT-assisted repository work, and other agents.
+Authoritative multi-agent policy: **`docs/AI-ENGINEERING-GOVERNANCE.md`**. GitHub-visible active issues + open PRs are the authoritative concurrency locks; **`.ai/ACTIVE_WORK.yaml`** is a mirror only. Required procedure: **`docs/ACTIVE-WORK-COORDINATION.md`**. This policy is mandatory for Claude Code, Cursor, Antigravity/Gemini, ChatGPT-assisted repository work, and other agents.
 
 Default authority: Joe is final product/release authority; Claude Code is the default lead website implementation/integration agent; Cursor and Antigravity/Gemini are specialist/review agents unless Joe explicitly reassigns the role for a specific task. There is only one website integration authority at a time.
 
-Every agent must use an isolated branch/worktree, check active claims plus current open PRs before editing, reconcile against current `origin/main` before merge, and treat `MERGED` and `LIVE` as separate states. Specialist agents do not independently merge/deploy website work by default.
+Every agent must use an isolated branch/worktree, check open active GitHub issues + all current open PRs + relevant remote branches before editing, then inspect the YAML mirror. Reconcile against current `origin/main` before merge, and treat `MERGED` and `LIVE` as separate states. Specialist agents do not independently merge/deploy website work by default.
 
 For visual work, rendered quality is an acceptance gate separate from code correctness. Inspect the actual UI in context before changing it and verify at 390 / 768 / 1440.
 
@@ -41,7 +41,7 @@ You are working in a multi-agent repository. Other agents may be modifying the s
 **Before working:**
 
 1. Fetch the latest `origin/main`.
-2. Read `docs/AI-ENGINEERING-GOVERNANCE.md` and `.ai/ACTIVE_WORK.yaml`, then inspect current open PRs/branches for concurrent work.
+2. Read `docs/AI-ENGINEERING-GOVERNANCE.md` and `docs/ACTIVE-WORK-COORDINATION.md`; inspect open ACTIVE/P0/IN PROGRESS GitHub issues, all current open PRs, and relevant remote branches; then inspect `.ai/ACTIVE_WORK.yaml` as a mirror.
 3. Read `design/BRAND.md`, `DESIGN_SYSTEM.md`, `UX_PRINCIPLES.md`, `IMAGERY.md`, and the Visual System v2 documents.
 4. Read `docs/SITE-VISUAL-TASKS.md`.
 5. Confirm your task has one assigned owner and is not already IN PROGRESS elsewhere.

--- a/docs/ACTIVE-WORK-COORDINATION.md
+++ b/docs/ACTIVE-WORK-COORDINATION.md
@@ -1,0 +1,74 @@
+# DE Active Work Coordination
+
+Status: **MANDATORY companion** to `docs/AI-ENGINEERING-GOVERNANCE.md`.
+
+## Why this exists
+
+A claim committed only on an unmerged feature branch is invisible to agents that correctly inspect `origin/main`. On August 30, 2026, `.ai/ACTIVE_WORK.yaml` on `main` showed no claims while a substantial homepage/Ask DE implementation PR was still open. That proved the YAML file cannot be the sole concurrency lock.
+
+## Authoritative lock order
+
+Before editing code, every agent must inspect, in this order:
+
+1. **Open GitHub issues** marked or titled `ACTIVE`, `P0`, `IN PROGRESS`, recovery, or otherwise clearly describing current implementation ownership.
+2. **All open pull requests**, including changed files, head branch, base branch, and current mergeability.
+3. **Relevant remote branches** when a prior task/recovery branch is named.
+4. `.ai/ACTIVE_WORK.yaml` as a convenient mirror.
+5. `docs/SITE-VISUAL-TASKS.md` for visual work.
+
+GitHub-visible issues and PRs are authoritative because every agent can see them without first merging another agent's branch.
+
+## Starting work
+
+Create or update one GitHub issue before implementation. Record:
+
+- task id/title;
+- owner/integrator;
+- subsystem;
+- branch;
+- exact starting `origin/main` SHA;
+- expected files or globs;
+- dependencies/source PRs;
+- status;
+- explicit blockers.
+
+Then create an isolated branch/worktree. A YAML claim may mirror the issue, but the issue must exist first.
+
+## Collision rule
+
+If an open issue/PR overlaps the same component, route, subsystem, or expected files:
+
+- do not start a parallel rewrite;
+- link the existing work;
+- reconcile through the lead integrator;
+- preserve unique commits before closing/superseding anything.
+
+An empty YAML registry never means the repository is idle.
+
+## Local-only WIP
+
+Local-only code is an emergency preservation condition. Before continuing development:
+
+1. inspect uncommitted changes, local commits, stash, worktrees, and agent artifacts;
+2. commit recoverable work intact to a `recovery/*` branch before refactoring;
+3. create a GitHub recovery issue containing the original task, source environment, last known remote SHA, and recovery status;
+4. if the local state cannot be recovered, mark the implementation lost but keep the requirement tracked for rebuild.
+
+Never silently drop local WIP because another PR shipped around it.
+
+## Before merge
+
+Immediately before merge, repeat the GitHub issue/PR/branch audit and fetch latest `main`. If `main` moved after validation began, the branch must be reconciled and the applicable gates rerun. A previously green run does not cover commits that landed afterward.
+
+## Completion
+
+A task is released only when its actual status is recorded as one of:
+
+- `MERGED`
+- `VERIFIED LIVE`
+- `BLOCKED`
+- `ABANDONED`
+- `SUPERSEDED`
+- `LOST LOCAL IMPLEMENTATION — REQUIREMENT PRESERVED`
+
+Close the active GitHub issue/claim only when the state above is explicit and no recovery work remains.


### PR DESCRIPTION
P0 governance repair from August 30 reconciliation. Fixes the demonstrated flaw where branch-local `.ai/ACTIVE_WORK.yaml` could show no work on main while an active feature PR existed.

Changes:
- GitHub open ACTIVE/P0/IN PROGRESS issues + all open PRs + relevant remote branches become the authoritative concurrency locks.
- `.ai/ACTIVE_WORK.yaml` is explicitly a mirror, never the sole lock.
- Adds `docs/ACTIVE-WORK-COORDINATION.md` covering claim order, collision handling, local-WIP recovery, re-audit after main moves, and completion states.
- Updates `AGENTS.md` so every agent sees the rule at entry.

Docs/coordination only; no runtime behavior. Tracked by #126 and master #125. Do not confuse this with GitHub technical branch protection, which remains #124.