### PR TITLE
feat: enforce account lifecycle disclosure boundary in tests

### DIFF
--- a/.cursor/rules/account-lifecycle.mdc
+++ b/.cursor/rules/account-lifecycle.mdc
@@ -28,6 +28,12 @@ Canonical values (v1.1, exactly one per account):
 3. Client-visible wording about the relationship comes from an approved presentation mapping, never the raw value. No mapping entry → show nothing.
 4. Leaking a lifecycle value to a client or the public is a **P0 defect**.
 
+## Enforcement — this is tested, not just documented
+
+`server/integrations/tenantIdentity.ts` exports `findLifecycleDisclosures(payload)` and `assertNoLifecycleDisclosure(payload, label)`. `server/integrations/lifecycleDisclosure.test.ts` feeds each client-bound serializer a source record polluted with lifecycle fields and asserts the output is clean — a serializer that starts spreading its source fails CI.
+
+**Adding a client-scoped serializer means adding it to `CLIENT_BOUND_SERIALIZERS` in that test.** The guard only covers serializers it has been given; it does not cover response objects built inline in a route handler, so review still matters there.
+
 ## Two different "lifecycles" — do not conflate
 
 `/portal/admin/lifecycle`, `AdminLifecycle.tsx`, `server/lifecycleOrchestrator.ts`, and `/api/portal/admin/lifecycle/*` are the **JumpCloud + Blackpoint employee identity lifecycle** (onboarding/offboarding a client's own staff). That is a different domain from **Account Lifecycle Status** (DE's relationship with the client organization). Do not merge, rename into, cross-wire, or infer one from the other.

--- a/docs/ACCOUNT-LIFECYCLE-STATUS.md
+++ b/docs/ACCOUNT-LIFECYCLE-STATUS.md
@@ -241,6 +241,22 @@ These are legacy surfaces requiring migration to the canonical 13-value model. T
 
 `MATURITY_STAGES` and `mapPortalMaturity()` produce a portal-side derived stage. Derived or not, it inherits this document's disclosure boundary: `prospect`, `former`, and `closed` must not surface to a client. If any maturity signal is ever shown client-side, it must go through an approved presentation mapping.
 
+### Automated enforcement
+
+The boundary is enforced by tests, not only by review. `server/integrations/tenantIdentity.ts` exports:
+
+- `ACCOUNT_LIFECYCLE_STATUSES` — the canonical 13 values;
+- `findLifecycleDisclosures(payload)` — walks a client-bound payload and returns every disclosure, by path;
+- `assertNoLifecycleDisclosure(payload, label)` — throws on any disclosure.
+
+Detection is deliberately asymmetric. A **lifecycle-named key** (`lifecycle`, `lifecycleStatus`, `accountLifecycleStatus`, `hubLifecycle`, in any casing or separator style) is always a violation — naming a field that way and putting anything in it discloses the classification. A **value** match only fires on unambiguous terms, so a portal user's `status: "active"`, a request's `state: "pending"`, and the existing client-visible `storeRole: "prospect"` do not trip it.
+
+`server/integrations/lifecycleDisclosure.test.ts` feeds each client-bound serializer a source record deliberately polluted with lifecycle fields — the shape a future schema addition or a Hub sync would produce — and asserts the output is clean. An allowlist serializer drops them; a serializer that starts spreading its source (`...user`) fails the test. This has been verified to fail on a deliberately leaky serializer, so it is a real guard rather than a vacuous one.
+
+**When you add a client-scoped serializer, add it to `CLIENT_BOUND_SERIALIZERS` in that test.** The guard cannot find a serializer it has never been given.
+
+Its limits, stated honestly: it covers serializers registered in that list, not every route handler that builds a response inline, and it cannot see values assembled only at runtime from live data. It raises the floor; it does not make a leak impossible.
+
 ### Checklist before merging a portal or website change
 
 1. Does any response reaching an unauthenticated visitor or a portal client contain a lifecycle value? If yes, remove it from the payload.

--- a/docs/ACCOUNT-LIFECYCLE-STATUS.md
+++ b/docs/ACCOUNT-LIFECYCLE-STATUS.md
@@ -2,7 +2,7 @@
 name: DE Account Lifecycle Status — Source of Truth (mirror)
 description: Mirror of the canonical DE Account Lifecycle Status model. Internal classification — governed everywhere, never client-facing.
 status: mirror
