### PR TITLE
Protection deck: turn the dark inset boxes into white cards

### DIFF
--- a/client/src/components/evidence/DiagramPrimitives.tsx
+++ b/client/src/components/evidence/DiagramPrimitives.tsx
@@ -50,6 +50,7 @@ export interface DiagramNodeProps {
   icon?: LucideIcon;
   status?: "healthy" | "monitored" | "alert" | "isolated";
   metrics?: string;
+  tone?: "dark" | "paper";
   className?: string;
 }
 
@@ -60,32 +61,44 @@ export const DiagramNode: React.FC<DiagramNodeProps> = ({
   icon: Icon,
   status = "monitored",
   metrics,
+  tone = "dark",
   className = "",
 }) => {
+  const isPaper = tone === "paper";
   const statusStyles = {
-    healthy: "border-emerald-500/30",
-    monitored: "border-de-hairline",
-    alert: "border-amber-500/35",
+    healthy: isPaper ? "border-emerald-600/35" : "border-emerald-500/30",
+    monitored: isPaper ? "border-[var(--de-paper-hairline)]" : "border-de-hairline",
+    alert: isPaper ? "border-amber-600/40" : "border-amber-500/35",
     isolated: "border-[#D3126A]/45",
   }[status];
 
   return (
-    <div className={`rounded-lg border bg-de-bg p-3 ${statusStyles} ${className}`}>
+    <div className={`rounded-lg border p-3 ${isPaper ? "bg-white" : "bg-de-bg"} ${statusStyles} ${className}`}>
       <div className="flex items-center gap-2.5">
         {Icon && (
-          <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-de-hairline bg-de-raised">
-            <Icon className="h-4 w-4 text-[#F04C97]" aria-hidden="true" />
+          <div
+            className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-md border ${
+              isPaper ? "border-[var(--de-paper-hairline)] bg-[var(--de-paper)]" : "border-de-hairline bg-de-raised"
+            }`}
+          >
+            <Icon className={`h-4 w-4 ${isPaper ? "text-[#A30E52]" : "text-[#F04C97]"}`} aria-hidden="true" />
           </div>
         )}
         <div className="min-w-0 flex-1">
-          <p className="font-heading text-xs font-bold text-white">{title}</p>
-          {subtitle && <p className="mt-0.5 text-[11px] leading-relaxed text-white/60">{subtitle}</p>}
+          <p className={`font-heading text-xs font-bold ${isPaper ? "text-[#1A1228]" : "text-white"}`}>{title}</p>
+          {subtitle && (
+            <p className={`mt-0.5 text-[11px] leading-relaxed ${isPaper ? "text-[#5A5368]" : "text-white/60"}`}>{subtitle}</p>
+          )}
         </div>
       </div>
       {metrics && (
-        <div className="mt-2 flex items-center justify-between gap-2 border-t border-de-hairline pt-1.5 font-mono text-[10px] text-white/50">
+        <div
+          className={`mt-2 flex items-center justify-between gap-2 border-t pt-1.5 font-mono text-[10px] ${
+            isPaper ? "border-[var(--de-paper-hairline)] text-[#5A5368]" : "border-de-hairline text-white/50"
+          }`}
+        >
           <span>Detail:</span>
-          <span className="text-right font-semibold text-white/75">{metrics}</span>
+          <span className={`text-right font-semibold ${isPaper ? "text-[#3A3448]" : "text-white/75"}`}>{metrics}</span>
         </div>
       )}
     </div>
@@ -96,6 +109,7 @@ export interface ControlGateProps {
   label: string;
   policy: string;
   enforced?: boolean;
+  tone?: "dark" | "paper";
 }
 
 /**
@@ -106,12 +120,18 @@ export const ControlGate: React.FC<ControlGateProps> = ({
   label,
   policy,
   enforced = false,
+  tone = "dark",
 }) => {
+  const isPaper = tone === "paper";
   return (
-    <div className="flex items-start gap-2 rounded border border-de-hairline bg-de-bg px-3 py-2 font-mono text-[11px]">
+    <div
+      className={`flex items-start gap-2 rounded border px-3 py-2 font-mono text-[11px] ${
+        isPaper ? "border-[var(--de-paper-hairline)] bg-white" : "border-de-hairline bg-de-bg"
+      }`}
+    >
       <span className={`mt-1 h-2 w-2 shrink-0 rounded-full ${enforced ? "bg-emerald-400" : "bg-[#D3126A]"}`} aria-hidden="true" />
-      <span className="font-bold text-white">{label}:</span>
-      <span className="text-white/70">{policy}</span>
+      <span className={`font-bold ${isPaper ? "text-[#1A1228]" : "text-white"}`}>{label}:</span>
+      <span className={isPaper ? "text-[#3A3448]" : "text-white/70"}>{policy}</span>
     </div>
   );
 };

--- a/client/src/components/visual/ProtectionCommandDeck.tsx
+++ b/client/src/components/visual/ProtectionCommandDeck.tsx
@@ -198,7 +198,7 @@ export const ProtectionCommandDeck: React.FC = () => {
               className={`flex min-h-11 items-center gap-2 rounded-lg border px-3.5 py-2 font-mono text-xs font-semibold transition-colors ${
                 isSelected
                   ? "border-[#D3126A] bg-[#D3126A] text-white"
-                  : "border-de-hairline bg-de-bg text-white/70 hover:border-white/20 hover:text-white"
+                  : "border-[var(--de-paper-hairline)] bg-white text-[#3A3448] hover:border-[#D3126A]/45 hover:text-[#1A1228]"
               }`}
               data-testid={`domain-tab-${domain.id}`}
             >
@@ -220,16 +220,16 @@ export const ProtectionCommandDeck: React.FC = () => {
         >
           <div className="space-y-4 lg:col-span-4">
             <div className="flex items-center gap-2.5">
-              <div className="flex h-9 w-9 items-center justify-center rounded-lg border border-de-hairline bg-de-bg text-[#F04C97]">
+              <div className="flex h-9 w-9 items-center justify-center rounded-lg border border-[var(--de-paper-hairline)] bg-white text-[#A30E52]">
                 <DomainIcon className="h-5 w-5" aria-hidden="true" />
               </div>
               <h3 className="font-heading text-lg font-bold text-white">{activeDomain.name}</h3>
             </div>
             <p className="text-sm leading-relaxed text-white/70">{activeDomain.purpose}</p>
 
-            <div className="rounded-lg border border-de-hairline bg-de-bg p-3.5">
-              <p className="mb-2 font-mono text-[10px] font-semibold uppercase tracking-wider text-[#F04C97]">Questions the assessment should answer</p>
-              <ul className="space-y-2 text-xs leading-relaxed text-white/80">
+            <div className="rounded-lg border border-[var(--de-paper-hairline)] bg-white p-3.5">
+              <p className="mb-2 font-mono text-[10px] font-semibold uppercase tracking-wider text-[#A30E52]">Questions the assessment should answer</p>
+              <ul className="space-y-2 text-xs leading-relaxed text-[#3A3448]">
                 {activeDomain.commonQuestions.map((question) => (
                   <li key={question} className="flex items-start gap-2">
                     <span className="mt-1 text-[#D3126A]" aria-hidden="true">•</span>
@@ -251,10 +251,11 @@ export const ProtectionCommandDeck: React.FC = () => {
                     metrics={node.detail}
                     icon={DomainIcon}
                     status="monitored"
+                    tone="paper"
                   />
                 ))}
               </div>
-              <ControlGate label={activeDomain.architecture.gate.label} policy={activeDomain.architecture.gate.policy} enforced={false} />
+              <ControlGate label={activeDomain.architecture.gate.label} policy={activeDomain.architecture.gate.policy} enforced={false} tone="paper" />
             </SecurityBoundary>
           </div>
 
@@ -266,7 +267,7 @@ export const ProtectionCommandDeck: React.FC = () => {
               </p>
               <div className="flex flex-wrap gap-1.5">
                 {activeDomain.operatingModel.scopeExamples.map((item) => (
-                  <span key={item} className="rounded border border-de-hairline bg-de-bg px-2 py-0.5 font-mono text-[10px] text-white/80">{item}</span>
+                  <span key={item} className="rounded border border-[var(--de-paper-hairline)] bg-white px-2 py-0.5 font-mono text-[10px] text-[#3A3448]">{item}</span>
                 ))}
               </div>
             </div>


### PR DESCRIPTION
## Summary

Joe flagged (with a color swatch) that the `#050312` (`--de-bg`) inset boxes inside the homepage six-domain Protection Command Deck should be white. All of those boxes — unselected domain tabs, the domain icon well, the "Questions the assessment should answer" card, the two diagram nodes, the control-gate strip, and the representative-scope chips — now render as white cards with `--de-paper-hairline` borders and dark ink text (`#1A1228` / `#3A3448` / `#5A5368`). Magenta accents on white use `--de-magenta-paper-ink` (`#A30E52`) per the accent-ink budget in `index.css`. No content changed; the ILLUSTRATIVE classification and all copy are untouched.

## Agent governance

Mandatory: `docs/AI-ENGINEERING-GOVERNANCE.md`.

- Task / claim ID: direct Joe request (this session); relates to VIS-005/VIS-009 surfaces
- Implementing agent: Claude Code
- Lead integrator: Claude Code (default)
- Isolated branch/worktree used: YES (`claude/box-color-white-ooj7ke`)
- `.ai/ACTIVE_WORK.yaml` + current open PRs checked before implementation: YES
- Any overlapping active agent work: NONE (active claim `pronunciation-flipbook-recovery` and open PRs #157/#156/#149 touch disjoint files)
- Merge/deploy authority: Joe explicitly instructed "merge and push" in-session

## Completion report

1. **What changed:** `DiagramNode` and `ControlGate` gained a `tone?: "dark" | "paper"` prop (default `"dark"`, so `ProActiveEcosystemDiagram` and every other consumer render exactly as before). `ProtectionCommandDeck` passes `tone="paper"` and converts its own `bg-de-bg` boxes to white cards with ink text.
2. **Why:** Joe asked for the `#050312` boxes in this section to be white.
3. **Files changed:** `client/src/components/visual/ProtectionCommandDeck.tsx`, `client/src/components/evidence/DiagramPrimitives.tsx`.
4. **Functionality preserved:** tab switching, aria-pressed states, test ids, animation, and all copy unchanged; other `DiagramNode`/`ControlGate` consumers unaffected (default tone).
5. **Tests performed:** `tsc` clean; full `vitest run` — 81 files, 357 tests, all pass; production `npm run build` exits 0 (pre-existing `button:hover` css-minify warnings originate in Zoho Desk widget styles, untouched here).
6. **Browser verification performed:** dev server + Playwright element screenshots of `#protection-stack` at 390, 768, and 1440, on the Identity and Recovery domains — white cards render with readable ink text on all three widths.
7. **Remaining issues:** none known.
8. **Human inputs still required:** production verification after deploy (MERGED ≠ LIVE).

## CONCURRENCY AUDIT

```
CONCURRENCY AUDIT
Branch base: 529a7da90362fab81b6226907ac37d0212ab096c
Current origin/main: 529a7da90362fab81b6226907ac37d0212ab096c
Commits landed on main since branch creation: none (branch is at main tip)
Overlapping files:
- none (open PRs #157/#156 touch pronunciation card files; #149 touches portal marketplace)
Overlapping active-agent claims:
- none (chatgpt pronunciation-flipbook-recovery claim covers disjoint files)
Reconciliation performed:
- none needed; branch based on current main tip
Newer-main work preserved:
YES
Whole-file replacements reviewed:
YES (none performed; targeted edits only)
Tests:
tsc clean; vitest 357/357 pass; production build exit 0
Visual QA:
390: PASS (white cards, ink text readable)
768: PASS
1440: PASS (Identity + Recovery domains)
Before/after evidence:
YES (screenshots delivered to Joe in session)
Screenshots captured:
YES
Production impact:
Homepage "What we protect" section only; shared primitives default tone unchanged
```

## Visual System v2

Uses existing primitives only (`DiagramNode`, `ControlGate` gain a tone variant mirroring `EvidenceFrame`'s existing `dark | paper` pattern; no new primitives invented). Classification remains ILLUSTRATIVE. VIS-005/VIS-009 are in VISUAL REVIEW owned as review pairings, not IN PROGRESS implementation claims; this is a Joe-directed color change on those surfaces.

## Release state

- PR state: IMPLEMENTED
- Production state: NOT DEPLOYED
- Expected release SHA / identifier: merge commit of this PR
- Production verification evidence: pending post-deploy check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ut75jTViS7nX4DVVtc8jcs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ut75jTViS7nX4DVVtc8jcs)_