### PR TITLE
Separate Cytracom phone naming from ControlOne SASE

### DIFF
--- a/VENDOR_SETUP_STATUS.md
+++ b/VENDOR_SETUP_STATUS.md
@@ -1,6 +1,8 @@
 # 🔌 Vendor Integration Setup Status
 
-## ✅ Connected & Active (3/11)
+> **Scope:** this file tracks technical/API integration status, not whether a vendor is approved for DE service delivery. Vendor lifecycle and commercial authority live in Intelligence Hub / Vendor Intelligence.
+
+## ✅ Connected & Active (3)
 
 ### Zoho (Existing)
 - **Status**: ✅ Connected
@@ -10,23 +12,23 @@
 - **Features**: Ticket management, CRM sync, Flow automation
 - **Endpoints**: Already integrated in portal
 
-### JumpCloud (Just Added)
+### JumpCloud
 - **Status**: ✅ Connected  
 - **Environment Variables**: JUMPCLOUD_API_KEY
 - **Features**: Device management, inventory, policy deployment
 - **Setup**: `server/services/vendor-integration-scaffold.ts` → JumpCloudIntegration class
 - **Next**: Build admin endpoints for device sync
 
-### Coro.net (Just Added)
-- **Status**: ✅ Connected
+### Coro.net
+- **Status**: ✅ Existing integration scaffold / credentials recorded
 - **Environment Variables**: CORO_CLIENT_ID, CORO_CLIENT_SECRET
 - **Features**: Security monitoring, threat alerts, compliance
 - **Setup**: `server/services/vendor-integration-scaffold.ts` → CoroIntegration class
-- **Next**: Build security dashboard integration
+- **Note**: Integration presence does not establish current DE vendor-selection status; use Hub Vendor Intelligence for that decision.
 
 ---
 
-## ⏳ Pending Credentials (5)
+## ⏳ Pending Credentials / API Enablement
 
 ### Procurement Partners
 - [ ] **Griffin IT** - Awaiting API Key/OAuth
@@ -42,31 +44,37 @@
 
 ---
 
-## 🔮 Future Integrations (To Be Added Later)
+## 🔮 Planned / Future Integrations
 
+- [ ] **Timus Networks** - **Selected DE Secure Access & Zero Trust platform**; partner/API details and DE commercial validation pending. JumpCloud is the preferred identity integration where applicable.
+- [ ] **Cytracom** - UCaaS/voice integration only; keep separate from ControlOne SASE.
 - [ ] **Uplevel Systems** - Awaiting credentials & API details
-- [ ] **Cytracom** - Awaiting credentials & API details
 - [ ] **Galactic Advisors** - Awaiting credentials & API details
 - [ ] **Atakama** - Awaiting credentials & API details
+
+### Legacy / migration only
+- **Cytracom ControlOne** - DE is migrating the SASE/ZTNA role to Timus. Do not build new standard ControlOne SASE integrations. Preserve only what is needed to operate and migrate existing deployments.
 
 ---
 
 ## 🚀 Next Steps
 
-1. **Activate JumpCloud Integration**
-   - Build device sync endpoint
-   - Display devices in admin dashboard
-   - Connect to Desktop Agent management
+1. **Complete Timus adoption gates**
+   - Complete partner onboarding and record real DE pricing/terms in Hub
+   - Build and validate the DE Timus tenant
+   - Configure/test JumpCloud SAML
+   - Validate SASE/ZTNA/SWG/FWaaS, posture, private access, logging, rollback, and support procedures
+   - Keep `quoteable=false` until commercial and pilot gates pass
 
-2. **Activate Coro.net Integration**
-   - Build security alerts feed
-   - Create threat dashboard
-   - Real-time alert notifications
+2. **Maintain existing connected integrations intentionally**
+   - Continue JumpCloud device/API work where required
+   - Treat legacy integration scaffolds as implementation state, not automatic vendor approval
 
