### PR TITLE
Recover pronunciation card + production-native PDF flipbook

### DIFF
--- a/.ai/ACTIVE_WORK.yaml
+++ b/.ai/ACTIVE_WORK.yaml
@@ -29,7 +29,23 @@
 #     started: 2026-08-30
 
 version: 2
-claims: []
+claims:
+  - id: pronunciation-flipbook-recovery
+    issue: 152
+    owner: chatgpt
+    subsystem: homepage-resources
+    branch: chatgpt/pronunciation-flipbook-recovery-20260831
+    base_sha: ecea1d9314f859bd5a17343c277e739f3bedb492
+    files:
+      - client/src/components/PronunciationCard.tsx
+      - client/src/pages/sections/ReferenceHeroSection.tsx
+      - client/src/pages/resources/DocumentFlipbook.tsx
+      - client/src/pages/resources/ResourcesIndex.tsx
+      - client/public/audio/README.md
+      - scripts/vendor-pdfjs.mjs
+      - package.json
+    status: active
+    started: 2026-08-31
 # fable-visual-batch (issue 118, branch claude/fable-visual-batch) RETIRED
 # 2026-08-31: merged via PR #148 (main @ 8a20592). Confirmed
 # `git diff origin/main origin/claude/fable-visual-batch` is empty — no

--- a/client/public/audio/README.md
+++ b/client/public/audio/README.md
@@ -1,0 +1,12 @@
+# Digerati pronunciation audio
+
+The homepage pronunciation card currently uses the browser's built-in speech synthesis as a no-download fallback for **dij-uh-RAH-tee** (`/ˌdɪdʒəˈrɑːti/`).
+
+For the canonical DE voice, add a clean human recording here as `digerati-pronunciation.mp3` (and optionally an Opus/WebM alternate), then update `client/src/components/PronunciationCard.tsx` to prefer that file while retaining speech synthesis as the accessibility/offline fallback.
+
+Recording target:
+- Spoken phrase only: “dij-uh-RAH-tee”
+- Neutral, confident delivery
+- No music, reverb, or background bed
+- Normalize conservatively; avoid clipping
+- Keep the file small because it is homepage media

--- a/client/src/components/PronunciationCard.tsx
+++ b/client/src/components/PronunciationCard.tsx
@@ -1,0 +1,78 @@
+import { useState } from "react";
+import { Play, Volume2 } from "lucide-react";
+
+const SPOKEN_PRONUNCIATION = "dij-uh-RAH-tee";
+
+interface PronunciationCardProps {
+  className?: string;
+}
+
+export function PronunciationCard({ className = "" }: PronunciationCardProps): JSX.Element {
+  const [status, setStatus] = useState("Ready to play pronunciation.");
+
+  const playPronunciation = () => {
+    if (!("speechSynthesis" in window) || typeof SpeechSynthesisUtterance === "undefined") {
+      setStatus("Audio pronunciation is not supported in this browser. Say dij-uh-RAH-tee.");
+      return;
+    }
+
+    window.speechSynthesis.cancel();
+    const utterance = new SpeechSynthesisUtterance(SPOKEN_PRONUNCIATION);
+    utterance.lang = "en-US";
+    utterance.rate = 0.78;
+    utterance.pitch = 1;
+    utterance.volume = 1;
+    utterance.onstart = () => setStatus("Playing pronunciation: dij-uh-RAH-tee.");
+    utterance.onend = () => setStatus("Pronunciation finished.");
+    utterance.onerror = () => setStatus("Audio could not play. Say dij-uh-RAH-tee.");
+    window.speechSynthesis.speak(utterance);
+  };
+
+  return (
+    <aside
+      className={`overflow-hidden rounded-2xl border border-white/15 bg-black/35 shadow-[0_24px_70px_-42px_rgba(123,108,255,0.8)] backdrop-blur-md ${className}`}
+      aria-label="How to pronounce Digerati"
+      data-testid="digerati-pronunciation-card"
+    >
+      <div className="grid gap-0 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-stretch">
+        <div className="px-5 py-4 sm:px-6">
+          <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+            <span className="font-heading text-[1.55rem] font-semibold tracking-[-0.035em] text-white">
+              di·ger·a·ti
+            </span>
+            <span className="font-mono text-sm text-white/55">/ˌdɪdʒəˈrɑːti/</span>
+          </div>
+          <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1">
+            <span className="font-mono text-[15px] font-semibold tracking-[0.04em] text-[#b9afff]">
+              dij-uh-RAH-tee
+            </span>
+            <span className="text-xs font-medium uppercase tracking-[0.14em] text-white/42">
+              Say it with confidence.
+            </span>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          onClick={playPronunciation}
+          className="group flex min-h-14 items-center justify-center gap-2 border-t border-white/10 bg-white/[0.045] px-5 text-sm font-semibold text-white transition hover:bg-white/[0.085] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[#9a8bff] sm:min-w-28 sm:border-l sm:border-t-0"
+          aria-label="Play pronunciation: dij-uh-RAH-tee"
+          data-testid="button-play-digerati-pronunciation"
+        >
+          <span className="relative flex h-8 w-8 items-center justify-center rounded-full border border-[#9a8bff]/55 bg-[#7b6cff]/15 transition group-hover:bg-[#7b6cff]/25">
+            <Play className="ml-0.5 h-3.5 w-3.5 fill-current" aria-hidden="true" />
+          </span>
+          <span className="inline-flex items-center gap-1.5">
+            <Volume2 className="h-3.5 w-3.5 text-white/60" aria-hidden="true" />
+            Hear it
+          </span>
+        </button>
+      </div>
+      <p className="sr-only" role="status" aria-live="polite">
+        {status}
+      </p>
+    </aside>
+  );
+}
+
+export default PronunciationCard;