-version: 1.1
+version: 1.2
 effective_date: 2026-09-09
 authority: digeratiexperts/Intelligence-Hub .agents/memory/account-lifecycle-status-source-of-truth.md
 classification: internal
@@ -20,7 +20,7 @@ classification: internal
 # DE Account Lifecycle Status — Source of Truth
 
 **Status:** Canonical  
-**Version:** 1.1  
+**Version:** 1.2  
 **Effective:** 2026-09-09  
 **Classification:** Internal — governed everywhere, displayed nowhere client-facing (see [Disclosure boundary](#disclosure-boundary--internal-only))  
 **Scope:** Digerati Experts account/client relationship lifecycle across TechSales, Zoho, Sales OS, portals, reporting, automations, integrations, and future systems.
@@ -30,6 +30,8 @@ This file is the authoritative definition of the DE **Account Lifecycle Status**
 **Authority and mirrors.** This file, in `digeratiexperts/Intelligence-Hub`, is the single authority. Mirrors are maintained at `docs/ACCOUNT-LIFECYCLE-STATUS.md` in `digeratiexperts-site`, `de-platform`, and `vulnerability-management`. In each mirror the **canonical section is byte-identical** to this file; a **repo-local application section is permitted after the canonical section** and is the only repo-local content. A mirror may not alter the vocabulary, the semantics, or the disclosure boundary. Change this file first, then propagate.
 
 **v1.1 change:** adds the internal-only disclosure boundary. The 13 values and their definitions are unchanged from v1.0.
+
+**v1.2 change:** sharpens the `Prospect` / `Tentative` boundary (whose side the evidence comes from) and adds the approved legacy migration mapping. The 13 values are still unchanged.
 
 > **Supersedes:** the previous account lifecycle taxonomy `Suspect → Prospect → Lead → Opportunity → Client` as a business-status model. `Lead`, `Opportunity`, `Qualified`, `Proposal Sent`, `Negotiation`, `Closed Won`, and similar terms remain valid **sales/deal pipeline concepts**, but they are **not Account Lifecycle Status values**.
 
@@ -49,7 +51,7 @@ The following 13 values are the complete approved vocabulary, in canonical order
 |---:|---|---|
 | 1 | **Suspect** | An organization appears potentially relevant to DE or plausibly fits the ICP, but DE has not established that a real opportunity exists. Research, list membership, enrichment, or apparent fit alone can support Suspect status. |
 | 2 | **Prospect** | There is enough evidence of fit, need, interest, engagement, access, timing, or opportunity to justify active sales pursuit. A Prospect is materially more qualified for pursuit than a Suspect. |
-| 3 | **Tentative** | The organization has indicated meaningful intent to move forward, but the commercial or client relationship is not yet finalized. |
+| 3 | **Tentative** | The organization has indicated meaningful intent to move forward, but the commercial or client relationship is not yet finalized. The intent must come from the **customer** — see the Prospect/Tentative boundary below. |
 | 4 | **Pending** | The relationship is effectively approved or expected to begin, but activation is waiting on a required dependency such as signature, payment, assessment, scheduling, provisioning, or another start condition. |
 | 5 | **Onboarding** | The organization is an official client and implementation, discovery, migration, remediation, stabilization, or initial service activation is underway. |
 | 6 | **Active** | The client relationship is operational and the client is receiving normal active services. |
@@ -80,6 +82,56 @@ A **Prospect** answers:
 Promotion from Suspect to Prospect requires more than mere existence on a list. The evidence can include fit, a recognizable need, interest, engagement, access to a relevant person, timing, a trigger event, or another credible opportunity signal.
 
 **Governance rule:** imported, scraped, enriched, or researched companies must not automatically inflate the Prospect population merely because they were discovered.
+
+## Prospect and Tentative — whose evidence?
+
+The boundary is **which side the evidence comes from**:
+
+> **Prospect** = DE believes pursuit is justified.  
+> **Tentative** = the customer has indicated meaningful intent to proceed.
+
+A qualified opportunity does **not** make an account Tentative. DE deciding that an opportunity is qualified is DE-side evidence, and DE-side confidence never advances the relationship on its own.
+
+Tentative becomes appropriate when the customer does something materially stronger — agreeing in principle, asking DE to proceed with onboarding or procurement steps, selecting a solution pending final approval, or otherwise expressing meaningful commitment.
+
+This keeps sales-pipeline granularity out of the lifecycle field. Do not duplicate deal stages inside Account Lifecycle Status.
+
+## An account has one lifecycle; its deals have their own stages
+
+Account Lifecycle Status and Deal Stage are independent. One account may simultaneously hold deals at different stages:
+
+```
+Account:  Prospect
+  Deal A: Closed Lost
+  Deal B: Qualification
+  Deal C: Closed Won
+```
+
+No single deal outcome dictates the account's lifecycle. A lost deal ends an opportunity, not a relationship.
+
+## Legacy migration mapping — approved
+
+The superseded taxonomy maps to v1.2 as follows. **Relationship evidence takes precedence over the legacy value**: where an account already shows `Active`, `Onboarding`, `Pending`, `Paused`, `At Risk`, `Offboarding`, or `Former` relationship state, preserve that status rather than applying the row below.
+
+| Legacy value | Maps to | Reasoning |
+|---|---|---|
+| `suspect` | `Suspect` | Direct equivalent. |
+| `prospect` | `Prospect` | Direct equivalent. |
+| `lead` | `Prospect` | A sales-funnel state, not a relationship state. Interest shown already satisfies Prospect; the funnel detail lives in the deal/SDR stage. |
+| `qualified_opportunity` | `Prospect` | DE-side qualification is not customer-side intent, so this is not Tentative. |
+| `client_pending_activation` | `Pending` | Direct equivalent. |
+| `active_client` | `Active` | Direct equivalent. |
+| `former_client` | `Former` | Direct equivalent. |
+| `disqualified` | `Disqualified` | Direct equivalent. |
+| `closed_lost` | `Prospect` | A deal outcome, not a relationship state — unless stronger account-level evidence establishes another status. |
+
+### Rules that constrain the migration
+
+- **`Closed Lost → Prospect`, unless stronger account-level evidence establishes another lifecycle status.** A future deal can be opened against the same Prospect without first undoing a false disqualification.
+- **`Disqualified` only** where DE explicitly determined the account is not viable for current pursuit. Never derive it from a lost deal.
+- **`Do Not Engage` only** for an explicit prohibition. Never derived.
+- **`Inactive` never means "we lost a deal."** It describes a dormant relationship or non-active service state.
+- No lifecycle value may be derived from deal stages. Any migration or automation that reads a deal stage to set the lifecycle is invalid under this document.
 
 ## Disclosure boundary — internal only
 
@@ -184,6 +236,27 @@ When choosing a lifecycle value, ask:
 - Deal-stage chips may continue to display deal/pipeline state; they must not be treated as the account lifecycle authority.
 - Code, database enums, `POSITIVE_RANK`, `floorLifecycle`, boot migrations, API labels, and UI strips that still encode the superseded July 2026 lifecycle taxonomy are **legacy implementation surfaces that require migration** to this v1.1 model.
 - Until that migration is complete, do not add new code that depends on the superseded `Lead → Opportunity → Client` account-lifecycle ordering.
+
+### Approved migration pattern — add, backfill, cut over
+
+`accounts.lifecycle` is a `NOT NULL` production column whose **semantics** change, not merely its spelling. It is migrated by adding a parallel field, never by an in-place enum swap: an in-place swap combines schema change, semantic transformation, and production data migration into one irreversible operation.
+
+1. Add the new lifecycle field using the v1.2 vocabulary.
+2. Leave the legacy field untouched.
+3. Backfill using the approved mapping above, preserving stronger relationship states.
+4. Produce a comparison report: legacy value → migrated value → reason.
+5. Validate that every production account has a valid new lifecycle value.
+6. Switch application reads to the new field.
+7. Switch writes to the new field.
+8. Observe production briefly for mismatches and errors.
+9. Remove the legacy column only after validation.
+
+The translation layer is temporary scaffolding with a defined end. Do not leave it in place indefinitely — a permanent dual taxonomy is the outcome this document exists to prevent.
+
+### Logic that is invalid under this model
+
+- Any function that **derives lifecycle from deal stages**. Deal pipeline state is a separate domain; reading it to set the lifecycle is forbidden regardless of how the result is labelled.
+- Any **numeric-rank ladder** used as the general transition rule. A single ordered rank cannot express `Paused`, `At Risk`, `Inactive`, `Former`, `Disqualified`, or `Do Not Engage`, which are legitimate non-linear states. Transitions follow explicit business rules and evidence.
 - Existing one-account-per-organization, exact merge-key, race-safe-create, Zoho ID separation, quote-linking, and demo-clear integrity rules remain valid unless separately superseded.
 
 ## Change control

--- a/server/integrations/lifecycleDisclosure.test.ts
+++ b/server/integrations/lifecycleDisclosure.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Enforcement for the Account Lifecycle Status disclosure boundary.
+ *
+ * See docs/ACCOUNT-LIFECYCLE-STATUS.md. Account Lifecycle Status is internal
+ * classification: governed everywhere, displayed nowhere client-facing. These
+ * tests exist so the rule fails CI instead of relying on a reviewer noticing.
+ *
+ * The serializer tests feed each client-bound serializer a source record that
+ * is deliberately polluted with lifecycle fields — the shape a future schema
+ * addition or a Hub sync would produce. An allowlist serializer drops them. A
+ * serializer that starts spreading its source (`...user`) will fail here.
+ *
+ * When you add a client-scoped serializer, add it to CLIENT_BOUND_SERIALIZERS.
+ */
+import { describe, expect, it } from "vitest";
+import { orgPublicUser } from "../portalOrg";
+import {
+  ACCOUNT_LIFECYCLE_STATUSES,
+  assertNoLifecycleDisclosure,
+  findLifecycleDisclosures,
+} from "./tenantIdentity";
+
+/** A portal user record carrying every lifecycle field shape we might inherit. */
+const pollutedUser = {
+  id: "user-1",
+  email: "person@acme.example",
+  fullName: "Test Person",
+  role: "user",
+  orgRole: "staff",
+  clientId: "client-acme",
+  departmentId: null,
+  managerUserId: null,
+  isCompanyItContact: false,
+  // Everything below must never reach a client.
+  accountLifecycleStatus: "At Risk",
+  lifecycle_status: "Do Not Engage",
+  hubLifecycle: "disqualified",
+  account: { lifecycle: "Suspect", name: "Acme" },
+} as any;
+
+const CLIENT_BOUND_SERIALIZERS: Array<{ name: string; run: () => unknown }> = [
+  { name: "orgPublicUser", run: () => orgPublicUser(pollutedUser) },
+];
+
+describe("Account Lifecycle Status — disclosure boundary", () => {
+  describe("client-bound serializers", () => {
+    for (const { name, run } of CLIENT_BOUND_SERIALIZERS) {
+      it(`${name} does not disclose lifecycle even when its source carries it`, () => {
+        const output = run();
+        expect(findLifecycleDisclosures(output)).toEqual([]);
+        expect(() => assertNoLifecycleDisclosure(output, name)).not.toThrow();
+      });
+    }
+
+    it("proves the fixture would trip the guard if a serializer passed it through", () => {
+      // Guards the guard: if this stops failing, the fixture has gone stale and
+      // the serializer tests above would pass vacuously.
+      expect(findLifecycleDisclosures(pollutedUser).length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("findLifecycleDisclosures", () => {
+    it("flags any lifecycle-named key regardless of its value", () => {
+      const found = findLifecycleDisclosures({ accountLifecycleStatus: "anything" });
+      expect(found).toEqual([
+        { path: "$.accountLifecycleStatus", reason: "key", found: "accountLifecycleStatus" },
+      ]);
+    });
+
+    it("matches key names across casing and separator styles", () => {
+      for (const key of ["lifecycle_status", "LifecycleStatus", "hub-lifecycle", "lifecycle"]) {
+        expect(findLifecycleDisclosures({ [key]: "x" })).toHaveLength(1);
+      }
+    });
+
+    it("flags unambiguous lifecycle values under an innocuous key", () => {
+      const found = findLifecycleDisclosures({ badge: "Do Not Engage" });
+      expect(found).toEqual([{ path: "$.badge", reason: "value", found: "Do Not Engage" }]);
+    });
+
+    it("finds disclosures nested in objects and arrays", () => {
+      const found = findLifecycleDisclosures({
+        clients: [{ name: "Acme", tags: ["At Risk"] }],
+      });
+      expect(found).toEqual([
+        { path: "$.clients[0].tags[0]", reason: "value", found: "At Risk" },
+      ]);
+    });
+
+    it("does not fire on legitimate client-visible values that merely collide", () => {
+      // A portal user account is "active"; a request is "pending"; storeRole is
+      // "prospect". None of these disclose the account's lifecycle.
+      const clean = {
+        user: { status: "active", storeRole: "prospect" },
+        request: { state: "pending" },
+        subscription: { state: "paused" },
+      };
+      expect(findLifecycleDisclosures(clean)).toEqual([]);
+    });
+
+    it("survives a circular payload without hanging", () => {
+      const node: any = { name: "Acme" };
+      node.self = node;
+      expect(() => findLifecycleDisclosures(node)).not.toThrow();
+    });
+
+    it("returns clean for a normal portal payload", () => {
+      expect(
+        findLifecycleDisclosures({
+          success: true,
+          user: { id: "u1", email: "a@b.example", role: "user", clientId: "c1" },
+        }),
+      ).toEqual([]);
+    });
+  });
+
+  describe("assertNoLifecycleDisclosure", () => {
+    it("throws with the offending path and points at the governing doc", () => {
+      expect(() => assertNoLifecycleDisclosure({ chip: "Disqualified" }, "dashboard")).toThrow(
+        /dashboard.*\$\.chip.*ACCOUNT-LIFECYCLE-STATUS\.md/s,
+      );
+    });
+
+    it("passes a clean payload", () => {
+      expect(() => assertNoLifecycleDisclosure({ ok: true })).not.toThrow();
+    });
+  });
+
+  describe("canonical vocabulary", () => {
+    it("carries exactly the 13 canonical v1.1 values in canonical order", () => {
+      expect([...ACCOUNT_LIFECYCLE_STATUSES]).toEqual([
+        "Suspect",
+        "Prospect",
+        "Tentative",
+        "Pending",
+        "Onboarding",
+        "Active",
+        "Paused",
+        "At Risk",
+        "Offboarding",
+        "Inactive",
+        "Former",
+        "Disqualified",
+        "Do Not Engage",
+      ]);
+    });
+
+    it("treats every high-sensitivity value as a disclosure under any key", () => {
+      // These six are absolute per the Source of Truth.
+      for (const value of ["Suspect", "At Risk", "Offboarding", "Disqualified", "Do Not Engage"]) {
+        expect(findLifecycleDisclosures({ label: value })).toHaveLength(1);
+      }
+    });
+  });
+});

--- a/server/integrations/tenantIdentity.ts
+++ b/server/integrations/tenantIdentity.ts
@@ -33,6 +33,125 @@ export const HUB_LIFECYCLES = [
 
 export type HubLifecycle = (typeof HUB_LIFECYCLES)[number];
 
+/**
+ * Account Lifecycle Status disclosure boundary.
+ *
+ * See docs/ACCOUNT-LIFECYCLE-STATUS.md. The field is internal classification:
+ * governed everywhere, displayed nowhere client-facing. Compliance means the
+ * value is absent from the payload a client or the public receives — hiding it
+ * in the UI does not count.
+ *
+ * The canonical v1.1 vocabulary. Storage/wire forms vary (spacing, case,
+ * snake_case), so comparison is normalized.
+ */
+export const ACCOUNT_LIFECYCLE_STATUSES = [
+  "Suspect",
+  "Prospect",
+  "Tentative",
+  "Pending",
+  "Onboarding",
+  "Active",
+  "Paused",
+  "At Risk",
+  "Offboarding",
+  "Inactive",
+  "Former",
+  "Disqualified",
+  "Do Not Engage",
+] as const;
+
+export type AccountLifecycleStatus = (typeof ACCOUNT_LIFECYCLE_STATUSES)[number];
+
+/** Field names that carry the lifecycle value and must not reach a client. */
+export const LIFECYCLE_DISCLOSURE_KEYS = [
+  "accountlifecyclestatus",
+  "lifecyclestatus",
+  "hublifecycle",
+  "accountlifecycle",
+  "lifecycle",
+] as const;
+
+function normalizeToken(value: string): string {
+  return value.trim().toLowerCase().replace(/[\s_-]+/g, "");
+}
+
+const LIFECYCLE_VALUE_TOKENS: ReadonlySet<string> = new Set([
+  ...ACCOUNT_LIFECYCLE_STATUSES.map((s) => normalizeToken(s)),
+  ...HUB_LIFECYCLES.map((s) => normalizeToken(s)),
+]);
+
+/**
+ * Values that are legitimately client-visible in their own domain and must not
+ * be mistaken for a lifecycle disclosure. `active`/`inactive` describe a portal
+ * user account; `pending` describes a request; `prospect` is an existing
+ * client-visible storeRole. They are only a violation under a lifecycle key.
+ */
+const AMBIGUOUS_VALUE_TOKENS: ReadonlySet<string> = new Set([
+  "active",
+  "inactive",
+  "pending",
+  "prospect",
+  "paused",
+  "former",
+]);
+
+export type LifecycleDisclosure = { path: string; reason: "key" | "value"; found: string };
+
+/**
+ * Walk a client-bound payload and report every Account Lifecycle Status
+ * disclosure. Returns [] when the payload is clean.
+ *
+ * A key match is always a violation: naming a field `lifecycle` and putting
+ * anything in it discloses the classification. A value match is a violation
+ * only for unambiguous lifecycle terms, so this does not fire on a portal
+ * user's `status: "active"`.
+ */
+export function findLifecycleDisclosures(
+  payload: unknown,
+  path = "$",
+  seen = new WeakSet<object>(),
+): LifecycleDisclosure[] {
+  if (payload === null || payload === undefined) return [];
+
+  if (typeof payload === "string") {
+    const token = normalizeToken(payload);
+    if (LIFECYCLE_VALUE_TOKENS.has(token) && !AMBIGUOUS_VALUE_TOKENS.has(token)) {
+      return [{ path, reason: "value", found: payload }];
+    }
+    return [];
+  }
+
+  if (typeof payload !== "object") return [];
+  if (seen.has(payload as object)) return [];
+  seen.add(payload as object);
+
+  if (Array.isArray(payload)) {
+    return payload.flatMap((item, i) => findLifecycleDisclosures(item, `${path}[${i}]`, seen));
+  }
+
+  const out: LifecycleDisclosure[] = [];
+  for (const [key, value] of Object.entries(payload as Record<string, unknown>)) {
+    const keyPath = `${path}.${key}`;
+    if (LIFECYCLE_DISCLOSURE_KEYS.includes(normalizeToken(key) as any)) {
+      out.push({ path: keyPath, reason: "key", found: key });
+      continue;
+    }
+    out.push(...findLifecycleDisclosures(value, keyPath, seen));
+  }
+  return out;
+}
+
+/** Throw if a client-bound payload discloses Account Lifecycle Status. */
+export function assertNoLifecycleDisclosure(payload: unknown, label = "payload"): void {
+  const found = findLifecycleDisclosures(payload);
+  if (found.length === 0) return;
+  const detail = found.map((f) => `${f.path} (${f.reason}: ${f.found})`).join(", ");
+  throw new Error(
+    `Account Lifecycle Status disclosed in client-bound ${label}: ${detail}. ` +
+      `See docs/ACCOUNT-LIFECYCLE-STATUS.md — omit it at the serialization boundary.`,
+  );
+}
+
 export type TenantIds = {
   portalClientId?: string | null;
   hubAccountId?: string | null;


### PR DESCRIPTION
## Summary

Two changes, both following on from merged PR #203.

> **Merge after** the authority PR, [Intelligence-Hub#149](https://github.com/digeratiexperts/Intelligence-Hub/pull/149).

## 1. The disclosure boundary is now enforced by tests

The v1.1 boundary was documentation and agent rules only. Nothing failed if a lifecycle value entered a client-scoped payload, so the rule held only while someone remembered to read the doc.

Adds to `server/integrations/tenantIdentity.ts`:

- `ACCOUNT_LIFECYCLE_STATUSES` — the canonical values
- `findLifecycleDisclosures(payload)` — walks a client-bound payload, returns every disclosure by path
- `assertNoLifecycleDisclosure(payload, label)` — throws, pointing at the governing doc

**Detection is deliberately asymmetric.** A lifecycle-named key (`lifecycle`, `lifecycleStatus`, `accountLifecycleStatus`, `hubLifecycle`, any casing/separator) is *always* a violation. A value match fires only on unambiguous terms, so a portal user's `status: "active"`, a request's `state: "pending"`, and the existing client-visible `storeRole: "prospect"` do **not** trip it. Without that asymmetry the guard would be noisy enough that someone eventually switches it off.

**The test is verified non-vacuous.** `lifecycleDisclosure.test.ts` feeds each client-bound serializer a source record deliberately polluted with lifecycle fields and asserts the output is clean. I confirmed it catches the real regression: temporarily making `orgPublicUser` spread its source made the serializer test fail as intended, and it passes again on revert. A fixture check also fails loudly if the polluted fixture ever stops tripping the guard.

**Stated limits** (recorded in the doc, not left implied): the guard covers serializers in `CLIENT_BOUND_SERIALIZERS`, **not** response objects built inline in a route handler, and not values assembled only at runtime. It raises the floor; it does not make a leak impossible.

## 2. Mirror synced to canonical v1.2

Regenerated from the Hub authority. The 13 values are unchanged; v1.2 sharpens the Prospect/Tentative boundary by whose evidence it is, establishes that account lifecycle and deal stage are independent, and adds the approved legacy migration mapping.

Relevant to this repo: `server/integrations/tenantIdentity.ts` still carries the legacy `HUB_LIFECYCLES` taxonomy, which v1.2 now maps explicitly (`lead` → `prospect`, `qualified_opportunity` → `prospect`, `closed_lost` → `prospect`). Migrating it is follow-up work in the read/write cut-over, not this PR.

## Agent governance

- Task / claim ID: account-lifecycle-enforcement
- Implementing agent: Claude Code
- Isolated branch/worktree used: **YES**
- `.ai/ACTIVE_WORK.yaml` + open PRs checked: **YES**
- Overlapping active agent work: **NONE**
- Merge/deploy authority: Joe's final authority

## Completion report

**1. What changed** — Guard functions + canonical vocabulary in `tenantIdentity.ts`; new test file; enforcement documented in the repo-local application section of `docs/ACCOUNT-LIFECYCLE-STATUS.md` and `.cursor/rules/account-lifecycle.mdc`; canonical section regenerated to v1.2.

**2. Why** — Governance that depends on an agent reading a doc is weaker than a test. A single serializer change could have breached the boundary silently.

**3. Files changed** — `server/integrations/tenantIdentity.ts`, `server/integrations/lifecycleDisclosure.test.ts` (new), `docs/ACCOUNT-LIFECYCLE-STATUS.md`, `.cursor/rules/account-lifecycle.mdc`

**4. Functionality preserved** — Additive only. New exports; no existing function's behavior changed; no route handler modified.

**5. Tests performed** — New suite 13 tests pass; full suite **410 tests / 91 files pass**; `npx tsc` **clean**; negative verification described above. Re-verified after the v1.2 mirror sync.

**6. Browser verification** — N/A, no UI change.

**7. Remaining issues** — Guard coverage limits above. `tenantIdentity.ts` legacy taxonomy still to migrate.

**8. Human inputs still required** — Joe's approval; merge after the Hub authority PR.

## CONCURRENCY AUDIT

```
CONCURRENCY AUDIT
Branch base: 884348f (merge of PR #203)
Current origin/main: 884348f
Commits landed on main since branch creation: 0
Overlapping files:
- NONE
Overlapping active-agent claims:
- NONE
Reconciliation performed:
- Branch recreated from current origin/main after #203 merged; nothing to reconcile
Newer-main work preserved:
YES (no newer main work exists)
Whole-file replacements reviewed:
YES - docs/ACCOUNT-LIFECYCLE-STATUS.md is regenerated wholesale from the
authority by design; the repo-local application section was re-extracted and
verified present after regeneration, including the new enforcement subsection.
tenantIdentity.ts extended by append only.
Tests:
410 passed (91 files). tsc clean.
Guard verified to FAIL against a deliberately leaky serializer, then pass on revert.
Canonical section sha256-verified identical across all four repos (b302587a...).
Visual QA:
390: N/A (no UI change)
768: N/A
1440: N/A
Before/after evidence:
N/A
Screenshots captured:
NO (no UI change)
Production impact:
None at runtime. New exports are not yet called by any route; this PR adds
enforcement in tests, not request-path assertions.
```

## Visual System v2

N/A — no visual treatments, HUD, evidence frames, or diagrams.

## Release state

- PR state: IMPLEMENTED
- Production state: NOT DEPLOYED
- Expected release SHA / identifier: n/a
- Production verification evidence: n/a

`MERGED` does not mean `LIVE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FGgfSo45R8FE8mrTJ9ySmj