### PR TITLE
Bug-hunt hardening follow-up: MFA CSPRNG, receipt XSS, Turnstile/CRM/config fixes (#8+)

### DIFF
--- a/client/src/components/TurnstileWidget.tsx
+++ b/client/src/components/TurnstileWidget.tsx
@@ -34,21 +34,26 @@ export default function TurnstileWidget({ onVerify, onError, theme = "dark" }: T
 
   useEffect(() => {
     if (isTestKey) {
+      if (!SITE_KEY && import.meta.env.PROD) {
+        // Misconfigured production build: bot protection is silently off.
+        console.error("[SECURITY] VITE_TURNSTILE_SITE_KEY is not set — Turnstile is disabled in this build");
+      }
       onVerifyRef.current("dev-bypass-token");
       return;
     }
 
     if ((window as any).turnstile) {
       renderWidget();
-      return;
+    } else {
+      const script = document.createElement("script");
+      script.src = "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit";
+      script.async = true;
+      script.onload = () => renderWidget();
+      document.head.appendChild(script);
     }
 
-    const script = document.createElement("script");
-    script.src = "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit";
-    script.async = true;
-    script.onload = () => renderWidget();
-    document.head.appendChild(script);
-
+    // Cleanup on both paths — the already-loaded branch previously returned
+    // without one, leaking a widget on every re-mount after the first.
     return () => {
       if (widgetIdRef.current !== null && (window as any).turnstile) {
         (window as any).turnstile.remove(widgetIdRef.current);

--- a/client/src/pages/portal/PortalLogin.tsx
+++ b/client/src/pages/portal/PortalLogin.tsx
@@ -31,6 +31,13 @@ export default function PortalLogin() {
   const [mfaMethod, setMfaMethod] = useState<"totp" | "email">("totp");
   const [mfaMessage, setMfaMessage] = useState("");
   const [turnstileToken, setTurnstileToken] = useState("");
+  // Remounting the widget issues a fresh single-use token after a failed
+  // attempt; without this the second submit re-sends a spent token.
+  const [turnstileKey, setTurnstileKey] = useState(0);
+  const resetTurnstile = () => {
+    setTurnstileToken("");
+    setTurnstileKey((k) => k + 1);
+  };
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const [zohoConfigured, setZohoConfigured] = useState<boolean | null>(null);
@@ -165,6 +172,7 @@ export default function PortalLogin() {
 
       if (!response.ok) {
         setError(data.message || "Login failed");
+        resetTurnstile();
         return;
       }
 
@@ -183,6 +191,7 @@ export default function PortalLogin() {
       navigate(marketplaceReturnTo(readQueryParam("returnTo")));
     } catch (err) {
       setError("Connection error. Please try again.");
+      resetTurnstile();
     } finally {
       setLoading(false);
     }
@@ -318,7 +327,7 @@ export default function PortalLogin() {
                     </a>
                   </div>
 
-                  <TurnstileWidget onVerify={setTurnstileToken} />
+                  <TurnstileWidget key={turnstileKey} onVerify={setTurnstileToken} />
 
                   <Button
                     type="submit"

--- a/deploy/vps/verify.sh
+++ b/deploy/vps/verify.sh
@@ -35,10 +35,13 @@ SITEMAP="$(curl -s -m 20 "$BASE/sitemap.xml")"
 if [ -z "$SITEMAP" ]; then
   bad "sitemap.xml empty"
 else
-  echo "$SITEMAP" | grep -oE '<loc>[^<]*</loc>' | sed 's/<[^>]*>//g' | while read -r url; do
+  # No pipeline here: a `| while` subshell would drop PASS/FAIL increments,
+  # letting the script exit 0 with broken sitemap routes.
+  SITEMAP_URLS="$(echo "$SITEMAP" | grep -oE '<loc>[^<]*</loc>' | sed 's/<[^>]*>//g')"
+  for url in $SITEMAP_URLS; do
     path="${url#https://digeratiexperts.com}"
     c="$(code "$BASE$path")"
-    [ "$c" = "200" ] && printf 'PASS  sitemap %s\n' "$path" || printf 'FAIL  sitemap %s -> %s\n' "$path" "$c"
+    [ "$c" = "200" ] && ok "sitemap $path" || bad "sitemap $path -> $c"
   done
 fi
 

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -1,13 +1,18 @@
+/**
+ * OBSOLETE — do not use PM2 for the public website.
+ *
+ * This .cjs variant previously still launched the deprecated /root/Replit-Site
+ * deployment on port 3300, colliding with the systemd unit. It is now a stub,
+ * matching ecosystem.config.js.
+ *
+ * Production process manager: systemd unit `digeratiexperts-site`
+ *   User: diger7051
+ *   WorkingDirectory: /home/digeratiexperts.com/current
+ *   Restart: sudo -n /usr/bin/systemctl restart digeratiexperts-site
+ *
+ * Deploy: sudo -u diger7051 bash deploy/vps/deploy.sh production
+ * Docs:   deploy/vps/README.md
+ */
 module.exports = {
-  apps: [{
-    name: 'digeratiexperts-site',
-    cwd: '/root/Replit-Site',
-    script: 'dist/index.js',
-    env: {
-      NODE_ENV: 'production',
-      PORT: '3300',
-      // Load DB URL via env file below OR set it here directly.
-    },
-    node_args: ['--env-file=.env']
-  }]
-}
+  apps: [],
+};

--- a/server/index.ts
+++ b/server/index.ts
@@ -30,9 +30,11 @@ import { eventBus, EventTypes } from "./eventBus";
 
 process.on('unhandledRejection', (reason, promise) => {
   const errorStr = String(reason);
-  if (errorStr.includes('endpoint has been disabled') || 
+  if (errorStr.includes('endpoint has been disabled') ||
       errorStr.includes('Connection terminated') ||
       errorStr.includes('connection to server')) {
+    // Tolerated (transient DB connection drops) but never silent.
+    console.warn('⚠️ Unhandled rejection (database connection, tolerated):', errorStr.slice(0, 200));
     return;
   }
   console.error('Unhandled Rejection:', reason);

--- a/server/middleware/security.ts
+++ b/server/middleware/security.ts
@@ -57,7 +57,18 @@ export async function verifyTurnstile(req: Request, res: Response, next: NextFun
   const turnstileToken = req.body.turnstileToken || req.body['cf-turnstile-response'];
   
   if (!process.env.TURNSTILE_SECRET_KEY) {
-    console.warn('[SECURITY] Turnstile not configured - skipping verification');
+    // Set TURNSTILE_ENFORCE=1 to fail closed when the secret is missing.
+    // Default remains fail-open so a config gap cannot lock out all logins,
+    // but in production it is logged as a security event, not a quiet skip.
+    if (process.env.TURNSTILE_ENFORCE === '1') {
+      console.error('[SECURITY] TURNSTILE_UNCONFIGURED_REJECT - enforcement on, secret missing');
+      return res.status(503).json({ error: 'Verification is temporarily unavailable. Please try again later.' });
+    }
+    if (process.env.NODE_ENV === 'production') {
+      console.error('[SECURITY] TURNSTILE_UNCONFIGURED - bot protection is OFF in production (set TURNSTILE_SECRET_KEY)');
+    } else {
+      console.warn('[SECURITY] Turnstile not configured - skipping verification');
+    }
     return next();
   }
 

--- a/server/portalAuthStore.removeKeys.test.ts
+++ b/server/portalAuthStore.removeKeys.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  getUser,
+  hasUser,
+  removeUserKeys,
+  setUser,
+} from "./portalAuthStore";
+
+describe("removeUserKeys", () => {
+  it("drops a stale email so it no longer authenticates after an email change", () => {
+    const user: any = {
+      id: "user-remove-1",
+      email: "old@example.com",
+      username: "removeuser1",
+      password: "x",
+      role: "user",
+      storeRole: "public",
+      clientId: null,
+    };
+    setUser(user);
+    expect(hasUser("old@example.com")).toBe(true);
+
+    // Simulate the profile handler: change email, then purge the old key.
+    user.email = "new@example.com";
+    setUser(user);
+    removeUserKeys(user.id, ["old@example.com"]);
+
+    expect(getUser("old@example.com")).toBeUndefined();
+    expect(getUser("new@example.com")?.id).toBe("user-remove-1");
+  });
+
+  it("does not remove a key that resolves to a different user", () => {
+    const a: any = { id: "user-a", email: "a@example.com", username: "ua", password: "x", role: "user", storeRole: "public", clientId: null };
+    const b: any = { id: "user-b", email: "b@example.com", username: "ub", password: "x", role: "user", storeRole: "public", clientId: null };
+    setUser(a);
+    setUser(b);
+    // user-a tries to purge user-b's key — must be a no-op.
+    removeUserKeys("user-a", ["b@example.com"]);
+    expect(getUser("b@example.com")?.id).toBe("user-b");
+  });
+});

--- a/server/portalAuthStore.ts
+++ b/server/portalAuthStore.ts
@@ -382,6 +382,23 @@ export function setUser(user: PortalAuthUser): void {
   void upsertUserDb(user);
 }
 
+/**
+ * Drop stale index keys (e.g. a previous email) that no longer point at the
+ * user after a profile change, so the old address can't still authenticate.
+ * Only removes a key when it currently resolves to this same user id.
+ */
+export function removeUserKeys(userId: string, keys: Array<string | null | undefined>): void {
+  for (const key of keys) {
+    if (!key) continue;
+    for (const variant of [key, key.toLowerCase()]) {
+      const existing = usersByKey.get(variant);
+      if (existing && existing.id === userId) {
+        usersByKey.delete(variant);
+      }
+    }
+  }
+}
+
 export function listUniqueUsers(): PortalAuthUser[] {
   const seen = new Set<string>();
   const out: PortalAuthUser[] = [];

--- a/server/portalZohoAuth.ts
+++ b/server/portalZohoAuth.ts
@@ -14,6 +14,7 @@
 
 import { createHash, createHmac, randomBytes, timingSafeEqual } from "crypto";
 import type { Request, Response } from "express";
+import { resolveJwtSecret } from "./config/authSecrets";
 
 const ACCOUNTS_BASE = (process.env.ZOHO_OIDC_ISSUER || "https://accounts.zoho.com").replace(
   /\/$/,
@@ -64,11 +65,12 @@ export function getZohoPortalConfig(): ZohoPortalConfig {
 }
 
 function stateSecret(): string {
+  // No hardcoded fallback: resolveJwtSecret fails closed in production and
+  // supplies a stable ephemeral secret in development.
   return (
     process.env.ZOHO_OAUTH_STATE_SECRET ||
-    process.env.JWT_SECRET ||
     process.env.SESSION_SECRET ||
-    "portal-zoho-state-dev-only"
+    resolveJwtSecret()
   );
 }
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,6 +1,6 @@
 import express, { type Express, type Request, type Response, NextFunction } from "express";
 import { storage } from "./storage";
-import { randomBytes, createHash } from "crypto";
+import { randomBytes, randomInt, createHash } from "crypto";
 import rateLimit from "express-rate-limit";
 import bcrypt from "bcrypt";
 import jwt from "jsonwebtoken";
@@ -36,6 +36,7 @@ import {
   getUser as portalAuthGetUser,
   hasUser as portalAuthHasUser,
   setUser as portalAuthSetUser,
+  removeUserKeys as portalAuthRemoveUserKeys,
   listUniqueUsers as portalAuthListUsers,
   getClient as portalAuthGetClient,
   setClient as portalAuthSetClient,
@@ -162,6 +163,16 @@ function clearPortalAuthCookies(res: Response) {
 
 // Utility function for generating IDs
 const randomId = () => randomBytes(16).toString('hex');
+
+// HTML-escape user-supplied strings interpolated into server-rendered HTML
+// (e.g. the order receipt). CSP allows inline scripts, so escaping is the guard.
+const escapeHtml = (value: unknown): string =>
+  String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 
 // Types
 interface AuthenticatedRequest extends Request {
@@ -2777,7 +2788,7 @@ export async function registerRoutes(app: Express) {
         const now = Date.now();
 
         if (user.mfaMethod === 'email') {
-          const code = String(Math.floor(100000 + Math.random() * 900000));
+          const code = String(randomInt(100000, 1000000));
           mfaChallenges.set(challengeToken, {
             userId: user.id,
             email: user.email,
@@ -2965,7 +2976,7 @@ export async function registerRoutes(app: Express) {
           message: "Scan the QR code with your authenticator app, then confirm with a code.",
         });
       } else {
-        const code = String(Math.floor(100000 + Math.random() * 900000));
+        const code = String(randomInt(100000, 1000000));
         const setupToken = randomId();
         mfaPendingSetups.set(setupToken, { userId: user.id, secret: code, createdAt: Date.now() });
 
@@ -3148,8 +3159,11 @@ export async function registerRoutes(app: Express) {
         if (portalUsers.has(nextEmail)) {
           return res.status(400).json({ message: "Email already in use" });
         }
+        const previousEmail = user.email;
         user.email = nextEmail;
         user.emailVerified = false;
+        // Drop the old email from the index so it can no longer authenticate.
+        portalAuthRemoveUserKeys(user.id, [previousEmail]);
       }
       portalUsers.set(user.email, user);
       if (user.username) portalUsers.set(user.username, user);
@@ -4140,7 +4154,7 @@ export async function registerRoutes(app: Express) {
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Receipt - ${order.orderNumber}</title>
+  <title>Receipt - ${escapeHtml(order.orderNumber)}</title>
   <style>
     body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 800px; margin: 0 auto; padding: 40px 20px; color: #333; }
     .header { text-align: center; margin-bottom: 40px; }
@@ -4172,7 +4186,7 @@ export async function registerRoutes(app: Express) {
   <div class="order-info">
     <div>
       <div class="label">Order Number</div>
-      <div class="value">${order.orderNumber}</div>
+      <div class="value">${escapeHtml(order.orderNumber)}</div>
     </div>
     <div>
       <div class="label">Order Date</div>
@@ -4202,7 +4216,7 @@ export async function registerRoutes(app: Express) {
     <tbody>
       ${lineItems.map((item: any) => `
         <tr>
-          <td>${item.name || "Item"}<br><small style="color:#666">SKU: ${item.sku || "N/A"}</small></td>
+          <td>${escapeHtml(item.name || "Item")}<br><small style="color:#666">SKU: ${escapeHtml(item.sku || "N/A")}</small></td>
           <td class="text-right">${item.quantity || 1}</td>
           <td class="text-right">$${parseFloat(item.unitPrice || "0").toFixed(2)}</td>
           <td class="text-right">$${parseFloat(item.total || "0").toFixed(2)}</td>
@@ -4228,12 +4242,12 @@ export async function registerRoutes(app: Express) {
 
   <div class="billing">
     <h3>Billing Information</h3>
-    <div>${order.billingName || "N/A"}</div>
-    ${order.billingCompany ? `<div>${order.billingCompany}</div>` : ""}
-    ${order.billingEmail ? `<div>${order.billingEmail}</div>` : ""}
-    ${billingAddress?.street ? `<div>${billingAddress.street}</div>` : ""}
+    <div>${escapeHtml(order.billingName || "N/A")}</div>
+    ${order.billingCompany ? `<div>${escapeHtml(order.billingCompany)}</div>` : ""}
+    ${order.billingEmail ? `<div>${escapeHtml(order.billingEmail)}</div>` : ""}
+    ${billingAddress?.street ? `<div>${escapeHtml(billingAddress.street)}</div>` : ""}
     ${billingAddress?.city || billingAddress?.state || billingAddress?.zipCode ? `
-      <div>${billingAddress.city || ""}${billingAddress.city && billingAddress.state ? ", " : ""}${billingAddress.state || ""} ${billingAddress.zipCode || ""}</div>
+      <div>${escapeHtml(billingAddress.city || "")}${billingAddress.city && billingAddress.state ? ", " : ""}${escapeHtml(billingAddress.state || "")} ${escapeHtml(billingAddress.zipCode || "")}</div>
     ` : ""}
   </div>
 

--- a/server/zoho/zohoClient.ts
+++ b/server/zoho/zohoClient.ts
@@ -37,19 +37,33 @@ class ZohoClient {
     return process.env.ZOHO_DESK_REFRESH_TOKEN || process.env.ZOHO_FORM_OAUTH || this.refreshToken;
   }
 
+  private crmRefreshPromise: Promise<string> | null = null;
+
+  // Dedup concurrent refreshes (Zoho rate-limits refresh-token grants) and
+  // send credentials in the POST body so they never land in URL/proxy logs.
   private async refreshAccessToken(): Promise<string> {
+    if (this.crmRefreshPromise) {
+      return this.crmRefreshPromise;
+    }
+    this.crmRefreshPromise = this._doRefreshCrmToken();
+    try {
+      return await this.crmRefreshPromise;
+    } finally {
+      this.crmRefreshPromise = null;
+    }
+  }
+
+  private async _doRefreshCrmToken(): Promise<string> {
     try {
       const response = await axios.post<ZohoTokenResponse>(
         'https://accounts.zoho.com/oauth/v2/token',
-        null,
-        {
-          params: {
-            grant_type: 'refresh_token',
-            client_id: this.clientId,
-            client_secret: this.clientSecret,
-            refresh_token: this.refreshToken,
-          },
-        }
+        new URLSearchParams({
+          grant_type: 'refresh_token',
+          client_id: this.clientId,
+          client_secret: this.clientSecret,
+          refresh_token: this.refreshToken,
+        }).toString(),
+        { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } }
       );
 
       this.accessToken = response.data.access_token;
@@ -84,15 +98,13 @@ class ZohoClient {
     try {
       const response = await axios.post<ZohoTokenResponse>(
         'https://accounts.zoho.com/oauth/v2/token',
-        null,
-        {
-          params: {
-            grant_type: 'refresh_token',
-            client_id: this.clientId,
-            client_secret: this.clientSecret,
-            refresh_token: token,
-          },
-        }
+        new URLSearchParams({
+          grant_type: 'refresh_token',
+          client_id: this.clientId,
+          client_secret: this.clientSecret,
+          refresh_token: token,
+        }).toString(),
+        { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } }
       );
 
       if (!response.data.access_token) {


### PR DESCRIPTION
## Summary

Follow-up to the merged [#171](https://github.com/digeratiexperts/digeratiexperts-site/pull/171), remediating the lower-severity findings (#8+) from the project-wide bug hunt. Scope is strictly those findings plus a regression test; no behavior outside them is touched.

| # | Finding | Root cause | Fix | Test |
|---|---------|-----------|-----|------|
| 8 | Email MFA code used `Math.random()` | not a CSPRNG | `crypto.randomInt(100000, 1000000)` for both email-MFA code sites (`server/routes.ts`) | full suite green; range asserted by construction |
| 9 | Zoho OAuth `state` secret fell back to hardcoded `"portal-zoho-state-dev-only"` | public literal in repo | resolves through `config/authSecrets` (fails closed in prod, stable ephemeral dev), no hardcoded fallback (`portalZohoAuth.ts`) | covered by existing authSecrets fail-closed tests |
| 10 | Order receipt HTML interpolated unescaped user billing/line-item fields (CSP allows inline scripts) | no escaping | `escapeHtml()` on orderNumber, item name/sku, billing name/company/email, address (`server/routes.ts`) | manual + suite |
| 11 | Turnstile fail-open was silent; client submitted `dev-bypass-token` on misconfig; consumed token not reset after failed login | missing signals + missing reset | server logs `[SECURITY]` error in prod when secret missing and supports `TURNSTILE_ENFORCE=1` to fail closed; client logs a prod-build error with no site key, resets the single-use token after a failed login (remount via `key`), and cleans up the widget on the already-loaded path | full suite |
| 17 | Zoho CRM token refresh: no in-flight dedup; credentials in URL query | unlike the Desk path | dedup via `crmRefreshPromise`; credentials moved to `x-www-form-urlencoded` POST body for both CRM and Desk refresh (`zoho/zohoClient.ts`) | full suite (Zoho client tests) |
| — | Stale email index after profile email change | old key never removed | `removeUserKeys()` purges the previous email on change so it can't still authenticate (`portalAuthStore.ts`, `routes.ts`) | **new** `portalAuthStore.removeKeys.test.ts` — purge + cross-user no-op |
| 9b | `ecosystem.config.cjs` still launched the deprecated `/root/Replit-Site` tree on port 3300 | live config, not stubbed | stubbed to `apps: []` like `ecosystem.config.js` | n/a |
| — | `deploy/vps/verify.sh` sitemap loop ran in a `\| while` subshell, dropping `FAIL` counts (exit 0 on broken routes) | subshell scoping | replaced pipeline with a `for` loop over a captured list, using `ok`/`bad` | shell |
| 18 | Uncaught DB-connection rejections swallowed silently | substring skip | now logged as tolerated warnings, not silent | n/a |

Not in scope (documented, deliberately deferred): plaintext MFA secrets at rest (`shared/schema.ts` — a schema/migration change with data-migration implications), the de-sync bearer-secret scheme (needs a coordinated Hub-side change), the dead `server/services/shipping.ts` mock code, and the missing migrations runner (an ops/deploy decision). Happy to take any of these next.

## Agent governance

- Task / claim ID: bug-hunt hardening follow-up (Joe-directed)
- Implementing agent: Claude Code (cloud session)
- Lead integrator: Claude Code by default
- Isolated branch/worktree used: YES (`claude/project-bug-hunt-0bjuuq` restarted from `origin/main` @ `2d7d12a` after #171 merged, per the merged-PR follow-up rule)
- `.ai/ACTIVE_WORK.yaml` + open PRs checked: YES — no file overlap
- Merge/deploy authority: Joe. Cloud session does not deploy.

## Completion report

1. **What changed:** the eight fixes above; 11 files, ~135/55.
2. **Why:** remediate remaining bug-hunt findings after #171.
3. **Files changed:** `server/routes.ts`, `portalZohoAuth.ts`, `middleware/security.ts`, `zoho/zohoClient.ts`, `portalAuthStore.ts`, `index.ts`; `client/src/components/TurnstileWidget.tsx`, `pages/portal/PortalLogin.tsx`; `deploy/vps/verify.sh`, `ecosystem.config.cjs`; new `server/portalAuthStore.removeKeys.test.ts`.
4. **Functionality preserved:** MFA/login/receipt/CRM flows unchanged for legitimate use; Turnstile default stays fail-open (a config gap can't lock out logins) but is now loud in prod.
5. **Tests:** `tsc` clean; `vitest` 88 files / 386 tests pass; production build OK; bundle budget 289.97/290.00 kB.
6. **Browser verification:** N/A from this environment (no visual treatment changed; the Turnstile change is token-lifecycle logic). A live failed-login retry is worth a manual check post-deploy.
7. **Remaining issues:** the deferred findings listed above.
8. **Human inputs still required:** review/merge (Joe). Optional env: set `TURNSTILE_ENFORCE=1` in prod once `TURNSTILE_SECRET_KEY` is confirmed present, to fail closed instead of open.

## CONCURRENCY AUDIT

```
CONCURRENCY AUDIT
Branch base: 2d7d12a (current origin/main; branch restarted from it)
Current origin/main: 2d7d12a
Commits landed on main since branch creation: 0
Overlapping files:
- NONE against open PRs
Overlapping active-agent claims:
- NONE
Reconciliation performed:
- branch restarted from origin/main after #171 merged; single commit on top
Newer-main work preserved:
YES
Whole-file replacements reviewed:
YES (ecosystem.config.cjs intentionally rewritten to a stub)
Tests:
tsc clean; vitest 88 files / 386 tests pass; production build OK; bundle budget 289.97/290.00 kB
Visual QA:
390/768/1440: N/A (no visual treatment changed)
Before/after evidence:
N/A (security/logic changes; behavior evidenced by tests)
Screenshots captured:
NO
Production impact:
Turnstile now logs loudly in prod if unconfigured; optional TURNSTILE_ENFORCE=1 fails closed. No env now required beyond #171's.
```

## Visual System v2

N/A — no visual treatments, HUD, or diagrams added.

## Release state

- PR state: IMPLEMENTED
- Production state: NOT DEPLOYED
- Expected release SHA / identifier: efb4a41
- Production verification evidence: pending — local Windows session owns VPS verification (`MERGED` ≠ `LIVE`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHtR1dF3njA7zwL6ofo99Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01UHtR1dF3njA7zwL6ofo99Q)_