### PR TITLE
chore: release stale fable-visual-batch active-work claim

### DIFF
--- a/.ai/ACTIVE_WORK.yaml
+++ b/.ai/ACTIVE_WORK.yaml
@@ -29,22 +29,12 @@
 #     started: 2026-08-30
 
 version: 2
-claims:
-  # homepage-ask-de-reference-redesign (issue 118, branch
-  # claude/homepage-ask-de-visual-19b3aa) RETIRED 2026-08-31: integrated via
-  # PR #147 (main @ 9c5e7f9, production-verified). PR #146 closed unmerged.
-  # That branch is no longer a release lane.
-  - id: fable-visual-batch
-    issue: 118
-    owner: claude
-    subsystem: homepage-support-chrome
-    branch: claude/fable-visual-batch
-    base_sha: 9c5e7f95fa7effde99698cd4c40d8c2c6d335df3
-    files:
-      - client/src/pages/sections/ReferenceHeroSection.tsx
-      - client/src/components/ZohoASAPWidget.tsx
-      - client/src/components/deDeskReferenceStyle.ts
-      - client/src/components/SiteBottomBar.tsx
-      - client/src/pages/about/MissionValues.tsx
-    status: active
-    started: 2026-08-31
+claims: []
+# fable-visual-batch (issue 118, branch claude/fable-visual-batch) RETIRED
+# 2026-08-31: merged via PR #148 (main @ 8a20592). Confirmed
+# `git diff origin/main origin/claude/fable-visual-batch` is empty — no
+# unique commits remain on that branch. Production-verified live at
+# https://digeratiexperts.com/ (redesigned hero + Ask DE chooser rendering).
+# homepage-ask-de-reference-redesign (branch claude/homepage-ask-de-visual-19b3aa)
+# was RETIRED earlier the same day, integrated via PR #147 (main @ 9c5e7f9).
+# PR #146 closed unmerged; that branch was never a release lane.


### PR DESCRIPTION
Corrects a stale claim in .ai/ACTIVE_WORK.yaml. PR #148 (branch claude/fable-visual-batch) merged and is fully absorbed into main (confirmed: `git diff origin/main origin/claude/fable-visual-batch` is empty) and production-verified live at https://digeratiexperts.com/. Posted the correction to issue #118. No functional change.