### PR TITLE
Portal marketplace: recognize DE staff instead of asking admins to request approval

### DIFF
--- a/client/src/pages/portal/PortalLayout.tsx
+++ b/client/src/pages/portal/PortalLayout.tsx
@@ -32,6 +32,7 @@ import {
   BarChart3,
   AlertTriangle,
   Briefcase,
+  Warehouse,
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import logoImage from "@assets/DE-Logo-new_1762461524794.webp";
@@ -86,6 +87,7 @@ const navItems: NavItem[] = [
 ];
 
 const adminItems = [
+  { href: "/internal/warehouse", label: "Digital Warehouse", icon: Warehouse },
   { href: "/portal/admin/companies", label: "Companies", icon: Building2 },
   { href: "/portal/admin/login-knocks", label: "Login Alerts", icon: Shield },
   { href: "/portal/admin/lifecycle", label: "Onboard / Offboard", icon: Users },

--- a/client/src/pages/portal/PortalMarketplace.tsx
+++ b/client/src/pages/portal/PortalMarketplace.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "wouter";
-import { ClipboardCheck, ShoppingCart } from "lucide-react";
+import { ClipboardCheck, ShoppingCart, Warehouse } from "lucide-react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { PortalLayout } from "./PortalLayout";
@@ -10,8 +10,9 @@ import { MARKETPLACE_ELIGIBILITY } from "@shared/checkoutEligibility";
 type MarketplaceResponse = {
   eligibility: typeof MARKETPLACE_ELIGIBILITY;
   items: unknown[];
-  status: "unavailable" | "unmapped";
+  status: "unavailable" | "unmapped" | "staff";
   reason: string;
+  warehouseUrl?: string;
 };
 
 export default function PortalMarketplace() {
@@ -19,6 +20,8 @@ export default function PortalMarketplace() {
     queryKey: ["/api/portal/marketplace"],
     queryFn: () => portalGet<MarketplaceResponse>("/api/portal/marketplace"),
   });
+
+  const isStaff = data?.status === "staff";
 
   return (
     <PortalLayout title="Client Marketplace">
@@ -37,36 +40,68 @@ export default function PortalMarketplace() {
           </div>
         )}
 
-        <Card data-testid="marketplace-empty">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <ShoppingCart className="h-5 w-5 text-[#D3126A]" />
-              Request Approval
-            </CardTitle>
-            <CardDescription>
-              {isLoading
-                ? "Checking your tenant catalog…"
-                : data?.reason || "Tenant catalog is not available from Hub yet."}
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <p className="text-sm text-gray-600 dark:text-gray-400">
-              Eligibility for this surface is <code>{data?.eligibility || MARKETPLACE_ELIGIBILITY}</code>.
-              No warehouse SKUs, vendors, costs, or margins are listed here.
-            </p>
-            <div className="flex flex-wrap gap-3">
-              <Button asChild className="bg-[#D3126A] text-white hover:bg-[#D3126A]/90">
-                <Link href="/portal/forms">
-                  <ClipboardCheck className="mr-2 h-4 w-4" />
-                  Request Approval
-                </Link>
-              </Button>
-              <Button asChild variant="outline">
-                <Link href="/portal/procurement">Open procurement</Link>
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
+        {isStaff ? (
+          <Card data-testid="marketplace-staff">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Warehouse className="h-5 w-5 text-[#D3126A]" />
+                DE Staff — Digital Warehouse
+              </CardTitle>
+              <CardDescription>
+                You are signed in as DE staff. This page is the client view — no approval
+                request is needed for your account.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                The full catalog with vendors, costs, and Pay Now lives in the staff-only
+                Digital Warehouse.
+              </p>
+              <div className="flex flex-wrap gap-3">
+                <Button asChild className="bg-[#D3126A] text-white hover:bg-[#D3126A]/90">
+                  <Link href={data?.warehouseUrl || "/internal/warehouse"}>
+                    <Warehouse className="mr-2 h-4 w-4" />
+                    Open Digital Warehouse
+                  </Link>
+                </Button>
+                <Button asChild variant="outline">
+                  <Link href="/portal/procurement">Open procurement</Link>
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        ) : (
+          <Card data-testid="marketplace-empty">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <ShoppingCart className="h-5 w-5 text-[#D3126A]" />
+                Request Approval
+              </CardTitle>
+              <CardDescription>
+                {isLoading
+                  ? "Checking your tenant catalog…"
+                  : data?.reason || "Tenant catalog is not available from Hub yet."}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                Eligibility for this surface is <code>{data?.eligibility || MARKETPLACE_ELIGIBILITY}</code>.
+                No warehouse SKUs, vendors, costs, or margins are listed here.
+              </p>
+              <div className="flex flex-wrap gap-3">
+                <Button asChild className="bg-[#D3126A] text-white hover:bg-[#D3126A]/90">
+                  <Link href="/portal/forms">
+                    <ClipboardCheck className="mr-2 h-4 w-4" />
+                    Request Approval
+                  </Link>
+                </Button>
+                <Button asChild variant="outline">
+                  <Link href="/portal/procurement">Open procurement</Link>
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        )}
       </div>
     </PortalLayout>
   );

--- a/docs/STORE-WAREHOUSE.md
+++ b/docs/STORE-WAREHOUSE.md
@@ -14,7 +14,7 @@ The former public `/store` workshop (SKU catalog, vendor marks, coverage heurist
 | Public curated Store | `/store`, `/store/solutions/:family`, `/store/solution` (`/store/checkout` alias) | Public Solution Builder — no vendor catalog, no Pay Now |
 | Legacy catalog paths | `/store/managed`, `/store/co-managed` | 301 to the appropriate public solution path |
 | Staff-only SKU URLs | `/store/product/:sku` except four ProActive models | Generic 404 — same body as unknown, no `Location` |
-| Client Marketplace | `/portal/marketplace` | Authenticated client; fail-safe Request Approval (no Hub catalog) |
+| Client Marketplace | `/portal/marketplace` | Authenticated client; fail-safe Request Approval (no Hub catalog). Live `admin` sees a staff notice pointing at `/internal/warehouse` instead of Request Approval — still no catalog data on this surface. |
 
 ## How staff open it
 

--- a/server/portalMarketplaceRoutes.test.ts
+++ b/server/portalMarketplaceRoutes.test.ts
@@ -1,35 +1,43 @@
 import express from "express";
 import { createServer, type Server } from "http";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { registerPortalMarketplaceRoutes } from "./portalMarketplaceRoutes";
+import { registerPortalMarketplaceRoutes, WAREHOUSE_PATH } from "./portalMarketplaceRoutes";
 import { MARKETPLACE_ELIGIBILITY } from "@shared/checkoutEligibility";
 
-describe("portal marketplace fail-safe", () => {
+type TestUser = { role?: string; clientId?: string | null };
+
+async function startApp(user: TestUser): Promise<{ server: Server; baseUrl: string }> {
+  const app = express();
+  const auth = (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    (req as express.Request & { user?: TestUser }).user = user;
+    next();
+  };
+  registerPortalMarketplaceRoutes(app, auth);
+  const server = createServer(app);
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("No test port");
+  return { server, baseUrl: `http://127.0.0.1:${address.port}` };
+}
+
+function stopServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+describe("portal marketplace fail-safe (client)", () => {
   let server: Server;
   let baseUrl = "";
 
   beforeAll(async () => {
-    const app = express();
-    const auth = (req: express.Request, _res: express.Response, next: express.NextFunction) => {
-      (req as express.Request & { user?: { clientId: string } }).user = {
-        clientId: "client-1",
-      };
-      next();
-    };
-    registerPortalMarketplaceRoutes(app, auth);
-    server = createServer(app);
-    await new Promise<void>((resolve) => {
-      server.listen(0, "127.0.0.1", resolve);
-    });
-    const address = server.address();
-    if (!address || typeof address === "string") throw new Error("No test port");
-    baseUrl = `http://127.0.0.1:${address.port}`;
+    ({ server, baseUrl } = await startApp({ role: "user", clientId: "client-1" }));
   });
 
   afterAll(async () => {
-    await new Promise<void>((resolve, reject) => {
-      server.close((error) => (error ? reject(error) : resolve()));
-    });
+    await stopServer(server);
   });
 
   it("returns an empty Request Approval catalog without warehouse fields", async () => {
@@ -39,6 +47,59 @@ describe("portal marketplace fail-safe", () => {
     expect(body.eligibility).toBe(MARKETPLACE_ELIGIBILITY);
     expect(body.items).toEqual([]);
     expect(body.status).toBe("unavailable");
+    const raw = JSON.stringify(body).toLowerCase();
+    expect(raw).not.toContain("sku");
+    expect(raw).not.toContain("margin");
+    expect(raw).not.toContain("ninjaone");
+    expect(raw).not.toContain("pay_now");
+    expect(raw).not.toContain("warehouse");
+  });
+});
+
+describe("portal marketplace unmapped account", () => {
+  let server: Server;
+  let baseUrl = "";
+
+  beforeAll(async () => {
+    ({ server, baseUrl } = await startApp({ role: "user", clientId: null }));
+  });
+
+  afterAll(async () => {
+    await stopServer(server);
+  });
+
+  it("does not point unmapped non-staff accounts at the warehouse", async () => {
+    const response = await fetch(`${baseUrl}/api/portal/marketplace`);
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.status).toBe("unmapped");
+    expect(body.eligibility).toBe(MARKETPLACE_ELIGIBILITY);
+    const raw = JSON.stringify(body).toLowerCase();
+    expect(raw).not.toContain("warehouse");
+    expect(raw).not.toContain("pay_now");
+  });
+});
+
+describe("portal marketplace staff account", () => {
+  let server: Server;
+  let baseUrl = "";
+
+  beforeAll(async () => {
+    ({ server, baseUrl } = await startApp({ role: "admin", clientId: null }));
+  });
+
+  afterAll(async () => {
+    await stopServer(server);
+  });
+
+  it("identifies staff and points at the warehouse without exposing catalog data", async () => {
+    const response = await fetch(`${baseUrl}/api/portal/marketplace`);
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.status).toBe("staff");
+    expect(body.warehouseUrl).toBe(WAREHOUSE_PATH);
+    expect(body.eligibility).toBe(MARKETPLACE_ELIGIBILITY);
+    expect(body.items).toEqual([]);
     const raw = JSON.stringify(body).toLowerCase();
     expect(raw).not.toContain("sku");
     expect(raw).not.toContain("margin");

--- a/server/portalMarketplaceRoutes.ts
+++ b/server/portalMarketplaceRoutes.ts
@@ -5,6 +5,8 @@ type AuthedRequest = Request & {
   user?: { role?: string; clientId?: string | null };
 };
 
+export const WAREHOUSE_PATH = "/internal/warehouse";
+
 export function registerPortalMarketplaceRoutes(
   app: Express,
   authMiddleware: (req: AuthedRequest, res: Response, next: NextFunction) => unknown,
@@ -13,8 +15,23 @@ export function registerPortalMarketplaceRoutes(
     "/api/portal/marketplace",
     authMiddleware,
     (req: AuthedRequest, res: Response) => {
-      const clientId = req.user?.clientId ?? null;
       res.setHeader("Cache-Control", "no-store");
+
+      // authMiddleware resolves role from the live portal record (never the JWT
+      // claim), so this branch cannot be reached with a stale admin token.
+      if (req.user?.role === "admin") {
+        res.json({
+          eligibility: MARKETPLACE_ELIGIBILITY,
+          items: [],
+          status: "staff",
+          reason:
+            "DE staff account — this surface is the client view. Use the Digital Warehouse.",
+          warehouseUrl: WAREHOUSE_PATH,
+        });
+        return;
+      }
+
+      const clientId = req.user?.clientId ?? null;
       res.json({
         eligibility: MARKETPLACE_ELIGIBILITY,
         items: [],


### PR DESCRIPTION
## Problem

The admin/owner landing on `/portal/marketplace` (via the store's "Open Client Marketplace" link or a direct visit) was shown the client-tenant fail-safe: "This account is not mapped to a client tenant" + a **Request Approval** CTA. The endpoint never checked role, so DE staff got the end-client treatment.

## Changes

- **`server/portalMarketplaceRoutes.ts`** — live-admin sessions now get `status: "staff"` with `warehouseUrl: "/internal/warehouse"`. Role comes from the live portal record via `authMiddleware` (never the JWT claim), so a stale admin token cannot reach the staff branch. The marketplace payload still carries no SKUs, vendors, margins, or `pay_now`.
- **`client/src/pages/portal/PortalMarketplace.tsx`** — staff see a "DE Staff — Digital Warehouse" card with an Open Digital Warehouse button instead of the Request Approval card. Client rendering is unchanged.
- **`client/src/pages/portal/PortalLayout.tsx`** — Admin sidebar section gains a direct **Digital Warehouse** link to `/internal/warehouse`.
- **`server/portalMarketplaceRoutes.test.ts`** — now covers mapped client, unmapped non-staff (asserts no warehouse pointer), and staff (asserts pointer + no catalog leakage).
- **`docs/STORE-WAREHOUSE.md`** — surface table updated for the staff branch.

## Verification

- `vitest run` on marketplace, eligibility, and warehouse-access suites: 7/7 pass.
- `npm run check` (tsc): clean.
- Live portal click-through not performed (requires Joe's admin login); page logic branches solely on the API `status` field covered by tests.

Baseline: current `origin/main` (8a20592). MERGED ≠ LIVE — production is only LIVE once RackNerd serves the merged SHA and health checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)