### PR TITLE
Experience v1, revision 3: Acts 5–10 and the final frame, shown inside the site at /experience

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -156,6 +156,7 @@ const DigeratiHomepage = lazy(() => import("@/pages/DigeratiHomepage").then((m) 
 const VersionsIndex = lazy(() => import("@/pages/versions/VersionsIndex"));
 const VersionTwoForward = lazy(() => import("@/pages/versions/VersionTwoForward"));
 const HomepageV1 = lazy(() => import("@/pages/versions/v1/DigeratiHomepage").then((m) => ({ default: m.DigeratiHomepage })));
+const ExperienceInSite = lazy(() => import("@/pages/ExperienceInSite"));
 const HomepageV3 = lazy(() => import("@/pages/versions/v3/DigeratiHomepage").then((m) => ({ default: m.DigeratiHomepage })));
 
 const WarehouseGate = lazy(() => import("@/pages/store/WarehouseGate"));
@@ -173,6 +174,13 @@ function Router() {
       <Route path="/" component={() => (
         <Suspense fallback={<PageLoadingSkeleton />}>
           <DigeratiHomepage />
+        </Suspense>
+      )} />
+
+      {/* Experience v1 in the site's own chrome — review only, noindex, not in navigation */}
+      <Route path="/experience" component={() => (
+        <Suspense fallback={<PageLoadingSkeleton />}>
+          <ExperienceInSite />
         </Suspense>
       )} />
 

--- a/client/src/pages/ExperienceInSite.tsx
+++ b/client/src/pages/ExperienceInSite.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useRef } from "react";
+import { MegaMenu } from "@/components/MegaMenu";
+import { SiteBottomBar } from "@/components/SiteBottomBar";
+import { DigeratiEnhancedFooterSection } from "./sections/DigeratiEnhancedFooterSection";
+import { useSEO } from "@/hooks/useSEO";
+
+/**
+ * Experience v1 inside the site's own chrome (Joe, 2026-09-03: "show me it
+ * with the site, not all by itself"). Review only: noindex, canonical to /.
+ *
+ * The story itself is the static Scrollcraft build under
+ * public/scrollcraft/experience-v1 (one source of truth, also served on its
+ * own at that path). This page fetches that build's HTML, keeps its story
+ * (the skip link, the fixed world and <main>), drops its own bar and footer
+ * in favour of the site's MegaMenu and footer, rewrites the relative asset
+ * paths, and loads the engine and the glue as classic scripts, exactly as
+ * the static page does. Nothing here changes the homepage.
+ */
+const BASE = "/scrollcraft/experience-v1/";
+
+const CHROME_CSS = `
+.x-host{position:relative;min-height:60vh}
+/* in flow mode (phones, reduced motion) the story starts below the fixed menu */
+html:not(.x-pin) .x-host{padding-top:112px}
+/* the site's fixed menu covers the top of the pinned stage; keep the copy clear of it */
+html.x-pin .x-m{padding-top:clamp(120px,16vh,160px)}
+`;
+
+export default function ExperienceInSite(): JSX.Element {
+  useSEO({
+    title: "Your environment isn't broken. It's been drifting.",
+    description:
+      "Digerati Experts maps the people, devices, cloud services, vendors and risks behind your business, then gives every part an owner, a boundary and a direction. Start with a Cyber Risk Assessment.",
+    canonical: "/",
+    noIndex: true,
+  });
+  const host = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const added: Element[] = [];
+    const add = <T extends Element>(el: T, parent: Element = document.head): T => { parent.appendChild(el); added.push(el); return el; };
+
+    (async () => {
+      const res = await fetch(`${BASE}index.html`, { cache: "no-cache" });
+      const html = await res.text();
+      if (cancelled || !host.current) return;
+      const doc = new DOMParser().parseFromString(html, "text/html");
+      for (const el of Array.from(doc.querySelectorAll("[src],[srcset]"))) {
+        for (const attr of ["src", "srcset"]) {
+          const v = el.getAttribute(attr);
+          if (v && v.startsWith("assets/")) el.setAttribute(attr, BASE + v);
+        }
+      }
+      const link = document.createElement("link");
+      link.rel = "stylesheet";
+      link.href = `${BASE}scrollcraft.css`;
+      add(link);
+      const style = document.createElement("style");
+      style.textContent = (doc.querySelector("style")?.textContent ?? "").replace(/url\("assets\//g, `url("${BASE}assets/`);
+      add(style);
+      const chrome = document.createElement("style");
+      chrome.textContent = CHROME_CSS;
+      add(chrome);
+      host.current.innerHTML = [".x-skip", "#world", "main"].map((s) => doc.querySelector(s)?.outerHTML ?? "").join("");
+      for (const file of ["scrollcraft.js", "experience.js"]) {
+        if (cancelled) return;
+        await new Promise<void>((resolve, reject) => {
+          const s = document.createElement("script");
+          s.src = `${BASE}${file}`;
+          s.onload = () => resolve();
+          s.onerror = () => reject(new Error(`${file} failed to load`));
+          add(s, document.body);
+        });
+      }
+    })().catch((err) => console.warn("[experience] could not mount the story", err));
+
+    return () => {
+      cancelled = true;
+      added.forEach((el) => el.remove());
+      document.documentElement.classList.remove("x-pin", "x-flow", "sc-ready");
+    };
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-[#050312] text-white">
+      <MegaMenu />
+      <SiteBottomBar />
+      <div ref={host} className="x-host" data-testid="experience-host" />
+      <DigeratiEnhancedFooterSection />
+    </div>
+  );
+}

--- a/public/scrollcraft/experience-v1/experience.js
+++ b/public/scrollcraft/experience-v1/experience.js
@@ -31,6 +31,9 @@
   var reduce = matchMedia('(prefers-reduced-motion: reduce)').matches;
   var narrowMQ = matchMedia('(max-width: 767px)');
   var clamp01 = function (v) { return v < 0 ? 0 : v > 1 ? 1 : v; };
+  // scene.js lives beside this script, wherever the page that loads it lives
+  // (the lab page, or the site's /experience route)
+  var SCENE_URL = document.currentScript && document.currentScript.src ? new URL('scene.js', document.currentScript.src).href : './scene.js';
 
   /* ---------------------------------------------------------- presentation */
   if (stillT === null && (reduce || narrowMQ.matches)) {
@@ -163,6 +166,7 @@
 
   function frame(now) {
     running = false;
+    if (!pin.isConnected) return; // the site navigated away from the page
     var p = stillT !== null ? 0 : progress();
     var t = stillT !== null ? stillT : timeline(p);
     var dt = lastTime ? Math.min(0.05, (now - lastTime) / 1000) : 0.016; lastTime = now;
@@ -181,7 +185,7 @@
 
   function startStills() {
     worldEl.classList.remove('live');
-    var tick = function () { var p = progress(); setGroups(p); showPoster(timeline(p)); };
+    var tick = function () { if (!pin.isConnected) return; var p = progress(); setGroups(p); showPoster(timeline(p)); };
     addEventListener('scroll', tick, { passive: true }); tick();
   }
 
@@ -198,7 +202,7 @@
       document.addEventListener('x-scene', function () { resolve(window.__sceneModule); }, { once: true });
       setTimeout(function () { if (!window.__sceneModule) reject(new Error('scene module did not load')); }, 20000);
     });
-    return import('./scene.js');
+    return import(SCENE_URL);
   }
   loadScene().then(function (mod) {
     var portrait = innerHeight > innerWidth;

--- a/public/scrollcraft/experience-v1/index.html
+++ b/public/scrollcraft/experience-v1/index.html
@@ -150,6 +150,45 @@ html.x-pin .x-close{box-shadow:0 -60px 120px rgba(5,3,18,.95)}
 .x-foot p{margin:0;width:min(1060px,100%);margin-inline:auto}
 .x-foot a{color:inherit}
 
+/* ── acts 5–10 and the final frame: the evidence layer, on the page ────── */
+.x-sec{position:relative;z-index:1;background:var(--sc-canvas);border-top:1px solid var(--hair);padding:clamp(56px,9vh,100px) var(--gutter)}
+.x-sec .wrap{width:min(1060px,100%);margin-inline:auto}
+.x-sec .x-line{font-size:clamp(26px,3.6vw,46px)}
+.x-blocks{margin-top:36px;display:grid;grid-template-columns:repeat(7,1fr);gap:10px}
+@media(max-width:1023px){.x-blocks{grid-template-columns:repeat(4,1fr)}}
+@media(max-width:640px){.x-blocks{grid-template-columns:repeat(2,1fr)}}
+.x-block,.x-band{border:1px solid var(--hair);border-radius:6px;background:rgba(255,255,255,.025)}
+.x-block{padding:14px 12px 16px;min-height:150px;display:flex;flex-direction:column;gap:8px}
+.x-block i,.x-band i{font-style:normal;font-family:var(--util);font-size:9.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--sc-ink-soft)}
+.x-block b,.x-band b{font-family:var(--sc-font-display);font-weight:500;font-size:16px;letter-spacing:-.01em}
+.x-block span,.x-band span{font-family:var(--sc-font-text);font-size:13.5px;line-height:1.45;color:var(--sc-ink-soft)}
+.x-band{margin-top:10px;padding:14px 16px;border-color:rgba(211,18,106,.55);background:linear-gradient(90deg,rgba(211,18,106,.16),rgba(211,18,106,.04));display:flex;gap:16px;align-items:baseline;flex-wrap:wrap}
+.x-band b{color:var(--sc-ink);font-size:17px}
+.x-rail{margin-top:36px;display:grid;grid-template-columns:repeat(7,1fr);gap:0 14px;border-top:1px solid var(--hair)}
+@media(max-width:860px){.x-rail{grid-template-columns:1fr 1fr}}
+@media(max-width:480px){.x-rail{grid-template-columns:1fr}}
+.x-rail div{position:relative;padding:16px 0 12px}
+.x-rail div::before{content:"";position:absolute;left:0;top:-1px;width:28px;height:2px;background:var(--sc-accent)}
+.x-rail b{display:block;font-family:var(--sc-font-display);font-weight:500;font-size:17px;margin-bottom:4px}
+.x-rail span{font-family:var(--sc-font-text);font-size:13.5px;color:var(--sc-ink-soft);line-height:1.45}
+.x-rows{margin-top:32px;display:grid;grid-template-columns:repeat(3,1fr);gap:28px}
+@media(max-width:760px){.x-rows{grid-template-columns:1fr}}
+.x-rows>div{border-top:1px solid var(--hair);padding-top:16px}
+.x-rows b{display:block;font-family:var(--sc-font-display);font-weight:500;font-size:18px;margin-bottom:6px}
+.x-rows p{margin:0;font-family:var(--sc-font-text);font-size:14.5px;line-height:1.5;color:var(--sc-ink-soft)}
+.x-rows ul{margin:6px 0 0;padding:0;list-style:none}
+.x-rows li{font-family:var(--sc-font-text);font-size:14px;line-height:1.55;color:var(--sc-ink-soft);padding-left:14px;position:relative}
+.x-rows li::before{content:"";position:absolute;left:0;top:.62em;width:6px;height:1px;background:var(--sc-accent)}
+.x-paths{margin-top:28px}
+.x-refuse ul{list-style:none;margin:24px 0 0;padding:0;columns:2;column-gap:40px}
+@media(max-width:760px){.x-refuse ul{columns:1}}
+.x-refuse li{break-inside:avoid;border-top:1px solid var(--hair);padding:14px 0;font-family:var(--sc-font-display);font-size:19px;font-weight:500;letter-spacing:-.01em}
+.x-refuse li::before{content:"No. ";color:var(--sc-accent)}
+.x-final{min-height:70vh;display:flex;align-items:center;border-top:0}
+html.x-pin .x-final{background:linear-gradient(rgba(5,3,18,.96),rgba(5,3,18,.42) 32%,rgba(5,3,18,.42) 68%,rgba(5,3,18,.96))}
+html.x-pin .x-final .x-still{display:none}
+.x-final .x-still{margin-top:32px}
+
 /* still-render mode: the world alone, for the poster frames */
 html[data-still] main,html[data-still] .x-bar,html[data-still] .x-skip,html[data-still] .x-foot,html[data-still] .x-labels{display:none}
 html[data-still] .x-world canvas{transition:none}
@@ -243,22 +282,116 @@ html[data-still] .x-world canvas{transition:none}
     </div>
   </section>
 
+  <!-- Act 5 · the eight blocks emerge -->
+  <section class="x-sec" id="blocks" aria-labelledby="blocks-h">
+    <div class="wrap">
+      <p class="x-eyebrow">Eight blocks</p>
+      <h2 id="blocks-h" class="x-line">Eight blocks. One accountable operating model.</h2>
+      <p class="x-dek">Everything DE protects and operates falls into eight blocks. Seven are the parts of your environment. The eighth, Risk &amp; Exposure, runs under all of them and never switches off.</p>
+      <div class="x-blocks" role="list">
+        <div class="x-block" role="listitem"><i>01</i><b>Identity</b><span>Who is this, and should they be here?</span></div>
+        <div class="x-block" role="listitem"><i>02</i><b>Endpoints</b><span>Is this device known, healthy and patched?</span></div>
+        <div class="x-block" role="listitem"><i>03</i><b>Email</b><span>Did this message come from who it says?</span></div>
+        <div class="x-block" role="listitem"><i>04</i><b>Browser &amp; web</b><span>Can this page or download hurt us?</span></div>
+        <div class="x-block" role="listitem"><i>05</i><b>Network</b><span>What can reach what, and who watches the edge?</span></div>
+        <div class="x-block" role="listitem"><i>06 · 24/7</i><b>Detection &amp; response</b><span>Who noticed, and what happened next?</span></div>
+        <div class="x-block" role="listitem"><i>07</i><b>People</b><span>Would your team know what to do?</span></div>
+      </div>
+      <div class="x-band"><i>08 · continuous</i><b>Risk &amp; Exposure</b><span>What could hurt the business, how badly, and what are we doing about it first? Measured under every other block, all the time.</span></div>
+    </div>
+  </section>
+
+  <!-- Act 6 · the business operating system -->
+  <section class="x-sec" id="cadence" aria-labelledby="cadence-h">
+    <div class="wrap">
+      <p class="x-eyebrow">Operated as one system</p>
+      <h2 id="cadence-h" class="x-line">One environment. One cadence.</h2>
+      <p class="x-dek">Nothing here is a project that ends. The same seven states repeat for the whole environment, so a new person, a new device, a new rule or a new vendor lands inside a system that already has an owner.</p>
+      <div class="x-rail">
+        <div><b>Assess</b><span>Inspect what exists, not what the last invoice says.</span></div>
+        <div><b>Understand</b><span>Map the dependencies and the exceptions.</span></div>
+        <div><b>Design</b><span>Decide the boundaries and who owns each one.</span></div>
+        <div><b>Stabilize</b><span>Fix what is drifting before adding anything.</span></div>
+        <div><b>Secure</b><span>Close the blocks in order of exposure.</span></div>
+        <div><b>Operate</b><span>Monitor, patch, back up, verify, respond.</span></div>
+        <div><b>Improve</b><span>Review each quarter against the business, not the tools.</span></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Act 7 · the customer in command -->
+  <section class="x-sec" id="command" aria-labelledby="command-h">
+    <div class="wrap">
+      <p class="x-eyebrow">You lead the business</p>
+      <h2 id="command-h" class="x-line">You stay in command. We carry the technology.</h2>
+      <div class="x-rows">
+        <div><b>A named lead</b><p>One person who knows your environment answers for it. Not a queue, not a ticket number.</p></div>
+        <div><b>Decisions in your words</b><p>Every recommendation says what it costs, what it buys and what happens if you wait. You decide.</p></div>
+        <div><b>Nothing hidden</b><p>DE Desk for support, the Client Portal for status and records, the Marketplace for adding capabilities to an environment we already understand.</p></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Act 8 · the assessment -->
   <section class="x-close" id="begin" aria-labelledby="begin-h">
     <div class="wrap">
       <p class="x-eyebrow">Where to begin</p>
       <h2 id="begin-h" class="x-line">Start by understanding what you have.</h2>
-      <p class="x-dek">A Cyber Risk Assessment inspects the environment you just walked through: identity, devices, email, backups and how the business actually operates. The findings are yours whether or not you ever sign anything else.</p>
+      <p class="x-dek">A Cyber Risk Assessment inspects the environment you just walked through. The findings are yours whether or not you ever sign anything else.</p>
       <p class="x-act-cta"><a class="x-btn big" href="https://digeratiexperts.com/book">Start with a Cyber Risk Assessment</a></p>
       <p class="x-note">Pick a time. No obligation. We recommend a fit only after we have looked.</p>
-      <nav class="x-paths" aria-labelledby="paths-h">
-        <p id="paths-h" class="x-eyebrow">Other ways in</p>
+      <div class="x-rows">
+        <div><b>What gets inspected</b><ul><li>Identity and access</li><li>Devices and patching</li><li>Email and the people it reaches</li><li>Backups, tested or not</li><li>Network, vendors and how the business actually operates</li></ul></div>
+        <div><b>What you receive</b><ul><li>Findings in plain language, ranked by exposure</li><li>A prioritized plan with owners and order</li><li>A fit recommendation, or none, if the honest answer is none</li></ul></div>
+        <div><b>What happens next</b><ul><li>You read it with your named lead</li><li>You choose a relationship, or you keep the findings and go</li><li>If you proceed, Stabilize starts within the first cadence</li></ul></div>
+      </div>
+      <p class="x-who">Digerati Experts works with healthcare practices, law firms, accounting and finance firms, real estate brokerages, nonprofits, professional services firms and animal hospitals across Arizona.</p>
+    </div>
+  </section>
+
+  <!-- Act 9 · three paths -->
+  <section class="x-sec" id="paths" aria-labelledby="paths-h">
+    <div class="wrap">
+      <p class="x-eyebrow">Three ways in</p>
+      <h2 id="paths-h" class="x-line">Assess first. Then choose the relationship.</h2>
+      <nav class="x-paths" aria-label="Ways to work with Digerati Experts">
         <ul>
-          <li><a href="https://digeratiexperts.com/solutions/proactive-ecosystem"><b>Handle our IT</b><span>ProActive Ecosystem or Co-Managed: DE responsible for the broader environment.</span></a></li>
-          <li><a href="https://digeratiexperts.com/solutions"><b>Solve a business need</b><span>A bounded portion of the environment, solved properly.</span></a></li>
-          <li><a href="https://digeratiexperts.com/store"><b>Client marketplace</b><span>An already-understood environment, adding capabilities.</span></a></li>
+          <li><a href="https://digeratiexperts.com/solutions/proactive-ecosystem"><b>Handle our IT</b><span>ProActive Ecosystem: DE responsible for the whole environment. Co-Managed IT: DE alongside the people you already have.</span></a></li>
+          <li><a href="https://digeratiexperts.com/solutions"><b>Solve a business need</b><span>One bounded part of the environment, solved properly: Cloud Edge / SASE, Managed Physical Site Network, Hybrid / Multi-Site, Co-Managed Network, Threadline for email (Migration, Inbox, Continuity, Recovery), Switchboard for phones.</span></a></li>
+          <li><a href="https://digeratiexperts.com/store"><b>Client marketplace</b><span>An environment we already understand, adding capabilities with the boundaries already drawn.</span></a></li>
         </ul>
       </nav>
-      <p class="x-who">Digerati Experts works with healthcare practices, law firms, accounting and finance firms, real estate brokerages, nonprofits, professional services firms and animal hospitals across Arizona.</p>
+    </div>
+  </section>
+
+  <!-- Act 10 · the refusals -->
+  <section class="x-sec x-refuse" id="refusals" aria-labelledby="refusals-h">
+    <div class="wrap">
+      <p class="x-eyebrow">What we won't do</p>
+      <h2 id="refusals-h" class="x-line">The refusals.</h2>
+      <ul>
+        <li>Promise outcomes before we understand the environment.</li>
+        <li>Sell the tool of the month.</li>
+        <li>Invent numbers, telemetry or certifications.</li>
+        <li>Treat compliance as theatre.</li>
+        <li>Recommend what the assessment does not support.</li>
+        <li>Take over what you would rather keep.</li>
+      </ul>
+    </div>
+  </section>
+
+  <!-- The final frame returns: the same world, level, held -->
+  <section class="x-sec x-final" id="final" aria-labelledby="final-h">
+    <div class="wrap">
+      <p class="x-eyebrow">The same business</p>
+      <h2 id="final-h" class="x-line">Same people. Same devices. One system, with one owner.</h2>
+      <p class="x-act-cta"><a class="x-btn big" href="https://digeratiexperts.com/book">Start with a Cyber Risk Assessment</a></p>
+      <figure class="x-still">
+        <picture>
+          <source media="(max-width:767px)" srcset="assets/stills/m03.webp" width="800" height="1000">
+          <img src="assets/stills/s03.webp" width="1600" height="1000" alt="The same office, level and joined, with one magenta boundary around the whole floor." loading="lazy">
+        </picture>
+      </figure>
     </div>
   </section>
 

--- a/scrollcraft/builds/experience-v1/experience.js
+++ b/scrollcraft/builds/experience-v1/experience.js
@@ -31,6 +31,9 @@
   var reduce = matchMedia('(prefers-reduced-motion: reduce)').matches;
   var narrowMQ = matchMedia('(max-width: 767px)');
   var clamp01 = function (v) { return v < 0 ? 0 : v > 1 ? 1 : v; };
+  // scene.js lives beside this script, wherever the page that loads it lives
+  // (the lab page, or the site's /experience route)
+  var SCENE_URL = document.currentScript && document.currentScript.src ? new URL('scene.js', document.currentScript.src).href : './scene.js';
 
   /* ---------------------------------------------------------- presentation */
   if (stillT === null && (reduce || narrowMQ.matches)) {
@@ -163,6 +166,7 @@
 
   function frame(now) {
     running = false;
+    if (!pin.isConnected) return; // the site navigated away from the page
     var p = stillT !== null ? 0 : progress();
     var t = stillT !== null ? stillT : timeline(p);
     var dt = lastTime ? Math.min(0.05, (now - lastTime) / 1000) : 0.016; lastTime = now;
@@ -181,7 +185,7 @@
 
   function startStills() {
     worldEl.classList.remove('live');
-    var tick = function () { var p = progress(); setGroups(p); showPoster(timeline(p)); };
+    var tick = function () { if (!pin.isConnected) return; var p = progress(); setGroups(p); showPoster(timeline(p)); };
     addEventListener('scroll', tick, { passive: true }); tick();
   }
 
@@ -198,7 +202,7 @@
       document.addEventListener('x-scene', function () { resolve(window.__sceneModule); }, { once: true });
       setTimeout(function () { if (!window.__sceneModule) reject(new Error('scene module did not load')); }, 20000);
     });
-    return import('./scene.js');
+    return import(SCENE_URL);
   }
   loadScene().then(function (mod) {
     var portrait = innerHeight > innerWidth;

--- a/scrollcraft/builds/experience-v1/index.html
+++ b/scrollcraft/builds/experience-v1/index.html
@@ -150,6 +150,45 @@ html.x-pin .x-close{box-shadow:0 -60px 120px rgba(5,3,18,.95)}
 .x-foot p{margin:0;width:min(1060px,100%);margin-inline:auto}
 .x-foot a{color:inherit}
 
+/* ── acts 5–10 and the final frame: the evidence layer, on the page ────── */
+.x-sec{position:relative;z-index:1;background:var(--sc-canvas);border-top:1px solid var(--hair);padding:clamp(56px,9vh,100px) var(--gutter)}
+.x-sec .wrap{width:min(1060px,100%);margin-inline:auto}
+.x-sec .x-line{font-size:clamp(26px,3.6vw,46px)}
+.x-blocks{margin-top:36px;display:grid;grid-template-columns:repeat(7,1fr);gap:10px}
+@media(max-width:1023px){.x-blocks{grid-template-columns:repeat(4,1fr)}}
+@media(max-width:640px){.x-blocks{grid-template-columns:repeat(2,1fr)}}
+.x-block,.x-band{border:1px solid var(--hair);border-radius:6px;background:rgba(255,255,255,.025)}
+.x-block{padding:14px 12px 16px;min-height:150px;display:flex;flex-direction:column;gap:8px}
+.x-block i,.x-band i{font-style:normal;font-family:var(--util);font-size:9.5px;letter-spacing:.18em;text-transform:uppercase;color:var(--sc-ink-soft)}
+.x-block b,.x-band b{font-family:var(--sc-font-display);font-weight:500;font-size:16px;letter-spacing:-.01em}
+.x-block span,.x-band span{font-family:var(--sc-font-text);font-size:13.5px;line-height:1.45;color:var(--sc-ink-soft)}
+.x-band{margin-top:10px;padding:14px 16px;border-color:rgba(211,18,106,.55);background:linear-gradient(90deg,rgba(211,18,106,.16),rgba(211,18,106,.04));display:flex;gap:16px;align-items:baseline;flex-wrap:wrap}
+.x-band b{color:var(--sc-ink);font-size:17px}
+.x-rail{margin-top:36px;display:grid;grid-template-columns:repeat(7,1fr);gap:0 14px;border-top:1px solid var(--hair)}
+@media(max-width:860px){.x-rail{grid-template-columns:1fr 1fr}}
+@media(max-width:480px){.x-rail{grid-template-columns:1fr}}
+.x-rail div{position:relative;padding:16px 0 12px}
+.x-rail div::before{content:"";position:absolute;left:0;top:-1px;width:28px;height:2px;background:var(--sc-accent)}
+.x-rail b{display:block;font-family:var(--sc-font-display);font-weight:500;font-size:17px;margin-bottom:4px}
+.x-rail span{font-family:var(--sc-font-text);font-size:13.5px;color:var(--sc-ink-soft);line-height:1.45}
+.x-rows{margin-top:32px;display:grid;grid-template-columns:repeat(3,1fr);gap:28px}
+@media(max-width:760px){.x-rows{grid-template-columns:1fr}}
+.x-rows>div{border-top:1px solid var(--hair);padding-top:16px}
+.x-rows b{display:block;font-family:var(--sc-font-display);font-weight:500;font-size:18px;margin-bottom:6px}
+.x-rows p{margin:0;font-family:var(--sc-font-text);font-size:14.5px;line-height:1.5;color:var(--sc-ink-soft)}
+.x-rows ul{margin:6px 0 0;padding:0;list-style:none}
+.x-rows li{font-family:var(--sc-font-text);font-size:14px;line-height:1.55;color:var(--sc-ink-soft);padding-left:14px;position:relative}
+.x-rows li::before{content:"";position:absolute;left:0;top:.62em;width:6px;height:1px;background:var(--sc-accent)}
+.x-paths{margin-top:28px}
+.x-refuse ul{list-style:none;margin:24px 0 0;padding:0;columns:2;column-gap:40px}
+@media(max-width:760px){.x-refuse ul{columns:1}}
+.x-refuse li{break-inside:avoid;border-top:1px solid var(--hair);padding:14px 0;font-family:var(--sc-font-display);font-size:19px;font-weight:500;letter-spacing:-.01em}
+.x-refuse li::before{content:"No. ";color:var(--sc-accent)}
+.x-final{min-height:70vh;display:flex;align-items:center;border-top:0}
+html.x-pin .x-final{background:linear-gradient(rgba(5,3,18,.96),rgba(5,3,18,.42) 32%,rgba(5,3,18,.42) 68%,rgba(5,3,18,.96))}
+html.x-pin .x-final .x-still{display:none}
+.x-final .x-still{margin-top:32px}
+
 /* still-render mode: the world alone, for the poster frames */
 html[data-still] main,html[data-still] .x-bar,html[data-still] .x-skip,html[data-still] .x-foot,html[data-still] .x-labels{display:none}
 html[data-still] .x-world canvas{transition:none}
@@ -243,22 +282,116 @@ html[data-still] .x-world canvas{transition:none}
     </div>
   </section>
 
+  <!-- Act 5 · the eight blocks emerge -->
+  <section class="x-sec" id="blocks" aria-labelledby="blocks-h">
+    <div class="wrap">
+      <p class="x-eyebrow">Eight blocks</p>
+      <h2 id="blocks-h" class="x-line">Eight blocks. One accountable operating model.</h2>
+      <p class="x-dek">Everything DE protects and operates falls into eight blocks. Seven are the parts of your environment. The eighth, Risk &amp; Exposure, runs under all of them and never switches off.</p>
+      <div class="x-blocks" role="list">
+        <div class="x-block" role="listitem"><i>01</i><b>Identity</b><span>Who is this, and should they be here?</span></div>
+        <div class="x-block" role="listitem"><i>02</i><b>Endpoints</b><span>Is this device known, healthy and patched?</span></div>
+        <div class="x-block" role="listitem"><i>03</i><b>Email</b><span>Did this message come from who it says?</span></div>
+        <div class="x-block" role="listitem"><i>04</i><b>Browser &amp; web</b><span>Can this page or download hurt us?</span></div>
+        <div class="x-block" role="listitem"><i>05</i><b>Network</b><span>What can reach what, and who watches the edge?</span></div>
+        <div class="x-block" role="listitem"><i>06 · 24/7</i><b>Detection &amp; response</b><span>Who noticed, and what happened next?</span></div>
+        <div class="x-block" role="listitem"><i>07</i><b>People</b><span>Would your team know what to do?</span></div>
+      </div>
+      <div class="x-band"><i>08 · continuous</i><b>Risk &amp; Exposure</b><span>What could hurt the business, how badly, and what are we doing about it first? Measured under every other block, all the time.</span></div>
+    </div>
+  </section>
+
+  <!-- Act 6 · the business operating system -->
+  <section class="x-sec" id="cadence" aria-labelledby="cadence-h">
+    <div class="wrap">
+      <p class="x-eyebrow">Operated as one system</p>
+      <h2 id="cadence-h" class="x-line">One environment. One cadence.</h2>
+      <p class="x-dek">Nothing here is a project that ends. The same seven states repeat for the whole environment, so a new person, a new device, a new rule or a new vendor lands inside a system that already has an owner.</p>
+      <div class="x-rail">
+        <div><b>Assess</b><span>Inspect what exists, not what the last invoice says.</span></div>
+        <div><b>Understand</b><span>Map the dependencies and the exceptions.</span></div>
+        <div><b>Design</b><span>Decide the boundaries and who owns each one.</span></div>
+        <div><b>Stabilize</b><span>Fix what is drifting before adding anything.</span></div>
+        <div><b>Secure</b><span>Close the blocks in order of exposure.</span></div>
+        <div><b>Operate</b><span>Monitor, patch, back up, verify, respond.</span></div>
+        <div><b>Improve</b><span>Review each quarter against the business, not the tools.</span></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Act 7 · the customer in command -->
+  <section class="x-sec" id="command" aria-labelledby="command-h">
+    <div class="wrap">
+      <p class="x-eyebrow">You lead the business</p>
+      <h2 id="command-h" class="x-line">You stay in command. We carry the technology.</h2>
+      <div class="x-rows">
+        <div><b>A named lead</b><p>One person who knows your environment answers for it. Not a queue, not a ticket number.</p></div>
+        <div><b>Decisions in your words</b><p>Every recommendation says what it costs, what it buys and what happens if you wait. You decide.</p></div>
+        <div><b>Nothing hidden</b><p>DE Desk for support, the Client Portal for status and records, the Marketplace for adding capabilities to an environment we already understand.</p></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Act 8 · the assessment -->
   <section class="x-close" id="begin" aria-labelledby="begin-h">
     <div class="wrap">
       <p class="x-eyebrow">Where to begin</p>
       <h2 id="begin-h" class="x-line">Start by understanding what you have.</h2>
-      <p class="x-dek">A Cyber Risk Assessment inspects the environment you just walked through: identity, devices, email, backups and how the business actually operates. The findings are yours whether or not you ever sign anything else.</p>
+      <p class="x-dek">A Cyber Risk Assessment inspects the environment you just walked through. The findings are yours whether or not you ever sign anything else.</p>
       <p class="x-act-cta"><a class="x-btn big" href="https://digeratiexperts.com/book">Start with a Cyber Risk Assessment</a></p>
       <p class="x-note">Pick a time. No obligation. We recommend a fit only after we have looked.</p>
-      <nav class="x-paths" aria-labelledby="paths-h">
-        <p id="paths-h" class="x-eyebrow">Other ways in</p>
+      <div class="x-rows">
+        <div><b>What gets inspected</b><ul><li>Identity and access</li><li>Devices and patching</li><li>Email and the people it reaches</li><li>Backups, tested or not</li><li>Network, vendors and how the business actually operates</li></ul></div>
+        <div><b>What you receive</b><ul><li>Findings in plain language, ranked by exposure</li><li>A prioritized plan with owners and order</li><li>A fit recommendation, or none, if the honest answer is none</li></ul></div>
+        <div><b>What happens next</b><ul><li>You read it with your named lead</li><li>You choose a relationship, or you keep the findings and go</li><li>If you proceed, Stabilize starts within the first cadence</li></ul></div>
+      </div>
+      <p class="x-who">Digerati Experts works with healthcare practices, law firms, accounting and finance firms, real estate brokerages, nonprofits, professional services firms and animal hospitals across Arizona.</p>
+    </div>
+  </section>
+
+  <!-- Act 9 · three paths -->
+  <section class="x-sec" id="paths" aria-labelledby="paths-h">
+    <div class="wrap">
+      <p class="x-eyebrow">Three ways in</p>
+      <h2 id="paths-h" class="x-line">Assess first. Then choose the relationship.</h2>
+      <nav class="x-paths" aria-label="Ways to work with Digerati Experts">
         <ul>
-          <li><a href="https://digeratiexperts.com/solutions/proactive-ecosystem"><b>Handle our IT</b><span>ProActive Ecosystem or Co-Managed: DE responsible for the broader environment.</span></a></li>
-          <li><a href="https://digeratiexperts.com/solutions"><b>Solve a business need</b><span>A bounded portion of the environment, solved properly.</span></a></li>
-          <li><a href="https://digeratiexperts.com/store"><b>Client marketplace</b><span>An already-understood environment, adding capabilities.</span></a></li>
+          <li><a href="https://digeratiexperts.com/solutions/proactive-ecosystem"><b>Handle our IT</b><span>ProActive Ecosystem: DE responsible for the whole environment. Co-Managed IT: DE alongside the people you already have.</span></a></li>
+          <li><a href="https://digeratiexperts.com/solutions"><b>Solve a business need</b><span>One bounded part of the environment, solved properly: Cloud Edge / SASE, Managed Physical Site Network, Hybrid / Multi-Site, Co-Managed Network, Threadline for email (Migration, Inbox, Continuity, Recovery), Switchboard for phones.</span></a></li>
+          <li><a href="https://digeratiexperts.com/store"><b>Client marketplace</b><span>An environment we already understand, adding capabilities with the boundaries already drawn.</span></a></li>
         </ul>
       </nav>
-      <p class="x-who">Digerati Experts works with healthcare practices, law firms, accounting and finance firms, real estate brokerages, nonprofits, professional services firms and animal hospitals across Arizona.</p>
+    </div>
+  </section>
+
+  <!-- Act 10 · the refusals -->
+  <section class="x-sec x-refuse" id="refusals" aria-labelledby="refusals-h">
+    <div class="wrap">
+      <p class="x-eyebrow">What we won't do</p>
+      <h2 id="refusals-h" class="x-line">The refusals.</h2>
+      <ul>
+        <li>Promise outcomes before we understand the environment.</li>
+        <li>Sell the tool of the month.</li>
+        <li>Invent numbers, telemetry or certifications.</li>
+        <li>Treat compliance as theatre.</li>
+        <li>Recommend what the assessment does not support.</li>
+        <li>Take over what you would rather keep.</li>
+      </ul>
+    </div>
+  </section>
+
+  <!-- The final frame returns: the same world, level, held -->
+  <section class="x-sec x-final" id="final" aria-labelledby="final-h">
+    <div class="wrap">
+      <p class="x-eyebrow">The same business</p>
+      <h2 id="final-h" class="x-line">Same people. Same devices. One system, with one owner.</h2>
+      <p class="x-act-cta"><a class="x-btn big" href="https://digeratiexperts.com/book">Start with a Cyber Risk Assessment</a></p>
+      <figure class="x-still">
+        <picture>
+          <source media="(max-width:767px)" srcset="assets/stills/m03.webp" width="800" height="1000">
+          <img src="assets/stills/s03.webp" width="1600" height="1000" alt="The same office, level and joined, with one magenta boundary around the whole floor." loading="lazy">
+        </picture>
+      </figure>
     </div>
   </section>
 

--- a/scrollcraft/builds/experience-v1/tools/gate.mjs
+++ b/scrollcraft/builds/experience-v1/tools/gate.mjs
@@ -102,13 +102,15 @@ for (const run of RUNS) {
       const vh = innerHeight;
       const eff = (el) => { let o = 1; for (let n = el; n && n !== document.body; n = n.parentElement) { const cs = getComputedStyle(n); if (cs.visibility === "hidden" || cs.display === "none" || n.inert) return 0; o *= parseFloat(cs.opacity); } return o; };
       const out = [];
-      for (const el of document.querySelectorAll("main h1, main h2, main p, main blockquote, main li")) {
-        const t = (el.innerText || "").trim(); if (t.length < 12) continue;
+      for (const el of document.querySelectorAll("main h1, main h2, main p, main blockquote, main li, main .x-block, main .x-band, main .x-rail > div, main .x-rows > div, main .x-still img")) {
+        const isImg = el.tagName === "IMG";
+        const t = isImg ? "[still: " + (el.getAttribute("alt") || "") + "]" : (el.innerText || "").trim();
+        if (!isImg && t.length < 12) continue;
         const r = el.getBoundingClientRect(); if (r.height === 0) continue;
-        const inter = Math.min(r.bottom, vh) - Math.max(r.top, 0); if (inter / r.height < 0.7) continue;
+        const inter = Math.min(r.bottom, vh) - Math.max(r.top, 0); if (inter / r.height < (isImg ? 0.5 : 0.7)) continue;
         if (eff(el) < 0.95) continue;
         const cs = getComputedStyle(el);
-        out.push({ tag: el.tagName, text: t.slice(0, 60), rect: { x: Math.round(r.left), y: Math.round(r.top), w: Math.round(r.width), h: Math.round(r.height) }, color: cs.color });
+        out.push({ tag: isImg ? "IMG" : el.tagName, text: t.slice(0, 60), rect: { x: Math.round(r.left), y: Math.round(r.top), w: Math.round(r.width), h: Math.round(r.height) }, color: cs.color });
       }
       return out;
     });
@@ -140,7 +142,7 @@ for (const run of RUNS) {
     }));
     if (flow.pinned) F("flow mode still pins");
     if (flow.hidden) F("flow mode hides " + flow.hidden + " copy elements");
-    if (flow.stills.length !== 3 || flow.stills.some((s) => !s.shown || !s.ok)) F("flow stills missing: " + JSON.stringify(flow.stills));
+    if (flow.stills.length < 3 || flow.stills.some((s) => !s.shown || !s.ok)) F("flow stills missing: " + JSON.stringify(flow.stills));
     stills = flow.stills.map((s) => s.src);
   }
 

--- a/scrollcraft/experience-v1/FLAGSHIP-PROTOTYPE-REPORT.md
+++ b/scrollcraft/experience-v1/FLAGSHIP-PROTOTYPE-REPORT.md
@@ -244,3 +244,27 @@ the current record; this revision is the response to the two lowest
 (usability 3, readiness 2) and to the artwork verdict, and it asks him to
 re-score the published page rather than claiming numbers of its own. The
 page stays `noindex, nofollow`.
+
+### Revision 3 · 2026-09-03 · the rest of the plan, shown with the site
+
+Joe: "finish the rest of the plan and show it all together with the entire
+upgraded site … show me it with the site is what I meant, not all by itself."
+
+- **Acts 5–10 and the final frame** now follow the three-movement story on
+  the page, as the evidence layer under the story: the eight blocks (seven
+  parts of the environment and Risk & Exposure as the continuous eighth),
+  the operating cadence (assess → understand → design → stabilize → secure →
+  operate → improve), the customer in command, the assessment (what is
+  inspected, what you receive, what happens next, one dominant control),
+  the three ways in with the canonical service names, the refusals, and the
+  final frame: the same world, level, held behind the last screen (a still
+  in flow mode).
+- **Shown with the site.** `/experience` is a React route that wraps the
+  same static build in the site's own MegaMenu and footer: it fetches the
+  build's HTML, keeps the story, drops the build's bar and footer, rewrites
+  asset paths and loads the engine and the glue exactly as the standalone
+  page does. `/experience-v1` now forwards there; the standalone page stays
+  at `/scrollcraft/experience-v1/`. Both are `noindex`; the homepage is
+  untouched.
+- **Not upgraded:** every other page of the site is as it was. This revision
+  adds one review route and changes one redirect.

--- a/server/index.ts
+++ b/server/index.ts
@@ -436,10 +436,12 @@ app.use(
 );
 
 // Experience v1 (Joe, 2026-09-03: "published to another page until I approve
-// it"): the flagship prototype lives in the lab; this is its speakable address.
+// it", then "show me it with the site"): the speakable address forwards to the
+// React route that wraps the story in the site's own menu and footer; the
+// standalone build stays at /scrollcraft/experience-v1/ for the lab.
 app.get("/experience-v1", (_req, res) => {
   res.setHeader("X-Robots-Tag", "noindex");
-  res.redirect(302, "/scrollcraft/experience-v1/");
+  res.redirect(302, "/experience");
 });
 
 // Homepage version archive (client/src/pages/versions/README.md): version 2


### PR DESCRIPTION
## Summary

Joe (2026-09-03): "finish the rest of the plan and show it all together with the entire upgraded site … show me it with the site is what I meant, not all by itself."

- **The rest of the plan.** After the three-movement story, the page now carries Acts 5–10 and the final frame as the evidence layer: the eight blocks (seven parts of the environment and Risk & Exposure as the continuous eighth), the operating cadence (assess → understand → design → stabilize → secure → operate → improve), the customer in command, the assessment (what is inspected, what you receive, what happens next, one dominant control), the three ways in with the canonical service names (ProActive Ecosystem, Co-Managed IT; Cloud Edge / SASE, Managed Physical Site Network, Hybrid / Multi-Site, Co-Managed Network, Threadline, Switchboard; the Client marketplace), the refusals, and the final frame: the same world, level, held behind the last screen.
- **Shown with the site.** `/experience` is a React route that wraps the same static build in the site's own MegaMenu, bottom bar and footer. It fetches the build's HTML, keeps the story, drops the build's bar and footer, rewrites the asset paths and loads the engine and the glue exactly as the standalone page does. `noindex`, canonical to `/`, not in navigation, not in the sitemap (the sitemap is a static list).
- `/experience-v1` now forwards to `/experience`; the standalone page stays at `/scrollcraft/experience-v1/` for the lab.
- **Nothing else on the site changed.** The homepage is untouched; every other page is as it was. This PR adds one review route and changes one redirect.

## Agent governance

- Task / claim ID: `de-experience-v1` (`.ai/ACTIVE_WORK.yaml`)
- Implementing agent: Claude Code
- Lead integrator: Claude Code by default
- Isolated branch/worktree used: YES (`/home/user/de-exp`, `claude/experience-v1-complete` from `main @ 4f82276`)
- `.ai/ACTIVE_WORK.yaml` + current open PRs checked before implementation: YES
- Any overlapping active agent work: NONE. `client/src/App.tsx` gains one lazy import and one route next to the versions routes; `server/index.ts` changes one redirect target; no open PR touches those lines.
- Merge/deploy authority: Joe's instruction of 2026-09-03 to finish the plan and show it with the site, on the review route he already approved publishing. Merging publishes the review route and the redirect only.

## Completion report

1. **What changed**: `scrollcraft/builds/experience-v1/index.html` (Acts 5–10, final frame, their CSS), `experience.js` (scene path beside the script; stops when the site navigates away), `tools/gate.mjs` (evidence-layer elements and stills count as content), the lab copy under `public/scrollcraft/experience-v1/`, `client/src/pages/ExperienceInSite.tsx` (new), `client/src/App.tsx` (route), `server/index.ts` (redirect), `FLAGSHIP-PROTOTYPE-REPORT.md` (revision 3).
2. **Why**: Joe's instruction above.
3. **Files changed**: 9.
4. **Functionality preserved**: the three-movement story, its flow mode, its keyboard behaviour and its stills are unchanged; the engine is untouched; `/`, `/versions`, `/v2`, `/scrollcraft/**` unchanged.
5. **Tests performed**: `tsc` clean; production build; the release gate on the standalone build (pinned runs at 1440×900 and 768×1024 pass; the flow runs' results are updated in a comment once the widened gate finishes).
6. **Browser verification performed**: the built client served with the repo's `public/` mounted at `/scrollcraft/**` as production does: `/experience` at 1440×900 (pinned, world live under the fixed MegaMenu) and 390×844 (flow), real chrome present, `noindex, nofollow`, eight sections, no horizontal overflow, no console errors. Headless Chromium, software GL only.
7. **Remaining issues**: the journey is longer again by design (about 8.6 vh on desktop, 11 vh on phones, decision section at about 6 vh on desktop); the first assessment control stays at the top and the header control persists. Safari, a real GPU and a real phone remain manual.
8. **Human inputs still required**: Joe's review of `/experience` in his browser.

## CONCURRENCY AUDIT

```
CONCURRENCY AUDIT
Branch base: 4f822768ee6104751cbbee0db4d78a4e837885dc (main, 2026-09-03)
Current origin/main: 4f82276
Commits landed on main since branch creation: 0
Overlapping files:
- client/src/App.tsx: one import and one route added beside the versions routes; no open PR touches them
- server/index.ts: one redirect target changed; no open PR touches it
- .ai/ACTIVE_WORK.yaml: untouched by this PR
Overlapping active-agent claims:
- de-site-v2-scrollcraft (#184): owns scrollcraft/** and the /scrollcraft mount; this lane is a claim inside it
Reconciliation performed: none needed (base == main)
Newer-main work preserved:
YES
Whole-file replacements reviewed:
YES (ExperienceInSite.tsx is new; index.html extended in place)
Tests:
tsc 0; production build; gate on the standalone build; in-site check at 1440 and 390
Visual QA:
390: PASS (flow inside the site chrome, no overflow, no errors)
768: PASS (standalone gate, pinned)
1440: PASS (pinned inside the site chrome, world live, no errors)
Before/after evidence:
YES (lab/insite screenshots, gitignored; the previous state is PR #193's page)
Screenshots captured:
YES
Production impact:
adds the noindex review route /experience and points /experience-v1 at it; nothing else.
```

## Visual System v2

Brand floor only: graphite ground, magenta where DE acts and on the one control, the three locked faces, the site's own chrome. The eight-block figure is code (CSS grid and a continuous band), not a card grid for its own sake. No photography, no generated imagery, no invented numbers.

## Release state

- PR state: IMPLEMENTED
- Production state: NOT DEPLOYED
- Expected release SHA / identifier: the merge commit of 9280a22
- Production verification evidence: pending; `/experience` must render the story inside the site chrome in a real browser

`MERGED` does not mean `LIVE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rhj3KMUtrJJHkdfhWmQuWq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rhj3KMUtrJJHkdfhWmQuWq)_