### PR TITLE
Homepage challenger: remove duplicate trust proof chapter

### DIFF
--- a/client/src/pages/DigeratiHomepageChallenger.tsx
+++ b/client/src/pages/DigeratiHomepageChallenger.tsx
@@ -12,7 +12,6 @@ import { DigeratiAIAssistanceSection } from "./sections/DigeratiAIAssistanceSect
 import { DigeratiIndustriesSection } from "./sections/DigeratiIndustriesSection";
 import { DigeratiPricingSection } from "./sections/DigeratiPricingSection";
 import { DigeratiTestimonialsSection } from "./sections/DigeratiTestimonialsSection";
-import { HomepageProofSection } from "./sections/HomepageProofSection";
 import { DigeratiMeetExpertsSection } from "./sections/DigeratiMeetExpertsSection";
 import { DigeratiFAQSection } from "./sections/DigeratiFAQSection";
 import { DigeratiNewsletterSection } from "./sections/DigeratiNewsletterSection";
@@ -81,9 +80,10 @@ export const DigeratiHomepageChallenger = (): JSX.Element => {
           <DigeratiHowWeProtectSection />
         </ScrollSectionAuto>
 
+        {/* One proof chapter is enough: reviews, case studies, Bill of Rights,
+            Guarantee, Trust Center, and industries are all reachable here. */}
         <ScrollSectionAuto id="testimonials">
           <DigeratiTestimonialsSection />
-          <HomepageProofSection />
         </ScrollSectionAuto>
 
         <ScrollSectionAuto id="trust">


### PR DESCRIPTION
## Purpose
Keep tightening the hidden `/homepage-challenger` without changing production `/`.

## Change
- Removes `HomepageProofSection` from the challenger composition only.
- Keeps `DigeratiTestimonialsSection` as the single proof chapter.
- No proof destination is lost: the retained section already exposes real reviews, case studies, Client Bill of Rights, Our Guarantee, Trust Center, and industries.
- The underlying `HomepageProofSection` component remains in the repo and production homepage behavior is unchanged.

## Why
The challenger rendered two back-to-back proof/trust chapters with substantially overlapping destinations. This removes repetition instead of deleting source content.

## Isolation
- One existing challenger composition file changed.
- `/` unchanged.
- Forms unchanged.
- Resource pages unchanged.
- No server/shared code changes.

Base: `main @ 749882245b87ac8e8e97aec739195105c3a26573`.