### PR TITLE
Fix Store jelly CSS bundle-budget regression

### DIFF
--- a/client/src/components/store/StorePageAtmosphere.tsx
+++ b/client/src/components/store/StorePageAtmosphere.tsx
@@ -1,10 +1,13 @@
 import { useRef } from "react";
 import { motion, useReducedMotion, useScroll, useTransform } from "framer-motion";
 import atmosphere from "@assets/de-section-atmosphere-electric.svg";
+import "../../styles/store-jelly.css";
 
 /**
  * Store field depth — electric lighting only (store accent lock).
  * Parallax is a few percent of travel and stops for reduced motion.
+ * Store-only motion CSS is imported here so Vite can keep it out of the
+ * global entry stylesheet and load it with Store/Solution Builder chunks.
  */
 export function StorePageAtmosphere() {
   const ref = useRef<HTMLDivElement>(null);

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,7 +1,6 @@
 import { createRoot } from "react-dom/client";
 import App from "./App";
 import "./index.css";
-import "./styles/store-jelly.css";
 import { initAnalytics } from "./lib/analytics";
 
 initAnalytics();


### PR DESCRIPTION
P0 regression repair after #137. The Store-only jelly stylesheet was imported from `client/src/main.tsx`, adding ~4 KB to every route's entry CSS and pushing the existing 290 KB budget over its hard limit.

This keeps the jelly motion unchanged but moves the stylesheet import to `StorePageAtmosphere`, which is already consumed by Store/Solution Builder surfaces. Vite can then code-split the Store-only CSS instead of charging every public page for it.

No budget increase. No pricing/data/Store behavior changes. Run full CI + Door 2 smoke before merge. After this lands, #116 must sync current main again and rerun its rendered 390/768/1440 smoke.