### PR TITLE
brand: make vector logo master authoritative at runtime

### DIFF
--- a/client/src/lib/brandRuntime.test.ts
+++ b/client/src/lib/brandRuntime.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+import legacyRuntimeLogo from "@assets/DE-Logo-new_1762461524794.webp";
+import canonicalReverseLogo from "@brand/digerati-logo-reverse.svg";
+
+describe("Digerati Experts runtime logo authority", () => {
+  it("resolves the legacy live import to the canonical reverse SVG master", () => {
+    expect(legacyRuntimeLogo).toBe(canonicalReverseLogo);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,9 @@
     "types": ["node", "vite/client"],
     "paths": {
       "@/*": ["./client/src/*"],
-      "@shared/*": ["./shared/*"]
+      "@shared/*": ["./shared/*"],
+      "@brand/*": ["./brand/*"],
+      "@assets/*": ["./attached_assets/*"]
     }
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,6 +26,15 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
+      // Compatibility bridge for live surfaces that still import the legacy
+      // raster asset. The canonical artwork is the vector master in brand/.
+      // Keep this exact alias before the broader @assets alias below.
+      "@assets/DE-Logo-new_1762461524794.webp": path.resolve(
+        import.meta.dirname,
+        "brand",
+        "digerati-logo-reverse.svg",
+      ),
+      "@brand": path.resolve(import.meta.dirname, "brand"),
       "@": path.resolve(import.meta.dirname, "client", "src"),
       "@shared": path.resolve(import.meta.dirname, "shared"),
       "@assets": path.resolve(import.meta.dirname, "attached_assets"),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,8 +12,15 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      "@assets/DE-Logo-new_1762461524794.webp": path.resolve(
+        __dirname,
+        "brand",
+        "digerati-logo-reverse.svg",
+      ),
+      "@brand": path.resolve(__dirname, "brand"),
       "@": path.resolve(__dirname, "client/src"),
       "@shared": path.resolve(__dirname, "shared"),
+      "@assets": path.resolve(__dirname, "attached_assets"),
     },
   },
 });


### PR DESCRIPTION
Continues merged PR #197 by making its vector master authoritative in current runtime surfaces without redesigning components or touching archived homepage snapshots.

Phase 1 of #210.

## What changes
- Exact Vite compatibility alias: legacy `@assets/DE-Logo-new_1762461524794.webp` resolves to canonical `brand/digerati-logo-reverse.svg`.
- `@brand` is now the explicit canonical brand-source alias.
- Vitest mirrors the runtime aliases.
- TypeScript knows both `@brand/*` and `@assets/*`.
- Regression test proves the legacy live import and canonical reverse master resolve to the same asset.

## Why
PR #197 created the master vector kit but left it additive. Current header/footer/portal/booking surfaces still referenced the legacy raster filename. This compatibility bridge moves those runtime surfaces onto Claude's SVG master without changing their component markup, dimensions, layout, alt text, or the archived `/version-*` snapshots.

Phase 2 will replace misleading legacy import names with an explicit shared brand asset module/component and audit primary-vs-reverse usage per background.

## Governance / concurrency
- Original branch base: `0916b03deded63e338482d1cf056c57d793747fd`
- Current base reconciled before final validation: `749882245b87ac8e8e97aec739195105c3a26573`
- Current head: `fdf5ada998881b09655f949580774bc56d5a37a3`
- Claim: #210
- New main work from PR #211 touched only `DigeratiHomepageChallenger.tsx` and `DigeratiThreeDoorsChallenger.tsx`; it was merged into this branch before final CI.
- No overlapping logo/brand migration work found.
- No archived `/version-*` component edited.
- No logo geometry, color, or wording changed.

## Final verification
CI run `34699835434` on the reconciled tree passed:
- production dependency audit
- typecheck
- unit tests
- MSP advisor tests
- production build
- browser bundle budget
- local production smoke

Production deploy is intentionally skipped on PR validation and will run only after merge to `main`.

`MERGED` != `LIVE`.