### PR TITLE
fix: normalize website lead taxonomy for Zoho CRM

### DIFF
--- a/server/publicSolutionRequestCrm.ts
+++ b/server/publicSolutionRequestCrm.ts
@@ -1,6 +1,7 @@
 import { curatedSolutionFamilies } from "../client/src/data/curatedSolutions";
 import { zohoClient } from "./zoho/zohoClient";
 import { zohoCRMService } from "./zoho/zohoCRM";
+import { websiteLeadTaxonomy } from "./zoho/leadTaxonomy";
 import type { PublicSolutionRequest } from "./publicSolutionRequestStore";
 
 function splitName(fullName: string): { first: string; last: string } {
@@ -87,15 +88,16 @@ export async function syncPublicSolutionRequestToCrm(
   try {
     const { first, last } = splitName(record.contactName);
     const description = buildPublicSolutionRequestDescription(record);
+    const taxonomy = websiteLeadTaxonomy("solution_request");
     const created = await zohoCRMService.createLead({
       First_Name: first || undefined,
       Last_Name: last,
       Email: record.contactEmail,
       Phone: record.contactPhone || undefined,
       Company: record.organizationName || "Solution request prospect",
-      Lead_Source: "Website Solution Request",
+      Lead_Source: taxonomy.leadSource,
       Description: description,
-      Lead_Status: "Not Contacted",
+      Lead_Status: taxonomy.leadStatus,
     });
     if (created?.id) return "recorded";
     return "pending";

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -6,6 +6,7 @@ import bcrypt from "bcrypt";
 import jwt from "jsonwebtoken";
 import { registerObjectStorageRoutes, ObjectStorageService } from "./replit_integrations/object_storage";
 import { zohoClient, zohoDeskService, splitVisitorName, zohoCRMService, zohoBillingService } from "./zoho";
+import { websiteLeadTaxonomy } from "./zoho/leadTaxonomy";
 import {
   parseZohoTicketId,
   validatePortalTicketUpload,
@@ -4886,13 +4887,14 @@ export async function registerRoutes(app: Express) {
       // Push lead to Zoho CRM
       let zohoLeadId = null;
       try {
+        const taxonomy = websiteLeadTaxonomy("quote_wizard");
         const zohoLead = await zohoCRMService.createLead({
           First_Name: firstName,
           Last_Name: lastName,
           Email: email,
           Company: company || 'Not Specified',
-          Lead_Source: 'Website Quote Wizard',
-          Lead_Status: 'New',
+          Lead_Source: taxonomy.leadSource,
+          Lead_Status: taxonomy.leadStatus,
           Description: `Quote Wizard: Recommended Plan: ${recommendedPlan}, Seats: ${seats}, Connectivity: ${connectivity}, Devices: ${devices}`,
         });
         zohoLeadId = (zohoLead as any)?.details?.id || zohoLead?.id;
@@ -5106,14 +5108,21 @@ export async function registerRoutes(app: Express) {
         const nameParts = name.trim().split(/\s+/);
         const firstName = nameParts[0] || "";
         const lastName = nameParts.slice(1).join(" ") || name;
+        const taxonomy = websiteLeadTaxonomy(
+          action === "request_assessment"
+            ? "advisor_assessment"
+            : action === "request_callback"
+              ? "advisor_callback"
+              : "advisor_lead",
+        );
         const zohoLead = await zohoCRMService.createLead({
           First_Name: firstName,
           Last_Name: lastName,
           Email: email,
           Phone: phone || "",
           Company: company || "Not Specified",
-          Lead_Source: sourceLabel,
-          Lead_Status: "New",
+          Lead_Source: taxonomy.leadSource,
+          Lead_Status: taxonomy.leadStatus,
           Description: summary.slice(0, 32000),
         });
         zohoLeadId = (zohoLead as any)?.details?.id || zohoLead?.id;
@@ -5183,6 +5192,7 @@ export async function registerRoutes(app: Express) {
         const nameParts = fullName.trim().split(' ');
         const firstName = nameParts[0] || '';
         const lastName = nameParts.slice(1).join(' ') || fullName;
+        const taxonomy = websiteLeadTaxonomy("assessment");
 
         const zohoLead = await zohoCRMService.createLead({
           First_Name: firstName,
@@ -5190,8 +5200,8 @@ export async function registerRoutes(app: Express) {
           Email: email,
           Phone: phone || '',
           Company: company || 'Not Specified',
-          Lead_Source: source === 'lead_form' ? 'Website Lead Form' : 'Website Assessment',
-          Lead_Status: 'New',
+          Lead_Source: taxonomy.leadSource,
+          Lead_Status: taxonomy.leadStatus,
           Description: `Free assessment request submitted from ${source || "homepage hero"}`,
         });
         zohoLeadId = (zohoLead as any)?.details?.id || zohoLead?.id;
@@ -5264,6 +5274,7 @@ export async function registerRoutes(app: Express) {
         const nameParts = name.trim().split(' ');
         const firstName = nameParts[0] || '';
         const lastName = nameParts.slice(1).join(' ') || name;
+        const taxonomy = websiteLeadTaxonomy("contact");
         
         const zohoLead = await zohoCRMService.createLead({
           First_Name: firstName,
@@ -5271,9 +5282,9 @@ export async function registerRoutes(app: Express) {
           Email: email,
           Phone: phone,
           Company: company || 'Not Specified',
-          Lead_Source: 'Website Contact Form',
+          Lead_Source: taxonomy.leadSource,
           Description: message || '',
-          Lead_Status: 'New',
+          Lead_Status: taxonomy.leadStatus,
         });
         zohoLeadId = (zohoLead as any)?.details?.id || (zohoLead as any)?.id;
         console.log("[ZOHO] Lead created:", zohoLeadId);
@@ -5344,11 +5355,12 @@ export async function registerRoutes(app: Express) {
         // Check if lead already exists
         const existingLead = await zohoCRMService.getLeadByEmail(email);
         if (!existingLead) {
+          const taxonomy = websiteLeadTaxonomy("newsletter");
           const zohoLead = await zohoCRMService.createLead({
             Last_Name: email.split('@')[0], // Use email prefix as name
             Email: email,
-            Lead_Source: 'Newsletter Signup',
-            Lead_Status: 'New',
+            Lead_Source: taxonomy.leadSource,
+            Lead_Status: taxonomy.leadStatus,
             Description: 'Subscribed to newsletter',
           });
           zohoLeadId = (zohoLead as any)?.details?.id || (zohoLead as any)?.id;

--- a/server/storeQuoteCrm.ts
+++ b/server/storeQuoteCrm.ts
@@ -3,6 +3,7 @@ import { zohoCRMService } from "./zoho/zohoCRM";
 import { money } from "@shared/storeCommerce";
 import type { CanonicalQuoteLine } from "./storeQuoteCommerce";
 import { quoteTotals } from "./storeQuoteCommerce";
+import { websiteLeadTaxonomy } from "./zoho/leadTaxonomy";
 
 export type StoreQuoteCrmInput = {
   quoteNumber: string;
@@ -126,15 +127,16 @@ export async function syncStoreQuoteToCrm(quote: StoreQuoteCrmInput): Promise<St
     if (existingLead?.id) {
       result.leadId = existingLead.id;
     } else {
+      const taxonomy = websiteLeadTaxonomy("store_quote");
       const created = await zohoCRMService.createLead({
         First_Name: first || undefined,
         Last_Name: last,
         Email: email,
         Phone: quote.contactPhone || undefined,
         Company: company,
-        Lead_Source: "Store Quote",
+        Lead_Source: taxonomy.leadSource,
         Description: description,
-        Lead_Status: "Not Contacted",
+        Lead_Status: taxonomy.leadStatus,
       });
       result.leadId = (created as { details?: { id?: string }; id?: string }).details?.id || created.id;
     }

--- a/server/zoho/leadTaxonomy.test.ts
+++ b/server/zoho/leadTaxonomy.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  ZOHO_LEAD_STATUS_PENDING_INITIAL_OUTREACH,
+  websiteLeadTaxonomy,
+} from "./leadTaxonomy";
+
+const connectedCrmLeadSources = new Set([
+  "Employee Referral",
+  "Trade Show",
+  "Seminar Partner",
+  "Online Store",
+  "Partner",
+  "External Referral",
+  "Web Download",
+  "Internal Seminar",
+  "Advertisement",
+  "Web Research",
+  "Cold Call",
+  "Sales Email Alias",
+  "Public Relations",
+  "Chat",
+  "WhatsApp - Digerati Experts",
+  "Google AdWords",
+  "Facebook",
+  "Twitter",
+]);
+
+describe("website to Zoho Lead taxonomy", () => {
+  it("maps every website intake to a Lead Source present in the connected CRM", () => {
+    const kinds = [
+      "solution_request",
+      "store_quote",
+      "quote_wizard",
+      "advisor_assessment",
+      "advisor_callback",
+      "advisor_lead",
+      "assessment",
+      "contact",
+      "newsletter",
+    ] as const;
+
+    for (const kind of kinds) {
+      expect(connectedCrmLeadSources.has(websiteLeadTaxonomy(kind).leadSource)).toBe(true);
+    }
+  });
+
+  it("uses the connected CRM's canonical initial-outreach status", () => {
+    expect(ZOHO_LEAD_STATUS_PENDING_INITIAL_OUTREACH).toBe(
+      "Pending Initial Outreach: Lead is waiting for the first contact attempt.",
+    );
+  });
+
+  it("keeps commerce, web intent, and conversational intake distinguishable", () => {
+    expect(websiteLeadTaxonomy("store_quote").leadSource).toBe("Online Store");
+    expect(websiteLeadTaxonomy("solution_request").leadSource).toBe("Web Download");
+    expect(websiteLeadTaxonomy("advisor_lead").leadSource).toBe("Chat");
+  });
+});

--- a/server/zoho/leadTaxonomy.ts
+++ b/server/zoho/leadTaxonomy.ts
@@ -1,0 +1,37 @@
+export const ZOHO_LEAD_STATUS_PENDING_INITIAL_OUTREACH =
+  "Pending Initial Outreach: Lead is waiting for the first contact attempt." as const;
+
+export type WebsiteLeadKind =
+  | "solution_request"
+  | "store_quote"
+  | "quote_wizard"
+  | "advisor_assessment"
+  | "advisor_callback"
+  | "advisor_lead"
+  | "assessment"
+  | "contact"
+  | "newsletter";
+
+const LEAD_SOURCE_BY_KIND: Record<WebsiteLeadKind, "Web Download" | "Online Store" | "Chat"> = {
+  solution_request: "Web Download",
+  store_quote: "Online Store",
+  quote_wizard: "Online Store",
+  advisor_assessment: "Chat",
+  advisor_callback: "Chat",
+  advisor_lead: "Chat",
+  assessment: "Web Download",
+  contact: "Web Download",
+  newsletter: "Web Download",
+};
+
+/**
+ * Maps granular website intake kinds to values that exist in the connected
+ * Zoho Leads picklists. Granular source detail remains in each event and
+ * description; this adapter owns only the constrained CRM vocabulary.
+ */
+export function websiteLeadTaxonomy(kind: WebsiteLeadKind) {
+  return {
+    leadSource: LEAD_SOURCE_BY_KIND[kind],
+    leadStatus: ZOHO_LEAD_STATUS_PENDING_INITIAL_OUTREACH,
+  } as const;
+}


### PR DESCRIPTION
## Outcome
Centralizes the constrained Zoho Lead taxonomy used by public website intake paths and replaces values that are absent from the connected CRM picklists.

### Mappings
- Store quote / quote wizard → `Online Store`
- Solution request / assessment / contact / newsletter → `Web Download`
- Virtual MSP Advisor → `Chat`
- Every new website Lead → `Pending Initial Outreach: Lead is waiting for the first contact attempt.`

Granular intake source remains in the existing event/description context; this adapter owns only Zoho's constrained fields.

## Why
The connected CRM metadata does not contain the legacy code values `Website Solution Request`, `Store Quote`, `Website Quote Wizard`, `Website Contact Form`, `Website Assessment`, `Newsletter Signup`, `Virtual MSP Advisor — …`, `Not Contacted`, or `New`. Those values could be rejected or silently omitted.

## Concurrency
- Base SHA: `0916b03deded63e338482d1cf056c57d793747fd`
- Open website issues/PRs inspected before implementation; no overlapping claim found
- Active claim: #208
- Expected lead integrator/reviewer: Claude Code

## Verification
- Red observed: focused test failed before implementation because the shared taxonomy module did not exist.
- `npx vitest run server/zoho/leadTaxonomy.test.ts server/storeQuoteCrm.test.ts` — 4 passed
- `npm run check` — passed
- `npm test -- --run` — 92 files / 413 tests passed
- `npm run build` — passed (pre-existing CSS/chunk/browser-data warnings remain)
- `git diff --check` — passed

## Production impact
No deployment, merge, CRM record write, cadence activation, or enrollment was performed. This PR changes payload values only after the authorized integration path merges and deploys it.

## Remaining risk
No authenticated live form submission was run. Post-deploy acceptance must submit each affected path and confirm the resulting Zoho Lead retains both constrained fields.

Relates to #208.