--- a/client/src/components/PronunciationCard.tsx
+++ b/client/src/components/PronunciationCard.tsx
@@ -30,23 +30,33 @@ export function PronunciationCard({ className = "" }: PronunciationCardProps): J
 
   return (
     <aside
-      className={`overflow-hidden rounded-2xl border border-white/15 bg-black/35 shadow-[0_24px_70px_-42px_rgba(123,108,255,0.8)] backdrop-blur-md ${className}`}
+      className={`overflow-hidden rounded-2xl border border-de-hairline bg-de-raised backdrop-blur-md ${className}`}
+      style={{ boxShadow: "0 24px 70px -42px rgba(123,108,255,0.8)" }}
       aria-label="How to pronounce Digerati"
       data-testid="digerati-pronunciation-card"
     >
-      <div className="grid gap-0 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-stretch">
+      <div className="grid sm:grid-cols-[minmax(0,1fr)_auto]">
         <div className="px-5 py-4 sm:px-6">
           <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-            <span className="font-heading text-[1.55rem] font-semibold tracking-[-0.035em] text-white">
+            <span
+              className="font-heading font-semibold text-white"
+              style={{ fontSize: "1.55rem", letterSpacing: "-0.035em" }}
+            >
               di·ger·a·ti
             </span>
-            <span className="font-mono text-sm text-white/55">/ˌdɪdʒəˈrɑːti/</span>
+            <span className="font-mono text-sm text-de-muted-soft">/ˌdɪdʒəˈrɑːti/</span>
           </div>
           <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1">
-            <span className="font-mono text-[15px] font-semibold tracking-[0.04em] text-[#b9afff]">
+            <span
+              className="font-mono font-semibold text-de-accent-ink"
+              style={{ fontSize: 15, letterSpacing: "0.04em" }}
+            >
               dij-uh-RAH-tee
             </span>
-            <span className="text-xs font-medium uppercase tracking-[0.14em] text-white/42">
+            <span
+              className="text-xs font-medium uppercase text-de-muted-soft"
+              style={{ letterSpacing: "0.14em" }}
+            >
               Say it with confidence.
             </span>
           </div>
@@ -55,15 +65,19 @@ export function PronunciationCard({ className = "" }: PronunciationCardProps): J
         <button
           type="button"
           onClick={playPronunciation}
-          className="group flex min-h-14 items-center justify-center gap-2 border-t border-white/10 bg-white/[0.045] px-5 text-sm font-semibold text-white transition hover:bg-white/[0.085] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[#9a8bff] sm:min-w-28 sm:border-l sm:border-t-0"
+          className="group flex min-h-14 items-center justify-center gap-2 border-t border-de-hairline bg-de-bg px-5 text-sm font-semibold text-white transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset sm:border-l sm:border-t-0"
+          style={{ minWidth: 112 }}
           aria-label="Play pronunciation: dij-uh-RAH-tee"
           data-testid="button-play-digerati-pronunciation"
         >
-          <span className="relative flex h-8 w-8 items-center justify-center rounded-full border border-[#9a8bff]/55 bg-[#7b6cff]/15 transition group-hover:bg-[#7b6cff]/25">
+          <span
+            className="flex h-8 w-8 items-center justify-center rounded-full border border-de-hairline transition group-hover:bg-white/10"
+            style={{ background: "rgba(123,108,255,0.15)" }}
+          >
             <Play className="ml-0.5 h-3.5 w-3.5 fill-current" aria-hidden="true" />
           </span>
           <span className="inline-flex items-center gap-1.5">
-            <Volume2 className="h-3.5 w-3.5 text-white/60" aria-hidden="true" />
+            <Volume2 className="h-3.5 w-3.5 text-de-muted-soft" aria-hidden="true" />
             Hear it
           </span>
         </button>

--- a/client/src/components/PronunciationCard.tsx
+++ b/client/src/components/PronunciationCard.tsx
@@ -30,7 +30,7 @@ export function PronunciationCard({ className = "" }: PronunciationCardProps): J
 
   return (
     <aside
-      className={`overflow-hidden rounded-2xl border border-de-hairline bg-de-raised backdrop-blur-md ${className}`}
+      className={`overflow-hidden rounded-2xl border border-de-hairline bg-de-raised ${className}`}
       style={{ boxShadow: "0 24px 70px -42px rgba(123,108,255,0.8)" }}
       aria-label="How to pronounce Digerati"
       data-testid="digerati-pronunciation-card"
@@ -65,13 +65,13 @@ export function PronunciationCard({ className = "" }: PronunciationCardProps): J
         <button
           type="button"
           onClick={playPronunciation}
-          className="group flex min-h-14 items-center justify-center gap-2 border-t border-de-hairline bg-de-bg px-5 text-sm font-semibold text-white transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset sm:border-l sm:border-t-0"
+          className="flex min-h-14 items-center justify-center gap-2 border-t border-de-hairline bg-de-bg px-5 text-sm font-semibold text-white transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset sm:border-l sm:border-t-0"
           style={{ minWidth: 112 }}
           aria-label="Play pronunciation: dij-uh-RAH-tee"
           data-testid="button-play-digerati-pronunciation"
         >
           <span
-            className="flex h-8 w-8 items-center justify-center rounded-full border border-de-hairline transition group-hover:bg-white/10"
+            className="flex h-8 w-8 items-center justify-center rounded-full border border-de-hairline"
             style={{ background: "rgba(123,108,255,0.15)" }}
           >
             <Play className="ml-0.5 h-3.5 w-3.5 fill-current" aria-hidden="true" />

--- a/client/src/pages/resources/DocumentFlipbook.tsx
+++ b/client/src/pages/resources/DocumentFlipbook.tsx
@@ -1,0 +1,409 @@
+import { ChangeEvent, DragEvent, KeyboardEvent, useEffect, useRef, useState } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { ArrowLeft, ArrowRight, BookOpen, ExternalLink, FileText, LockKeyhole, Upload } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+type PdfViewport = { width: number; height: number };
+type PdfRenderTask = { promise: Promise<void>; cancel?: () => void };
+type PdfPage = {
+  getViewport: (options: { scale: number }) => PdfViewport;
+  render: (options: { canvasContext: CanvasRenderingContext2D; viewport: PdfViewport }) => PdfRenderTask;
+};
+type PdfDocument = {
+  numPages: number;
+  getPage: (pageNumber: number) => Promise<PdfPage>;
+  destroy?: () => Promise<void> | void;
+};
+type PdfLoadingTask = {
+  promise: Promise<PdfDocument>;
+  destroy?: () => Promise<void> | void;
+};
+type PdfJs = {
+  GlobalWorkerOptions: { workerSrc: string };
+  getDocument: (options: { data: Uint8Array; isEvalSupported: boolean }) => PdfLoadingTask;
+};
+
+declare global {
+  interface Window {
+    pdfjsLib?: PdfJs;
+  }
+}
+
+const PDFJS_SCRIPT = "/vendor/pdfjs/pdf.js";
+const PDFJS_WORKER = "/vendor/pdfjs/pdf.worker.js";
+const MAX_PDF_BYTES = 75 * 1024 * 1024;
+let pdfJsPromise: Promise<PdfJs> | null = null;
+
+function loadPdfJs(): Promise<PdfJs> {
+  if (window.pdfjsLib) {
+    window.pdfjsLib.GlobalWorkerOptions.workerSrc = PDFJS_WORKER;
+    return Promise.resolve(window.pdfjsLib);
+  }
+  if (pdfJsPromise) return pdfJsPromise;
+
+  pdfJsPromise = new Promise<PdfJs>((resolve, reject) => {
+    const existing = document.querySelector<HTMLScriptElement>(`script[src="${PDFJS_SCRIPT}"]`);
+    const script = existing ?? document.createElement("script");
+
+    const ready = () => {
+      if (!window.pdfjsLib) {
+        pdfJsPromise = null;
+        reject(new Error("PDF engine loaded without exposing pdfjsLib."));
+        return;
+      }
+      window.pdfjsLib.GlobalWorkerOptions.workerSrc = PDFJS_WORKER;
+      resolve(window.pdfjsLib);
+    };
+
+    const failed = () => {
+      pdfJsPromise = null;
+      reject(new Error("The local PDF engine could not be loaded."));
+    };
+
+    script.addEventListener("load", ready, { once: true });
+    script.addEventListener("error", failed, { once: true });
+
+    if (!existing) {
+      script.src = PDFJS_SCRIPT;
+      script.async = true;
+      script.dataset.dePdfjs = "true";
+      document.head.appendChild(script);
+    }
+  });
+
+  return pdfJsPromise;
+}
+
+function isPdf(file: File): boolean {
+  return file.type === "application/pdf" || file.name.toLowerCase().endsWith(".pdf");
+}
+
+function looksLikeOfficeDocument(file: File): boolean {
+  return /\.(doc|docx|ppt|pptx)$/i.test(file.name);
+}
+
+function pageLabel(start: number, pageCount: number, spread: boolean): string {
+  if (!spread || start >= pageCount) return `Page ${start} of ${pageCount}`;
+  return `Pages ${start}–${Math.min(start + 1, pageCount)} of ${pageCount}`;
+}
+
+export function DocumentFlipbook(): JSX.Element {
+  const prefersReducedMotion = useReducedMotion();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const leftCanvasRef = useRef<HTMLCanvasElement>(null);
+  const rightCanvasRef = useRef<HTMLCanvasElement>(null);
+  const documentRef = useRef<PdfDocument | null>(null);
+  const loadingTaskRef = useRef<PdfLoadingTask | null>(null);
+  const objectUrlRef = useRef<string | null>(null);
+  const renderGeneration = useRef(0);
+
+  const [fileName, setFileName] = useState("");
+  const [originalUrl, setOriginalUrl] = useState("");
+  const [pageCount, setPageCount] = useState(0);
+  const [pageStart, setPageStart] = useState(1);
+  const [isWide, setIsWide] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isRendering, setIsRendering] = useState(false);
+  const [error, setError] = useState("");
+  const [dragActive, setDragActive] = useState(false);
+
+  useEffect(() => {
+    const media = window.matchMedia("(min-width: 768px)");
+    const update = () => setIsWide(media.matches);
+    update();
+    media.addEventListener("change", update);
+    return () => media.removeEventListener("change", update);
+  }, []);
+
+  useEffect(() => {
+    setPageStart((current) => {
+      const step = isWide ? 2 : 1;
+      const aligned = Math.floor((Math.max(current, 1) - 1) / step) * step + 1;
+      return Math.min(aligned, Math.max(1, pageCount));
+    });
+  }, [isWide, pageCount]);
+
+  useEffect(() => {
+    const pdf = documentRef.current;
+    if (!pdf || pageCount === 0) return;
+
+    const generation = ++renderGeneration.current;
+    let cancelled = false;
+    const tasks: PdfRenderTask[] = [];
+
+    const renderPage = async (pageNumber: number, canvas: HTMLCanvasElement | null) => {
+      if (!canvas || pageNumber > pageCount) {
+        if (canvas) {
+          const context = canvas.getContext("2d");
+          context?.clearRect(0, 0, canvas.width, canvas.height);
+          canvas.style.display = "none";
+        }
+        return;
+      }
+
+      canvas.style.display = "block";
+      const page = await pdf.getPage(pageNumber);
+      if (cancelled || generation !== renderGeneration.current) return;
+
+      const baseViewport = page.getViewport({ scale: 1 });
+      const hostWidth = Math.max(canvas.parentElement?.clientWidth ?? 600, 280);
+      const availableWidth = isWide ? Math.max((hostWidth - 18) / 2, 260) : hostWidth;
+      const cssWidth = Math.min(availableWidth, 720);
+      const cssScale = cssWidth / baseViewport.width;
+      const pixelRatio = Math.min(window.devicePixelRatio || 1, 2);
+      const viewport = page.getViewport({ scale: cssScale * pixelRatio });
+      const context = canvas.getContext("2d", { alpha: false });
+      if (!context) throw new Error("Canvas rendering is unavailable in this browser.");
+
+      canvas.width = Math.ceil(viewport.width);
+      canvas.height = Math.ceil(viewport.height);
+      canvas.style.width = `${Math.round(viewport.width / pixelRatio)}px`;
+      canvas.style.height = `${Math.round(viewport.height / pixelRatio)}px`;
+      context.save();
+      context.fillStyle = "#ffffff";
+      context.fillRect(0, 0, canvas.width, canvas.height);
+      context.restore();
+
+      const task = page.render({ canvasContext: context, viewport });
+      tasks.push(task);
+      await task.promise;
+    };
+
+    setIsRendering(true);
+    setError("");
+
+    void Promise.all([
+      renderPage(pageStart, leftCanvasRef.current),
+      renderPage(isWide ? pageStart + 1 : pageCount + 1, rightCanvasRef.current),
+    ])
+      .catch((reason: unknown) => {
+        if (!cancelled) {
+          setError(reason instanceof Error ? reason.message : "This page could not be rendered.");
+        }
+      })
+      .finally(() => {
+        if (!cancelled && generation === renderGeneration.current) setIsRendering(false);
+      });
+
+    return () => {
+      cancelled = true;
+      tasks.forEach((task) => task.cancel?.());
+    };
+  }, [isWide, pageCount, pageStart]);
+
+  useEffect(() => {
+    return () => {
+      renderGeneration.current += 1;
+      void loadingTaskRef.current?.destroy?.();
+      void documentRef.current?.destroy?.();
+      if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
+    };
+  }, []);
+
+  const clearCurrentDocument = async () => {
+    renderGeneration.current += 1;
+    await loadingTaskRef.current?.destroy?.();
+    await documentRef.current?.destroy?.();
+    loadingTaskRef.current = null;
+    documentRef.current = null;
+    if (objectUrlRef.current) {
+      URL.revokeObjectURL(objectUrlRef.current);
+      objectUrlRef.current = null;
+    }
+    setOriginalUrl("");
+    setPageCount(0);
+    setPageStart(1);
+  };
+
+  const loadFile = async (file: File) => {
+    setError("");
+
+    if (looksLikeOfficeDocument(file)) {
+      setError("Word and PowerPoint files need to be exported as PDF first. This viewer does not upload your document to a conversion service.");
+      return;
+    }
+    if (!isPdf(file)) {
+      setError("Choose a PDF file. Word and PowerPoint documents can be exported to PDF before opening them here.");
+      return;
+    }
+    if (file.size > MAX_PDF_BYTES) {
+      setError("This PDF is larger than 75 MB. Use a smaller or optimized PDF so the browser can render it safely.");
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      await clearCurrentDocument();
+      const pdfjs = await loadPdfJs();
+      const buffer = await file.arrayBuffer();
+      const loadingTask = pdfjs.getDocument({ data: new Uint8Array(buffer), isEvalSupported: false });
+      loadingTaskRef.current = loadingTask;
+      const pdf = await loadingTask.promise;
+      documentRef.current = pdf;
+      const objectUrl = URL.createObjectURL(file);
+      objectUrlRef.current = objectUrl;
+      setOriginalUrl(objectUrl);
+      setFileName(file.name);
+      setPageCount(pdf.numPages);
+      setPageStart(1);
+    } catch (reason: unknown) {
+      await clearCurrentDocument();
+      setFileName("");
+      setError(reason instanceof Error ? reason.message : "The PDF could not be opened.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const onInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) void loadFile(file);
+    event.target.value = "";
+  };
+
+  const onDrop = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setDragActive(false);
+    const file = event.dataTransfer.files?.[0];
+    if (file) void loadFile(file);
+  };
+
+  const step = isWide ? 2 : 1;
+  const canGoPrevious = pageStart > 1;
+  const canGoNext = pageStart + step <= pageCount;
+  const goPrevious = () => setPageStart((current) => Math.max(1, current - step));
+  const goNext = () => setPageStart((current) => Math.min(Math.max(1, pageCount), current + step));
+
+  const onViewerKeyDown = (event: KeyboardEvent<HTMLElement>) => {
+    if (event.key === "ArrowLeft" && canGoPrevious) {
+      event.preventDefault();
+      goPrevious();
+    }
+    if (event.key === "ArrowRight" && canGoNext) {
+      event.preventDefault();
+      goNext();
+    }
+    if (event.key === "Home" && pageCount > 0) {
+      event.preventDefault();
+      setPageStart(1);
+    }
+    if (event.key === "End" && pageCount > 0) {
+      event.preventDefault();
+      const lastStart = isWide ? Math.max(1, pageCount % 2 === 0 ? pageCount - 1 : pageCount) : pageCount;
+      setPageStart(lastStart);
+    }
+  };
+
+  return (
+    <section
+      id="document-flipbook"
+      className="scroll-mt-[calc(var(--de-nav-offset)+1rem)] pt-16"
+      aria-labelledby="document-flipbook-title"
+      onKeyDown={onViewerKeyDown}
+    >
+      <div className="overflow-hidden rounded-3xl border border-de-hairline bg-[#070513] shadow-[0_35px_90px_-60px_rgba(123,108,255,0.75)]">
+        <div className="grid gap-8 border-b border-white/10 px-5 py-8 sm:px-8 lg:grid-cols-[minmax(0,0.85fr)_minmax(0,1.15fr)] lg:px-10 lg:py-10">
+          <div>
+            <div className="inline-flex items-center gap-2 rounded-full border border-[#7b6cff]/30 bg-[#7b6cff]/10 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.14em] text-[#b9afff]">
+              <BookOpen className="h-3.5 w-3.5" aria-hidden="true" />
+              Browser-local viewer
+            </div>
+            <h2 id="document-flipbook-title" className="mt-4 font-heading text-3xl font-semibold tracking-[-0.035em] text-white sm:text-4xl">
+              Digital Document Flipbook
+            </h2>
+            <p className="mt-4 max-w-2xl text-base leading-7 text-white/65">
+              Open a PDF and read it like a responsive book. On larger screens you get a two-page spread; phones use one page at a time.
+            </p>
+            <div className="mt-5 flex items-start gap-3 rounded-xl border border-emerald-400/15 bg-emerald-400/[0.06] p-4 text-sm leading-6 text-white/68">
+              <LockKeyhole className="mt-0.5 h-4 w-4 shrink-0 text-emerald-300" aria-hidden="true" />
+              <p>
+                <strong className="font-semibold text-white/90">Private by design:</strong> the selected PDF is read and rendered in your browser. It is not uploaded to Digerati Experts.
+              </p>
+            </div>
+          </div>
+
+          <div
+            className={`flex min-h-52 flex-col items-center justify-center rounded-2xl border border-dashed px-6 py-8 text-center transition ${dragActive ? "border-[#9a8bff] bg-[#7b6cff]/12" : "border-white/20 bg-white/[0.035]"}`}
+            onDragEnter={(event) => { event.preventDefault(); setDragActive(true); }}
+            onDragOver={(event) => event.preventDefault()}
+            onDragLeave={() => setDragActive(false)}
+            onDrop={onDrop}
+          >
+            <input ref={inputRef} type="file" accept="application/pdf,.pdf,.doc,.docx,.ppt,.pptx" className="sr-only" onChange={onInputChange} />
+            <span className="flex h-12 w-12 items-center justify-center rounded-2xl border border-white/10 bg-white/[0.055] text-[#b9afff]">
+              <Upload className="h-5 w-5" aria-hidden="true" />
+            </span>
+            <p className="mt-4 text-base font-semibold text-white">Drop a PDF here</p>
+            <p className="mt-1 text-sm text-white/48">or choose one from this device · up to 75 MB</p>
+            <Button type="button" variant="outline" className="mt-5 border-white/20 bg-white/5 text-white hover:bg-white/10 hover:text-white" onClick={() => inputRef.current?.click()} disabled={isLoading}>
+              <FileText className="mr-2 h-4 w-4" aria-hidden="true" />
+              {isLoading ? "Opening PDF…" : "Choose document"}
+            </Button>
+            <p className="mt-4 max-w-md text-xs leading-5 text-white/40">
+              Word or PowerPoint? Export it to PDF first. We deliberately do not send Office files to a third-party converter.
+            </p>
+          </div>
+        </div>
+
+        {error && (
+          <div className="border-b border-red-300/15 bg-red-300/[0.06] px-5 py-3 text-sm text-red-100 sm:px-8 lg:px-10" role="alert">
+            {error}
+          </div>
+        )}
+
+        {pageCount > 0 ? (
+          <div className="p-4 sm:p-6 lg:p-8">
+            <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+              <div className="min-w-0">
+                <p className="truncate text-sm font-semibold text-white" title={fileName}>{fileName}</p>
+                <p className="mt-0.5 text-xs text-white/45">{pageLabel(pageStart, pageCount, isWide)}{isRendering ? " · rendering" : ""}</p>
+              </div>
+              <div className="flex items-center gap-2">
+                {originalUrl && (
+                  <a href={originalUrl} target="_blank" rel="noreferrer" className="inline-flex h-9 items-center gap-1.5 rounded-lg border border-white/15 px-3 text-xs font-semibold text-white/70 transition hover:bg-white/[0.06] hover:text-white">
+                    Original
+                    <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+                  </a>
+                )}
+                <Button type="button" variant="outline" size="icon" className="h-9 w-9 border-white/15 bg-white/[0.035] text-white hover:bg-white/[0.08] hover:text-white" onClick={goPrevious} disabled={!canGoPrevious} aria-label="Previous page">
+                  <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+                </Button>
+                <Button type="button" variant="outline" size="icon" className="h-9 w-9 border-white/15 bg-white/[0.035] text-white hover:bg-white/[0.08] hover:text-white" onClick={goNext} disabled={!canGoNext} aria-label="Next page">
+                  <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                </Button>
+              </div>
+            </div>
+
+            <div className="relative overflow-hidden rounded-2xl border border-white/10 bg-[#0b0915] p-3 shadow-inner sm:p-5" tabIndex={0} aria-label="PDF flipbook. Use left and right arrow keys to change pages.">
+              <AnimatePresence mode="wait" initial={false}>
+                <motion.div
+                  key={`${pageStart}-${isWide ? "spread" : "single"}`}
+                  initial={prefersReducedMotion ? false : { opacity: 0.72, rotateY: 4, x: 8 }}
+                  animate={{ opacity: 1, rotateY: 0, x: 0 }}
+                  exit={prefersReducedMotion ? undefined : { opacity: 0.72, rotateY: -4, x: -8 }}
+                  transition={{ duration: prefersReducedMotion ? 0 : 0.2, ease: "easeOut" }}
+                  className="mx-auto flex min-h-72 w-full items-start justify-center gap-[18px] [perspective:1400px]"
+                >
+                  <canvas ref={leftCanvasRef} className="max-w-full rounded-md bg-white shadow-[0_18px_45px_-24px_rgba(0,0,0,0.9)]" aria-label={`PDF page ${pageStart}`} />
+                  <canvas ref={rightCanvasRef} className="hidden max-w-[calc(50%-9px)] rounded-md bg-white shadow-[0_18px_45px_-24px_rgba(0,0,0,0.9)] md:block" aria-label={isWide && pageStart + 1 <= pageCount ? `PDF page ${pageStart + 1}` : undefined} />
+                </motion.div>
+              </AnimatePresence>
+            </div>
+
+            <div className="mt-4 flex items-center justify-center gap-3 text-xs text-white/45">
+              <span>← / → pages</span>
+              <span aria-hidden="true">·</span>
+              <span>Home / End jump</span>
+            </div>
+          </div>
+        ) : (
+          <div className="flex min-h-40 items-center justify-center px-5 py-10 text-center text-sm text-white/42">
+            Choose a PDF above to start the flipbook.
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+export default DocumentFlipbook;

--- a/client/src/pages/resources/DocumentFlipbook.tsx
+++ b/client/src/pages/resources/DocumentFlipbook.tsx
@@ -297,56 +297,77 @@ export function DocumentFlipbook(): JSX.Element {
   return (
     <section
       id="document-flipbook"
-      className="scroll-mt-[calc(var(--de-nav-offset)+1rem)] pt-16"
+      className="pt-16"
+      style={{ scrollMarginTop: "calc(var(--de-nav-offset) + 1rem)" }}
       aria-labelledby="document-flipbook-title"
       onKeyDown={onViewerKeyDown}
     >
-      <div className="overflow-hidden rounded-3xl border border-de-hairline bg-[#070513] shadow-[0_35px_90px_-60px_rgba(123,108,255,0.75)]">
-        <div className="grid gap-8 border-b border-white/10 px-5 py-8 sm:px-8 lg:grid-cols-[minmax(0,0.85fr)_minmax(0,1.15fr)] lg:px-10 lg:py-10">
+      <div
+        className="overflow-hidden rounded-3xl border border-de-hairline bg-de-raised"
+        style={{ boxShadow: "0 35px 90px -60px rgba(123,108,255,0.75)" }}
+      >
+        <div className="grid gap-8 border-b border-de-hairline px-5 py-8 sm:px-8 lg:grid-cols-2 lg:px-10 lg:py-10">
           <div>
-            <div className="inline-flex items-center gap-2 rounded-full border border-[#7b6cff]/30 bg-[#7b6cff]/10 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.14em] text-[#b9afff]">
+            <div
+              className="inline-flex items-center gap-2 rounded-full border border-de-hairline bg-de-bg px-3 py-1.5 text-xs font-semibold uppercase text-de-accent-ink"
+              style={{ letterSpacing: "0.14em" }}
+            >
               <BookOpen className="h-3.5 w-3.5" aria-hidden="true" />
               Browser-local viewer
             </div>
-            <h2 id="document-flipbook-title" className="mt-4 font-heading text-3xl font-semibold tracking-[-0.035em] text-white sm:text-4xl">
+            <h2
+              id="document-flipbook-title"
+              className="mt-4 font-heading text-3xl font-semibold text-white sm:text-4xl"
+              style={{ letterSpacing: "-0.035em" }}
+            >
               Digital Document Flipbook
             </h2>
-            <p className="mt-4 max-w-2xl text-base leading-7 text-white/65">
+            <p className="mt-4 max-w-2xl text-base leading-7 text-de-muted-soft">
               Open a PDF and read it like a responsive book. On larger screens you get a two-page spread; phones use one page at a time.
             </p>
-            <div className="mt-5 flex items-start gap-3 rounded-xl border border-emerald-400/15 bg-emerald-400/[0.06] p-4 text-sm leading-6 text-white/68">
-              <LockKeyhole className="mt-0.5 h-4 w-4 shrink-0 text-emerald-300" aria-hidden="true" />
+            <div className="mt-5 flex items-start gap-3 rounded-xl border border-de-hairline bg-de-bg p-4 text-sm leading-6 text-de-muted-soft">
+              <LockKeyhole className="mt-0.5 h-4 w-4 shrink-0 text-de-accent-ink" aria-hidden="true" />
               <p>
-                <strong className="font-semibold text-white/90">Private by design:</strong> the selected PDF is read and rendered in your browser. It is not uploaded to Digerati Experts.
+                <strong className="font-semibold text-white">Private by design:</strong> the selected PDF is read and rendered in your browser. It is not uploaded to Digerati Experts.
               </p>
             </div>
           </div>
 
           <div
-            className={`flex min-h-52 flex-col items-center justify-center rounded-2xl border border-dashed px-6 py-8 text-center transition ${dragActive ? "border-[#9a8bff] bg-[#7b6cff]/12" : "border-white/20 bg-white/[0.035]"}`}
+            className="flex min-h-52 flex-col items-center justify-center rounded-2xl border border-dashed px-6 py-8 text-center transition"
+            style={{
+              borderColor: dragActive ? "rgba(154,139,255,0.9)" : "rgba(255,255,255,0.2)",
+              background: dragActive ? "rgba(123,108,255,0.12)" : "rgba(255,255,255,0.035)",
+            }}
             onDragEnter={(event) => { event.preventDefault(); setDragActive(true); }}
             onDragOver={(event) => event.preventDefault()}
             onDragLeave={() => setDragActive(false)}
             onDrop={onDrop}
           >
             <input ref={inputRef} type="file" accept="application/pdf,.pdf,.doc,.docx,.ppt,.pptx" className="sr-only" onChange={onInputChange} />
-            <span className="flex h-12 w-12 items-center justify-center rounded-2xl border border-white/10 bg-white/[0.055] text-[#b9afff]">
+            <span className="flex h-12 w-12 items-center justify-center rounded-2xl border border-de-hairline bg-de-bg text-de-accent-ink">
               <Upload className="h-5 w-5" aria-hidden="true" />
             </span>
             <p className="mt-4 text-base font-semibold text-white">Drop a PDF here</p>
-            <p className="mt-1 text-sm text-white/48">or choose one from this device · up to 75 MB</p>
-            <Button type="button" variant="outline" className="mt-5 border-white/20 bg-white/5 text-white hover:bg-white/10 hover:text-white" onClick={() => inputRef.current?.click()} disabled={isLoading}>
+            <p className="mt-1 text-sm text-de-muted-soft">or choose one from this device · up to 75 MB</p>
+            <Button
+              type="button"
+              variant="outline"
+              className="mt-5 border-de-hairline bg-de-bg text-white hover:bg-white/10 hover:text-white"
+              onClick={() => inputRef.current?.click()}
+              disabled={isLoading}
+            >
               <FileText className="mr-2 h-4 w-4" aria-hidden="true" />
               {isLoading ? "Opening PDF…" : "Choose document"}
             </Button>
-            <p className="mt-4 max-w-md text-xs leading-5 text-white/40">
+            <p className="mt-4 max-w-md text-xs leading-5 text-de-muted-soft">
               Word or PowerPoint? Export it to PDF first. We deliberately do not send Office files to a third-party converter.
             </p>
           </div>
         </div>
 
         {error && (
-          <div className="border-b border-red-300/15 bg-red-300/[0.06] px-5 py-3 text-sm text-red-100 sm:px-8 lg:px-10" role="alert">
+          <div className="border-b border-de-hairline bg-de-bg px-5 py-3 text-sm text-red-200 sm:px-8 lg:px-10" role="alert">
             {error}
           </div>
         )}
@@ -356,25 +377,52 @@ export function DocumentFlipbook(): JSX.Element {
             <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
               <div className="min-w-0">
                 <p className="truncate text-sm font-semibold text-white" title={fileName}>{fileName}</p>
-                <p className="mt-0.5 text-xs text-white/45">{pageLabel(pageStart, pageCount, isWide)}{isRendering ? " · rendering" : ""}</p>
+                <p className="mt-0.5 text-xs text-de-muted-soft">
+                  {pageLabel(pageStart, pageCount, isWide)}{isRendering ? " · rendering" : ""}
+                </p>
               </div>
               <div className="flex items-center gap-2">
                 {originalUrl && (
-                  <a href={originalUrl} target="_blank" rel="noreferrer" className="inline-flex h-9 items-center gap-1.5 rounded-lg border border-white/15 px-3 text-xs font-semibold text-white/70 transition hover:bg-white/[0.06] hover:text-white">
+                  <a
+                    href={originalUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex h-9 items-center gap-1.5 rounded-lg border border-de-hairline px-3 text-xs font-semibold text-de-muted-soft transition hover:bg-white/10 hover:text-white"
+                  >
                     Original
                     <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
                   </a>
                 )}
-                <Button type="button" variant="outline" size="icon" className="h-9 w-9 border-white/15 bg-white/[0.035] text-white hover:bg-white/[0.08] hover:text-white" onClick={goPrevious} disabled={!canGoPrevious} aria-label="Previous page">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  className="h-9 w-9 border-de-hairline bg-de-bg text-white hover:bg-white/10 hover:text-white"
+                  onClick={goPrevious}
+                  disabled={!canGoPrevious}
+                  aria-label="Previous page"
+                >
                   <ArrowLeft className="h-4 w-4" aria-hidden="true" />
                 </Button>
-                <Button type="button" variant="outline" size="icon" className="h-9 w-9 border-white/15 bg-white/[0.035] text-white hover:bg-white/[0.08] hover:text-white" onClick={goNext} disabled={!canGoNext} aria-label="Next page">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  className="h-9 w-9 border-de-hairline bg-de-bg text-white hover:bg-white/10 hover:text-white"
+                  onClick={goNext}
+                  disabled={!canGoNext}
+                  aria-label="Next page"
+                >
                   <ArrowRight className="h-4 w-4" aria-hidden="true" />
                 </Button>
               </div>
             </div>
 
-            <div className="relative overflow-hidden rounded-2xl border border-white/10 bg-[#0b0915] p-3 shadow-inner sm:p-5" tabIndex={0} aria-label="PDF flipbook. Use left and right arrow keys to change pages.">
+            <div
+              className="relative overflow-hidden rounded-2xl border border-de-hairline bg-de-bg p-3 shadow-inner sm:p-5"
+              tabIndex={0}
+              aria-label="PDF flipbook. Use left and right arrow keys to change pages."
+            >
               <AnimatePresence mode="wait" initial={false}>
                 <motion.div
                   key={`${pageStart}-${isWide ? "spread" : "single"}`}
@@ -382,22 +430,32 @@ export function DocumentFlipbook(): JSX.Element {
                   animate={{ opacity: 1, rotateY: 0, x: 0 }}
                   exit={prefersReducedMotion ? undefined : { opacity: 0.72, rotateY: -4, x: -8 }}
                   transition={{ duration: prefersReducedMotion ? 0 : 0.2, ease: "easeOut" }}
-                  className="mx-auto flex min-h-72 w-full items-start justify-center gap-[18px] [perspective:1400px]"
+                  className="mx-auto flex min-h-72 w-full items-start justify-center gap-4"
+                  style={{ perspective: 1400 }}
                 >
-                  <canvas ref={leftCanvasRef} className="max-w-full rounded-md bg-white shadow-[0_18px_45px_-24px_rgba(0,0,0,0.9)]" aria-label={`PDF page ${pageStart}`} />
-                  <canvas ref={rightCanvasRef} className="hidden max-w-[calc(50%-9px)] rounded-md bg-white shadow-[0_18px_45px_-24px_rgba(0,0,0,0.9)] md:block" aria-label={isWide && pageStart + 1 <= pageCount ? `PDF page ${pageStart + 1}` : undefined} />
+                  <canvas
+                    ref={leftCanvasRef}
+                    className="max-w-full rounded-md bg-white shadow-xl"
+                    aria-label={`PDF page ${pageStart}`}
+                  />
+                  <canvas
+                    ref={rightCanvasRef}
+                    className="hidden rounded-md bg-white shadow-xl md:block"
+                    style={{ maxWidth: isWide ? "calc(50% - 9px)" : "100%" }}
+                    aria-label={isWide && pageStart + 1 <= pageCount ? `PDF page ${pageStart + 1}` : undefined}
+                  />
                 </motion.div>
               </AnimatePresence>
             </div>
 
-            <div className="mt-4 flex items-center justify-center gap-3 text-xs text-white/45">
+            <div className="mt-4 flex items-center justify-center gap-3 text-xs text-de-muted-soft">
               <span>← / → pages</span>
               <span aria-hidden="true">·</span>
               <span>Home / End jump</span>
             </div>
           </div>
         ) : (
-          <div className="flex min-h-40 items-center justify-center px-5 py-10 text-center text-sm text-white/42">
+          <div className="flex min-h-40 items-center justify-center px-5 py-10 text-center text-sm text-de-muted-soft">
             Choose a PDF above to start the flipbook.
           </div>
         )}

--- a/client/src/pages/resources/DocumentFlipbook.tsx
+++ b/client/src/pages/resources/DocumentFlipbook.tsx
@@ -334,8 +334,9 @@ export function DocumentFlipbook(): JSX.Element {
           </div>
 
           <div
-            className="flex min-h-52 flex-col items-center justify-center rounded-2xl border border-dashed px-6 py-8 text-center transition"
+            className="flex flex-col items-center justify-center rounded-2xl border border-dashed px-6 py-8 text-center transition"
             style={{
+              minHeight: 208,
               borderColor: dragActive ? "rgba(154,139,255,0.9)" : "rgba(255,255,255,0.2)",
               background: dragActive ? "rgba(123,108,255,0.12)" : "rgba(255,255,255,0.035)",
             }}
@@ -430,8 +431,8 @@ export function DocumentFlipbook(): JSX.Element {
                   animate={{ opacity: 1, rotateY: 0, x: 0 }}
                   exit={prefersReducedMotion ? undefined : { opacity: 0.72, rotateY: -4, x: -8 }}
                   transition={{ duration: prefersReducedMotion ? 0 : 0.2, ease: "easeOut" }}
-                  className="mx-auto flex min-h-72 w-full items-start justify-center gap-4"
-                  style={{ perspective: 1400 }}
+                  className="mx-auto flex w-full items-start justify-center gap-4"
+                  style={{ perspective: 1400, minHeight: 288 }}
                 >
                   <canvas
                     ref={leftCanvasRef}
@@ -455,7 +456,10 @@ export function DocumentFlipbook(): JSX.Element {
             </div>
           </div>
         ) : (
-          <div className="flex min-h-40 items-center justify-center px-5 py-10 text-center text-sm text-de-muted-soft">
+          <div
+            className="flex items-center justify-center px-5 py-10 text-center text-sm text-de-muted-soft"
+            style={{ minHeight: 160 }}
+          >
             Choose a PDF above to start the flipbook.
           </div>
         )}

--- a/client/src/pages/resources/ResourcesIndex.tsx
+++ b/client/src/pages/resources/ResourcesIndex.tsx
@@ -14,6 +14,7 @@ import { ConversionPathBar } from "@/components/ConversionPathBar";
 import { useSEO } from "@/hooks/useSEO";
 import { CTA } from "@/lib/ctaCopy";
 import { Button } from "@/components/ui/button";
+import { DocumentFlipbook } from "@/pages/resources/DocumentFlipbook";
 
 const resources = [
   {
@@ -71,6 +72,12 @@ const resources = [
     icon: BookOpen,
   },
   {
+    name: "Document Flipbook",
+    href: "/resources#document-flipbook",
+    description: "Open a PDF locally in your browser and read it as a responsive digital book.",
+    icon: BookOpen,
+  },
+  {
     name: "Campaign offers",
     href: "/go",
     description: "Single-offer pages for search and social — one path, one primary CTA.",
@@ -123,6 +130,9 @@ export default function ResourcesIndex() {
             );
           })}
         </ul>
+
+        <DocumentFlipbook />
+
         <div className="mt-16">
           <ConversionPathBar
             headline="Need a recommendation, not a PDF?"

--- a/client/src/pages/sections/ReferenceHeroSection.tsx
+++ b/client/src/pages/sections/ReferenceHeroSection.tsx
@@ -197,7 +197,9 @@ export function ReferenceHeroSection(): JSX.Element {
             <span>Fully managed or co-managed</span>
           </div>
 
-          <PronunciationCard className="mt-7 max-w-[620px]" />
+          <div className="mt-7" style={{ maxWidth: 620 }}>
+            <PronunciationCard />
+          </div>
         </motion.div>
 
         {/* DE Cyber Risk Assessment preview — the existing product artwork,

--- a/client/src/pages/sections/ReferenceHeroSection.tsx
+++ b/client/src/pages/sections/ReferenceHeroSection.tsx
@@ -4,6 +4,7 @@ import { ArrowRight, Check, CheckCircle2, ClipboardCheck, MapPin, ShieldCheck } 
 import { Link } from "wouter";
 import { Button } from "@/components/ui/button";
 import { DashboardMockup } from "@/components/graphics";
+import { PronunciationCard } from "@/components/PronunciationCard";
 import { useBooking } from "@/contexts/BookingContext";
 import { analytics } from "@/lib/analytics";
 import { CTA } from "@/lib/ctaCopy";
@@ -195,6 +196,8 @@ export function ReferenceHeroSection(): JSX.Element {
             <span aria-hidden="true">·</span>
             <span>Fully managed or co-managed</span>
           </div>
+
+          <PronunciationCard className="mt-7 max-w-[620px]" />
         </motion.div>
 
         {/* DE Cyber Risk Assessment preview — the existing product artwork,

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "license": "MIT",
   "scripts": {
     "dev": "cross-env NODE_ENV=development tsx server/index.ts",
+    "predev": "npm run vendor:pdfjs",
+    "vendor:pdfjs": "node scripts/vendor-pdfjs.mjs",
     "sitemap": "node scripts/generate-sitemap.mjs",
+    "prebuild": "npm run vendor:pdfjs",
     "build": "node scripts/generate-sitemap.mjs && vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "cross-env NODE_ENV=production node dist/index.js",
     "check": "tsc",

--- a/scripts/public-route-smoke.mjs
+++ b/scripts/public-route-smoke.mjs
@@ -3,7 +3,7 @@ import { chromium } from "playwright";
 
 /**
  * Smoke-test indexable marketing routes against a running server.
- * Includes rendered homepage/Ask DE regression checks at 390 / 768 / 1440.
+ * Includes rendered homepage/Ask DE/resources regression checks at 390 / 768 / 1440.
  * Usage: BASE_URL=http://127.0.0.1:3300 node scripts/public-route-smoke.mjs
  */
 const BASE = process.env.BASE_URL || "http://127.0.0.1:3300";
@@ -23,6 +23,7 @@ const routes = [
   "/book",
   "/industries/healthcare",
   "/industries/law-firms",
+  "/resources",
   "/resources/case-studies",
   "/resources/case-studies/healthcare-hipaa-readiness",
   "/resources/blog",
@@ -125,10 +126,11 @@ for (const path of routes) {
   }
 }
 
-// Render the real homepage at the required DE visual-review widths and exercise
-// the single-pane Ask DE chooser. This is intentionally part of the canonical
-// smoke gate so a later merge cannot silently restore a source-correct but
-// visually broken homepage/support shell.
+// Render the real homepage at the required DE visual-review widths, exercise
+// the single-pane Ask DE chooser, and verify the recovered pronunciation and
+// resources flipbook surfaces. This is intentionally part of the canonical
+// smoke gate so a later merge cannot silently restore source-correct but
+// visually broken public UI.
 {
   const widths = [390, 768, 1440];
   const screenshotDir = "tmp/public-visual-smoke";
@@ -155,7 +157,13 @@ for (const path of routes) {
           fails.push(`homepage ${width}px → unexpected H1: ${headline}`);
         }
 
-        for (const testId of ["button-hero-schedule", "button-hero-pricing", "button-open-asap-widget"]) {
+        for (const testId of [
+          "button-hero-schedule",
+          "button-hero-pricing",
+          "digerati-pronunciation-card",
+          "button-play-digerati-pronunciation",
+          "button-open-asap-widget",
+        ]) {
           await page.locator(`[data-testid="${testId}"]`).waitFor({ state: "visible", timeout: 10_000 });
         }
 
@@ -190,9 +198,19 @@ for (const path of routes) {
         if (deskOverflow > 2) fails.push(`support desk ${width}px → horizontal overflow ${deskOverflow}px`);
         await page.screenshot({ path: `${screenshotDir}/support-desk-${width}.png`, fullPage: false });
 
-        if (pageErrors.length) fails.push(`homepage ${width}px → page errors: ${pageErrors.join(" | ")}`);
+        await page.goto(`${BASE}/resources#document-flipbook`, { waitUntil: "domcontentloaded", timeout: 30_000 });
+        await page.waitForLoadState("networkidle", { timeout: 15_000 }).catch(() => {});
+        const flipbookTitle = page.locator("#document-flipbook-title");
+        await flipbookTitle.waitFor({ state: "visible", timeout: 10_000 });
+        await page.getByRole("button", { name: "Choose document" }).waitFor({ state: "visible", timeout: 10_000 });
+        await flipbookTitle.scrollIntoViewIfNeeded();
+        const resourcesOverflow = await page.evaluate(() => document.documentElement.scrollWidth - window.innerWidth);
+        if (resourcesOverflow > 2) fails.push(`resources flipbook ${width}px → horizontal overflow ${resourcesOverflow}px`);
+        await page.screenshot({ path: `${screenshotDir}/resources-flipbook-${width}.png`, fullPage: false });
+
+        if (pageErrors.length) fails.push(`public UI ${width}px → page errors: ${pageErrors.join(" | ")}`);
       } catch (err) {
-        fails.push(`homepage/Ask DE ${width}px → ${err.message}`);
+        fails.push(`homepage/Ask DE/resources ${width}px → ${err.message}`);
       } finally {
         await context.close();
       }
@@ -208,5 +226,5 @@ if (fails.length) {
   process.exit(1);
 }
 console.log(
-  `Public route smoke OK (${routes.length} routes + google-reviews + bbp_search 410 + internal-tool noindex + rendered homepage/Ask DE 390/768/1440) against ${BASE}`,
+  `Public route smoke OK (${routes.length} routes + google-reviews + bbp_search 410 + internal-tool noindex + rendered homepage/Ask DE/resources 390/768/1440) against ${BASE}`,
 );

--- a/scripts/vendor-pdfjs.mjs
+++ b/scripts/vendor-pdfjs.mjs
@@ -4,10 +4,10 @@ import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
-const PACKAGE_SPEC = "pdfjs-dist-viewer-min@3.11.174";
-const EXPECTED_INTEGRITY = "sha512-kqbAoDchc87zyTe/XLoKyLHh3Aa3KSbiRd0eHyRoJFgUIYSB3uaMZ1Hvqqf4/y6hbV8K5f7slnmLVauVLzF/iw==";
-const MIN_PDFJS_BYTES = 250_000;
-const MIN_WORKER_BYTES = 900_000;
+const PACKAGE_SPEC = "pdfjs-dist@3.11.174";
+const EXPECTED_INTEGRITY = "sha512-TdTZPf1trZ8/UFu5Cx/GXB7GZM30LT+wWUNfsi6Bq8ePLnb+woNKtDymI2mxZYBpMbonNFqKmiz684DIfnd8dA==";
+const MIN_PDFJS_BYTES = 450_000;
+const MIN_WORKER_BYTES = 1_200_000;
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const destination = path.join(root, "client", "public", "vendor", "pdfjs");
@@ -45,14 +45,14 @@ try {
     archive,
     "-C",
     temp,
-    "package/build/minified/build/pdf.js",
-    "package/build/minified/build/pdf.worker.js",
+    "package/build/pdf.js",
+    "package/build/pdf.worker.js",
     "package/LICENSE",
   ]);
 
   const sourceRoot = path.join(temp, "package");
-  const pdfJs = path.join(sourceRoot, "build", "minified", "build", "pdf.js");
-  const worker = path.join(sourceRoot, "build", "minified", "build", "pdf.worker.js");
+  const pdfJs = path.join(sourceRoot, "build", "pdf.js");
+  const worker = path.join(sourceRoot, "build", "pdf.worker.js");
   const license = path.join(sourceRoot, "LICENSE");
   const [pdfJsStat, workerStat] = await Promise.all([stat(pdfJs), stat(worker)]);
   if (pdfJsStat.size < MIN_PDFJS_BYTES || workerStat.size < MIN_WORKER_BYTES) {
@@ -69,7 +69,7 @@ try {
   const readme = [
     "# PDF.js runtime assets",
     "",
-    `Generated at build/dev time from npm package \`${PACKAGE_SPEC}\`.`,
+    `Generated at build/dev time from the official Mozilla npm package \`${PACKAGE_SPEC}\`.`,
     `Expected npm integrity: \`${EXPECTED_INTEGRITY}\`.`,
     "",
     "The browser loads these files from the site's own origin so the production CSP does not need a third-party script or worker exception.",
@@ -78,7 +78,6 @@ try {
   ].join("\n");
   await import("node:fs/promises").then(({ writeFile }) => writeFile(path.join(destination, "README.md"), readme, "utf8"));
 
-  // Read a byte from the copied license so a partial/corrupt copy fails before Vite starts.
   const copiedLicense = await readFile(path.join(destination, "LICENSE"));
   if (copiedLicense.length < 1_000) throw new Error("PDF.js license copy is unexpectedly short.");
 

--- a/scripts/vendor-pdfjs.mjs
+++ b/scripts/vendor-pdfjs.mjs
@@ -1,0 +1,88 @@
+import { copyFile, mkdir, mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const PACKAGE_SPEC = "pdfjs-dist-viewer-min@3.11.174";
+const EXPECTED_INTEGRITY = "sha512-kqbAoDchc87zyTe/XLoKyLHh3Aa3KSbiRd0eHyRoJFgUIYSB3uaMZ1Hvqqf4/y6hbV8K5f7slnmLVauVLzF/iw==";
+const MIN_PDFJS_BYTES = 250_000;
+const MIN_WORKER_BYTES = 900_000;
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const destination = path.join(root, "client", "public", "vendor", "pdfjs");
+const temp = await mkdtemp(path.join(tmpdir(), "de-pdfjs-"));
+const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+const tarCommand = process.platform === "win32" ? "tar.exe" : "tar";
+
+function run(command, args) {
+  const result = spawnSync(command, args, { cwd: root, encoding: "utf8", windowsHide: true });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(" ")} failed (${result.status}): ${result.stderr || result.stdout}`);
+  }
+  return result.stdout;
+}
+
+try {
+  const output = run(npmCommand, [
+    "pack",
+    PACKAGE_SPEC,
+    "--ignore-scripts",
+    "--json",
+    "--pack-destination",
+    temp,
+  ]);
+  const metadata = JSON.parse(output);
+  const packed = Array.isArray(metadata) ? metadata[0] : null;
+  if (!packed?.filename || packed.integrity !== EXPECTED_INTEGRITY) {
+    throw new Error(`PDF.js package integrity mismatch. Expected ${EXPECTED_INTEGRITY}, received ${packed?.integrity ?? "none"}.`);
+  }
+
+  const archive = path.join(temp, packed.filename);
+  run(tarCommand, [
+    "-xzf",
+    archive,
+    "-C",
+    temp,
+    "package/build/minified/build/pdf.js",
+    "package/build/minified/build/pdf.worker.js",
+    "package/LICENSE",
+  ]);
+
+  const sourceRoot = path.join(temp, "package");
+  const pdfJs = path.join(sourceRoot, "build", "minified", "build", "pdf.js");
+  const worker = path.join(sourceRoot, "build", "minified", "build", "pdf.worker.js");
+  const license = path.join(sourceRoot, "LICENSE");
+  const [pdfJsStat, workerStat] = await Promise.all([stat(pdfJs), stat(worker)]);
+  if (pdfJsStat.size < MIN_PDFJS_BYTES || workerStat.size < MIN_WORKER_BYTES) {
+    throw new Error(`PDF.js package contents look incomplete (${pdfJsStat.size}/${workerStat.size} bytes).`);
+  }
+
+  await mkdir(destination, { recursive: true });
+  await Promise.all([
+    copyFile(pdfJs, path.join(destination, "pdf.js")),
+    copyFile(worker, path.join(destination, "pdf.worker.js")),
+    copyFile(license, path.join(destination, "LICENSE")),
+  ]);
+
+  const readme = [
+    "# PDF.js runtime assets",
+    "",
+    `Generated at build/dev time from npm package \`${PACKAGE_SPEC}\`.`,
+    `Expected npm integrity: \`${EXPECTED_INTEGRITY}\`.`,
+    "",
+    "The browser loads these files from the site's own origin so the production CSP does not need a third-party script or worker exception.",
+    "Do not hand-edit generated pdf.js/pdf.worker.js. Update the pinned package and integrity in scripts/vendor-pdfjs.mjs instead.",
+    "",
+  ].join("\n");
+  await import("node:fs/promises").then(({ writeFile }) => writeFile(path.join(destination, "README.md"), readme, "utf8"));
+
+  // Read a byte from the copied license so a partial/corrupt copy fails before Vite starts.
+  const copiedLicense = await readFile(path.join(destination, "LICENSE"));
+  if (copiedLicense.length < 1_000) throw new Error("PDF.js license copy is unexpectedly short.");
+
+  console.log(`[vendor-pdfjs] ${PACKAGE_SPEC} ready (${pdfJsStat.size} B engine, ${workerStat.size} B worker)`);
+} finally {
+  await rm(temp, { recursive: true, force: true });
+}


### PR DESCRIPTION
Closes #152.

## Recovery scope
This ports the useful behavior out of the legacy `digeratiexperts/de_site@19a27fbd3988c5c3adf0eeb880fe2e08b3265551` prototype into the canonical React/TypeScript site without copying the prototype's standalone HTML or CDN runtime.

### Pronunciation
- Adds a compact dictionary-style `di·ger·a·ti` card to the current homepage hero.
- Keeps the approved IPA `/ˌdɪdʒəˈrɑːti/` and `dij-uh-RAH-tee` reading.
- Accessible play action uses browser speech synthesis today; `client/public/audio/README.md` defines the canonical human-recording replacement path.

### Document flipbook
- Adds a browser-local PDF viewer/flipbook to `/resources#document-flipbook`.
- Responsive: one page on narrow screens, two-page spread at tablet/desktop widths.
- Keyboard: Left/Right and Home/End.
- Reduced-motion aware.
- PDF data stays in the visitor's browser; there is no upload endpoint.
- Word/PowerPoint are handled honestly: export to PDF first rather than silently sending files to an external conversion service.
- 75 MB browser-memory guard.

### PDF.js / CSP
The legacy prototype loaded PDF.js directly from cdnjs. Production CSP does not permit that and this PR does not weaken the CSP.

Instead, `scripts/vendor-pdfjs.mjs` fetches the official Mozilla `pdfjs-dist@3.11.174` package from the npm registry during `predev`/`prebuild`, verifies the exact pinned npm integrity (`sha512-TdTZPf1trZ8/UFu5Cx/GXB7GZM30LT+wWUNfsi6Bq8ePLnb+woNKtDymI2mxZYBpMbonNFqKmiz684DIfnd8dA==`), extracts only `pdf.js`, `pdf.worker.js`, and the Apache-2.0 license, and serves those generated runtime assets from the DE origin. No runtime CDN exception, `package.json` dependency, or `package-lock.json` change is required.

## Concurrency audit
- Branch base: `ecea1d9314f859bd5a17343c277e739f3bedb492`.
- Start-of-task open PR audit: #149 is portal marketplace/layout work; no intended file overlap with this PR.
- GitHub issue #152 was created as the authoritative active-work lock before implementation; `.ai/ACTIVE_WORK.yaml` mirrors the claim.
- This branch does not touch the PR #149 portal marketplace files or Desk widget files.
- Current homepage/Ask DE work from main is preserved; hero was edited from the exact current-main file, not restored from an older branch.
- Before merge, current `main` must be re-fetched and the overlap audit repeated per governance §6.

## Validation gates
CI must pass typecheck, unit tests, advisor tests, production build, dependency audit, bundle budget and public smoke. The canonical public smoke now explicitly verifies:
- homepage pronunciation card + play control;
- existing Ask DE chooser/support shell;
- `/resources#document-flipbook` and Choose Document control;
- no horizontal overflow at 390 / 768 / 1440;
- rendered screenshots for homepage, Ask DE, support Desk, and flipbook at all three widths.

Because this is visual work, this PR remains **draft** until the final CI/rendered evidence is green and reviewed in context.

## Remaining risk / non-scope
- The canonical human pronunciation recording is not present yet; browser speech synthesis is the functional fallback.
- The separate in-chat auth/passkey handoff is **not** included here because its described local commit had throwing persistence/mailer adapters and the patch/bundle bytes are not present in the connected artifacts. Safe rebuild requirements are preserved in #153 rather than shipping knowingly broken auth.
- This PR is not a production claim. Under repo governance, ChatGPT does not self-merge; Claude Code remains the default lead integrator unless Joe explicitly overrides that role for this release.

## Production impact
Once merge-readiness review is complete and the PR is merged to `main`, the existing CI workflow runs the production VPS deploy job on the repo-scoped `de-production/website-prod` runner after check/test/build succeeds, and verifies the live runtime. `MERGED` is still not `LIVE` until that production verification succeeds.