-3. **When ready with remaining vendors**
-   - Provide credentials
-   - I'll activate in same pattern
-   - Build UI/endpoints for each
+3. **Migrate ControlOne safely**
+   - Inventory each existing ControlOne deployment
+   - Move secure-access functions to Timus after pilot acceptance
+   - Assign physical routing/LAN/WAN dependencies to the Managed Network platform before cutover
+   - Keep Cytracom voice/UCaaS independent
 
 ---
 

--- a/client/src/pages/portal/PortalCytracom.tsx
+++ b/client/src/pages/portal/PortalCytracom.tsx
@@ -37,7 +37,7 @@ export default function PortalCytracom() {
   };
 
   return (
-    <PortalLayout title="Cytracom ControlOne">
+    <PortalLayout title="Cytracom Phone">
       <div className="space-y-6">
         {/* Status Overview */}
         <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
@@ -101,8 +101,8 @@ export default function PortalCytracom() {
         {/* Download Softphone */}
         <Card>
           <CardHeader>
-            <CardTitle>Download ControlOne Softphone</CardTitle>
-            <CardDescription>Install the Cytracom ControlOne app for desktop and mobile calling</CardDescription>
+            <CardTitle>Download Cytracom Softphone</CardTitle>
+            <CardDescription>Install the Cytracom app for desktop and mobile calling</CardDescription>
           </CardHeader>
           <CardContent>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
@@ -253,7 +253,7 @@ export default function PortalCytracom() {
             <div className="flex items-start gap-4">
               <CheckCircle className="h-5 w-5 text-blue-600 mt-0.5" />
               <div>
-                <p className="font-medium text-blue-900 dark:text-blue-100">Cytracom ControlOne Support</p>
+                <p className="font-medium text-blue-900 dark:text-blue-100">Cytracom Phone Support</p>
                 <p className="text-sm text-blue-700 dark:text-blue-300 mt-1">
                   For phone system issues, check our <a href="/portal/kb" className="underline">Knowledge Base</a> or 
                   contact support at <strong>support@digeratiexperts.com</strong>. For urgent issues, call <strong>{PRIMARY_PHONE.display}</strong>.

--- a/client/src/pages/portal/PortalLayout.tsx
+++ b/client/src/pages/portal/PortalLayout.tsx
@@ -72,7 +72,7 @@ const navItems: NavItem[] = [
   { href: "/portal/invoices", label: "Invoices", icon: FileText, key: "billing" },
   { href: "/portal/orders", label: "Orders", icon: ShoppingCart, key: "other" },
   { href: "/portal/vpn", label: "VPN Access", icon: Shield, key: "other" },
-  { href: "/portal/cytracom", label: "ControlOne Phone", icon: Phone, key: "other" },
+  { href: "/portal/cytracom", label: "Cytracom Phone", icon: Phone, key: "other" },
   { href: "/portal/ship-center", label: "Ship Center", icon: Truck, key: "other" },
   { href: "/portal/marketplace", label: "Client Marketplace", icon: ShoppingCart, key: "other" },
   { href: "/portal/procurement", label: "Procurement Store", icon: ShoppingCart, key: "other" },


### PR DESCRIPTION
Corrects website/vendor nomenclature as part of the Timus/ControlOne platform alignment.

- Renames the portal nav item from `ControlOne Phone` to `Cytracom Phone`
- Renames the Cytracom phone page title/support/download copy so it no longer presents ControlOne as a softphone/UCaaS product
- Preserves the `/portal/cytracom` route and Cytracom UCaaS capability
- Updates `VENDOR_SETUP_STATUS.md` so technical/API connector state is not confused with vendor approval
- Records Timus as the selected Secure Access & Zero Trust platform pending commercial/pilot gates
- Records ControlOne as migration-only and Cytracom as voice/UCaaS only
- Does not add Timus to public/vendor-logo merchandising yet because an approved Timus logo asset and commercial quote gate are still pending

ControlOne SASE retirement and Timus adoption are governed in Intelligence-Hub issue #152.